### PR TITLE
Grunt task

### DIFF
--- a/grunt/internTask.js
+++ b/grunt/internTask.js
@@ -12,30 +12,26 @@ module.exports = function (grunt) {
 		});
 
 		if (opts.reporters) {
-			if (opts.reporters instanceof Array) {
+			if (typeof opts.reporters === 'string') {
+				args.push('reporters=' + args.reporters);
+			}
+			else {
 				opts.reporters.forEach(function (reporter) {
 					args.push('reporters=' + reporter);
 				});
 			}
-			else if (typeof opts.reporters === 'string') {
-				args.push('reporters=' + args.reporters);
-			}
 		}
 
 		if (opts.suites) {
-			if (opts.suites instanceof Array) {
+			if (typeof opts.suites === 'string') {
+				args.push('suites=' + args.suites);
+			}
+			else {
 				opts.suites.forEach(function (suite) {
 					args.push('suites=' + suite);
 				});
 			}
-			else if (typeof opts.suites === 'string') {
-				args.push('suites=' + args.suites);
-			}
 		}
-
-		opts.suites && opts.suites.forEach(function (suite) {
-			args.push('suites=' + suite);
-		});
 
 		var child = grunt.util.spawn({
 			cmd: process.argv[0],


### PR DESCRIPTION
Adds a grunt task at `grunt/internTask.js`. 

**Example configuration showing all options**

``` js
grunt.initConfig({
    intern: {
        someReleaseTarget: {
            runType: 'runner',  // defaults to client,
            options: {
                config: "intern-selftest/tests/selftest.intern.js",
                reporters: ['console', 'lcov'],
                suites: ['intern-selftest/tests/all'],
                proxyOnly: true,
                autoRun: true
            }
        },
        anotherReleaseTarget: { ... }
    }
});
...
grunt.loadTasks('path/to/intern/grunt');
```
