### PR TITLE
Update client to exit with proper code based on errors

### DIFF
--- a/client.js
+++ b/client.js
@@ -97,9 +97,7 @@ else {
 							hasErrors = true;
 						});
 
-						topic.publish('/runner/start');
 						main.run().always(function () {
-							topic.publish('/runner/end');
 							process.exit(hasErrors ? 1 : 0);
 						});
 					}


### PR DESCRIPTION
I noticed that `client` doesn't exit with the right code when errors occur in a test like `runner` does. This should add the exact same logic to `client`.
