### PR TITLE
Use fixed sauce-connect-launcher that will not crash in spawned Node.js process

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"dependencies": {
 		"wd": "0.0.x",
 		"istanbul": "0.1.x",
-		"sauce-connect-launcher": "git://github.com/csnover/sauce-connect-launcher.git#b8e13982"
+		"sauce-connect-launcher": "git://github.com/bryanforbes/sauce-connect-launcher.git#94e67ae4f4"
 	},
 	"bugs": "https://github.com/theintern/intern/issues",
 	"keywords": [ "JavaScript", "Dojo", "Toolkit", "Unit", "Testing", "CI" ],


### PR DESCRIPTION
Currently, `sauce-connect-launcher` uses `progress` which does not allow forcing terminal mode in `readline`. This means that the grunt task will crash on certain platforms (Mac OS, maybe others) if Sauce Connect has not been downloaded already. I have forked both `sauce-connect-launcher` and `progress` and submitted a pull request (https://github.com/visionmedia/node-progress/pull/23) for `progress` (I'll do the same for `sauce-connect-launcher` as soon as the first one lands). This is a temporary measure until those two packages are fixed.
