### PR TITLE
Add loader plugin to handle non-AMD dependncies, refs #30

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -1,10 +1,13 @@
 define([
-	'intern/lib/util',
+	'./lib/util',
 	'dojo/Deferred'
 ], function (util, Deferred) {
 	var queue = util.createQueue(1);
 
 	return {
+		/**
+		 * AMD plugin API interface for in-order loading of module dependencies
+		 */
 		load: function (id, parentRequire, callback) {
 			queue(function () {
 				var dfd = new Deferred();


### PR DESCRIPTION
Example usage:

``` js
define([
    'intern!object',
    'intern/chai!assert',
    'intern/sync!jquery-1.5.min.js',
    'intern/sync!jquery.somePlugin.js'
], function (registerSuite, assert) {
// ...
```
