### PR TITLE
add a new config parameter, disableCodeCoverageAnalysis, that allows to disable the code coverage analysis.

### DIFF
--- a/lib/wd.js
+++ b/lib/wd.js
@@ -69,10 +69,11 @@ define([
 	 * A WebDriver instance with Promises/A interface methods instead of Node.js callback-style methods.
 	 * @extends wd/lib/webdriver
 	 */
-	function PromisedWebDriver(config, desiredEnvironment) {
+	function PromisedWebDriver(config, desiredEnvironment, codeCoverageEnabled) {
 		this._wd = new WebDriver(config);
 		this._desiredEnvironment = desiredEnvironment;
 		this._context = [];
+		this._codeCoverageEnabled = codeCoverageEnabled;
 	}
 
 	// The original object is indirectly extended by adapting individual methods in order to ensure that any
@@ -107,22 +108,26 @@ define([
 
 					var dfd = new Deferred();
 
-					// Since we are in the middle of a chained call, we must do a low-level call to the wd object;
-					// if we try to just call PromisedWebDriver methods directly, the chain will be stalled permanently
-					// waiting for the `get` call to complete because the PWD methods cannot run until `get` completes
-					// but `get` will not be able to complete without the subsequent PWD methods
-					this._wd.execute('return typeof __internCoverage !== "undefined" && JSON.stringify(__internCoverage)', function (error, returnValue) {
-						if (error) {
-							dfd.reject(error);
-							return;
-						}
+					if (this._codeCoverageEnabled) {
+						// Since we are in the middle of a chained call, we must do a low-level call to the wd object;
+						// if we try to just call PromisedWebDriver methods directly, the chain will be stalled permanently
+						// waiting for the `get` call to complete because the PWD methods cannot run until `get` completes
+						// but `get` will not be able to complete without the subsequent PWD methods
+						this._wd.execute('return typeof __internCoverage !== "undefined" && JSON.stringify(__internCoverage)', function (error, returnValue) {
+							if (error) {
+								dfd.reject(error);
+								return;
+							}
 
-						// returnValue might be falsy on a page with no coverage data, so don't try to publish coverage
-						// results to prevent things from breaking
-						returnValue && topic.publish('/coverage', self.sessionId, JSON.parse(returnValue));
+							// returnValue might be falsy on a page with no coverage data, so don't try to publish coverage
+							// results to prevent things from breaking
+							returnValue && topic.publish('/coverage', self.sessionId, JSON.parse(returnValue));
 
+							wrappedFunction.apply(self, args).then(dfd.resolve.bind(dfd), dfd.reject.bind(dfd));
+						});
+					} else {
 						wrappedFunction.apply(self, args).then(dfd.resolve.bind(dfd), dfd.reject.bind(dfd));
-					});
+					}
 
 					return dfd.promise;
 				};
@@ -245,8 +250,8 @@ define([
 		 * for integration with Sauce Labs.
 		 * @returns {PromisedWebDriver}
 		 */
-		remote: function (config, desiredEnvironment) {
-			return new PromisedWebDriver(config, desiredEnvironment);
+		remote: function (config, desiredEnvironment, codeCoverageEnabled) {
+			return new PromisedWebDriver(config, desiredEnvironment, codeCoverageEnabled);
 		}
 	};
 });

--- a/runner.js
+++ b/runner.js
@@ -77,7 +77,7 @@ else {
 				createProxy({
 					basePath: this.require.baseUrl,
 					excludeInstrumentation: config.excludeInstrumentation,
-					instrumenter: new Instrumenter({
+					instrumenter: config.disableCodeCoverageAnalysis ? null : new Instrumenter({
 						// coverage variable is changed primarily to avoid any jshint complaints, but also to make it clearer
 						// where the global is coming from
 						coverageVariable: '__internCoverage',
@@ -139,7 +139,7 @@ else {
 				util.flattenEnvironments(config.capabilities, config.environments).forEach(function (environmentType) {
 					var suite = new Suite({
 						name: 'main',
-						remote: wd.remote(config.webdriver, environmentType),
+						remote: wd.remote(config.webdriver, environmentType, !config.disableCodeCoverageAnalysis),
 						publishAfterSetup: true,
 						setup: function () {
 							var remote = this.remote;

--- a/tests/example.intern.js
+++ b/tests/example.intern.js
@@ -56,6 +56,9 @@ define({
 	// Functional test suite(s) to run in each browser once non-functional tests are completed
 	functionalSuites: [ /* 'myPackage/tests/functional' */ ],
 
+	// Should code coverage analysis be disabled
+	disableCodeCoverageAnalysis: false,
+
 	// A regular expression matching URLs to files that should not be included in code coverage analysis
 	excludeInstrumentation: /^tests\//
 });


### PR DESCRIPTION
It is usefull for testing on some
android platforms where code coverage retrieval fails (see issue #44,
https://github.com/theintern/intern/issues/44).
