### PR TITLE
unit test keep-alive implementation, refs #49

### DIFF
--- a/lib/ClientSuite.js
+++ b/lib/ClientSuite.js
@@ -36,7 +36,6 @@ define([
 				},
 				self = this,
 				dfd = new Deferred(),
-				heartbeat,
 				handles = [
 					topic.subscribe('/suite/end', function (suite) {
 						if (suite.sessionId === remote.sessionId && !suite.parent) {
@@ -50,7 +49,8 @@ define([
 					topic.subscribe('/client/end', function (sessionId) {
 						if (sessionId === remote.sessionId) {
 							clearHandles();
-							clearInterval(heartbeat);
+							// Passing a delay of 0 clears the current interval and won't create a new one
+							remote.setHeartbeatInterval(0);
 							dfd.resolve();
 						}
 					})
@@ -58,12 +58,10 @@ define([
 
 			// Intern runs unit tests on the remote Selenium server by navigating to the client runner HTML page. No
 			// Selenium commands are issued after this initial call to remote.get() below, so Sauce Labs will assume
-			// failure if unit tests take longer than the specified "idle-timeout" Sauce capabilities parameter. We
-			// issue a keep-alive heartbeat to ensure that Sauce Labs knows the session is still active.For more info 
-			// on Sauce timeouts, see https://saucelabs.com/docs/additional-config.
-			heartbeat = setInterval(function () {
-				remote._wd.url();
-			}, config.capabilities['idle-timeout'] * 1000 || 90000);
+			// failure if unit tests take longer than the specified "idle-timeout" Sauce capabilities parameter. 
+			// wd.setHeartbeatInterval() creates an interval that issues a keep-alive Selenium command to ensure that 
+			// Sauce Labs knows the session is still active. For more info see https://saucelabs.com/docs/additional-config.
+			remote.setHeartbeatInterval(config.capabilities['idle-timeout'] * 1000);
 
 			remote.get(config.proxyUrl + '__intern/client.html?' + ioQuery.objectToQuery(options)).otherwise(clearHandles);
 

--- a/lib/wd.js
+++ b/lib/wd.js
@@ -233,6 +233,24 @@ define([
 	};
 
 	/**
+	 * Establishes an interval on which a generic Selenium command is issued, and cancels any previous interval if one
+	 * exists. This method is used to keep Sauce Labs from thinking long-running unit test sessions have gone inactive.
+	 * @param {number} [delay=90000] Millisecond delay between each heartbeat command. A delay of 0 does not create a new
+	 * interval. If no delay is passed, it will default to match the default Sauce Labs idle-timeout parameter.
+	 */
+	var heartbeatInterval;
+	PromisedWebDriver.prototype.setHeartbeatInterval = function (delay) {
+		var self = this;
+
+		this._lastPromise = when(this._lastPromise).then(function () {
+			clearInterval(heartbeatInterval);
+			return (delay === 0) ? null : setInterval(function () { self._wd.url(); }, delay || 90000);
+		});
+
+		return this;
+	};
+
+	/**
 	 * This interface provides a mechanism for creating a remote WebDriver instance that uses Promises/A instead of
 	 * Node.js callbacks to provide more expressive tests.
 	 */


### PR DESCRIPTION
Intern runs unit tests on the remote Selenium server by navigating to the client runner HTML page. No Selenium commands are issued after this initial call to remote.get() below, so Sauce Labs will assume failure if unit tests take longer than the specified "idle-timeout" Sauce capabilities parameter. 

This PR takes care of issuing a keep-alive heartbeat to ensure that Sauce Labs knows the session is still active.

For more info  on Sauce timeouts, see https://saucelabs.com/docs/additional-config.
