### PR TITLE
Emits grunt events after a test passes or fails

### DIFF
--- a/tasks/intern.js
+++ b/tasks/intern.js
@@ -38,14 +38,14 @@ module.exports = function (grunt) {
 
 		child.stderr.on('data', function (data) {
 			if (/\bFAIL/i.test(data)) {
-				grunt.event.emit("intern:fail", data.toString());
+				grunt.event.emit('intern:fail', data.toString());
 			}
 		});
 
 		child.stdout.on('data', function (data) {
 			var result = /\bPASS/i.test(data) ? 'ok' : /\bFAIL/i.test(data) ? 'error' : 'write';
-			if (result === "ok") {
-				grunt.event.emit("intern:pass", data.toString());
+			if (result === 'ok') {
+				grunt.event.emit('intern:pass', data.toString());
 			}
 			grunt.log[result](data);
 		});


### PR DESCRIPTION
Emits grunt events `intern:pass` and `intern:fail` after each test using parsed results from stdout and stderr. Passes the message as the sole parameter to the event. Useful for performing grunt tasks (e.g. notifications) after a test.
