### PR TITLE
Added missing method name, `isEnabled`, to `elementArgumentMethods`.

### DIFF
--- a/lib/wd.js
+++ b/lib/wd.js
@@ -45,6 +45,7 @@ define([
 		moveTo: true,
 		flick: true,
 		isVisible: true,
+		isEnabled: true,
 		// `type` must be used with element context or else this happens in Safari:
 		// https://code.google.com/p/selenium/issues/detail?id=4996
 		type: true


### PR DESCRIPTION
Prior to this change, calling `remote.isEnabled()` resulted in the test runner hanging.
