### PR TITLE
Fix #67, call beforeEach and afterEach for each test in nested suites

### DIFF
--- a/lib/Suite.js
+++ b/lib/Suite.js
@@ -101,17 +101,39 @@ define([
 		},
 
 		/**
-		 * By default, run the parent's beforeEach.
+		 * Allows setup code to run before each test execution.  Use one of the testing interfaces,
+		 * see ./interfaces/*, to define one or more beforeEach functions for a suite or aspect after this function.
 		 */
 		beforeEach: function() {
-			return this.parent && this.parent.beforeEach();
+			var parent = this.parent;
+			return parent && parent.beforeEach && parent.beforeEach();
 		},
 
 		/**
-		 * By default, run the parent's afterEach.
+		 * Allows tear down code to run after each test execution.  Use one of the testing interfaces,
+		 * see ./interfaces/*, to define one or more afterEach functions for a suite or aspect after this function.
 		 */
 		afterEach: function() {
-			return this.parent && this.parent.afterEach();
+			var parent = this.parent;
+			return parent && parent.afterEach && parent.afterEach();
+		},
+
+		/**
+		 * Convenience mechanism for calling pre/post test methods which captures and handles errors that might be
+		 * raised by these methods.
+		 */
+		call: function (methodName) {
+			var result;
+			try {
+				result = this[methodName] && this[methodName]();
+			}
+			catch (error) {
+				var dfd = new Deferred();
+				dfd.reject(error);
+				result = dfd.promise;
+			}
+
+			return when(result);
 		},
 
 		/**
@@ -130,23 +152,6 @@ define([
 		 * @returns {dojo/promise/Promise}
 		 */
 		run: function () {
-			/**
-			 * Convenience mechanism for calling pre/post test methods which captures and handles errors that might be
-			 * raised by these methods.
-			 */
-			function call(name) {
-				var result;
-				try {
-					result = self[name] && self[name]();
-				}
-				catch (error) {
-					var dfd = new Deferred();
-					dfd.reject(error);
-					result = dfd.promise;
-				}
-
-				return when(result);
-			}
 
 			function runNextTest() {
 				// TODO: Eliminate nextTick once dojo/promise implements Promises/A+
@@ -171,30 +176,19 @@ define([
 
 					var test = tests[i++];
 					if (test) {
-						// Don't run beforeEach or afterEach if this test is a suite.  The suite's
-						// run method will do that for its own tests.
-						if (test instanceof Suite) {
-							test.run().always(function () {
-								remoteReset();
+						test.run().always(function (error) {
+							if (error && error.fatal) {
+								handleTestError(error);
+							} else {
+								self.remote && self.remote.reset();
 								runNextTest();
-							});
-						} else {
-							call('beforeEach').then(function () {
-								test.run().always(function () {
-									remoteReset();
-									call('afterEach').then(runNextTest, handleTestError);
-								});
-							}, handleTestError);
-						}
+							}
+						});
 					}
 					else {
 						finishRun();
 					}
 				});
-			}
-
-			function remoteReset() {
-				self.remote && self.remote.reset();
 			}
 
 			function handleFatalError(error, fromFinishRun) {
@@ -213,7 +207,7 @@ define([
 						topic.publish('/suite/end', self);
 					}
 
-					call('teardown').always(function (teardownError) {
+					self.call('teardown').always(function (teardownError) {
 						if (!error && teardownError instanceof Error) {
 							handleFatalError(teardownError, true);
 							error = teardownError;
@@ -242,7 +236,7 @@ define([
 				started = true;
 			}
 
-			call('setup').then(function () {
+			self.call('setup').then(function () {
 				if (self.publishAfterSetup) {
 					started = true;
 					topic.publish('/suite/start', self);

--- a/lib/Test.js
+++ b/lib/Test.js
@@ -130,54 +130,84 @@ define([
 		 * @returns {dojo/promise/Promise}
 		 */
 		run: function () {
-			function handleTestError(error) {
-				self.timeElapsed = Date.now() - startTime;
-				self.error = error;
-				topic.publish('/test/fail', self);
-				finishRun();
-				dfd.reject(error);
+
+			function runTest() {
+				var runTestDfd = new Deferred(),
+					result,
+					timer;
+
+				function handleTestError(error) {
+					self.timeElapsed = Date.now() - startTime;
+					self.error = error;
+					topic.publish('/test/fail', self);
+					finishRun();
+					runTestDfd.reject(error);
+				}
+
+				function finishRun() {
+					clearTimeout(timer);
+					topic.publish('/test/end', self);
+				}
+
+				topic.publish('/test/start', self);
+				try {
+					var startTime = Date.now();
+					result = self.test();
+
+					if (self.isAsync && (!result || !result.then)) {
+						result = self.async().promise;
+					}
+
+					if (result && result.then) {
+						self.isAsync = true;
+						timer = setTimeout(function () {
+							// Cancelling the promise will trigger errback
+							result.cancel(new CancelError('Timeout reached on ' + self.id));
+						}, self.timeout);
+					}
+
+					when(result).then(function () {
+						self.timeElapsed = Date.now() - startTime;
+						self.hasPassed = true;
+						topic.publish('/test/pass', self);
+						finishRun();
+						runTestDfd.resolve();
+					}, handleTestError);
+				}
+				catch (error) {
+					handleTestError(error);
+				}
+
+				return runTestDfd.promise;
 			}
 
-			function finishRun() {
-				clearTimeout(timer);
-				topic.publish('/test/end', self);
+			function handlePrePostError(error) {
+				error.fatal = true;
+				runDfd.reject(error);
+			}
+
+			function callParent(method) {
+				return when(parent && parent.call && parent.call(method));
 			}
 
 			var self = this,
-				dfd = new Deferred(),
-				result,
-				timer;
+				parent = self.parent,
+				runDfd = new Deferred();
 
-			topic.publish('/test/start', self);
 			try {
-				var startTime = Date.now();
-				result = self.test();
-
-				if (self.isAsync && (!result || !result.then)) {
-					result = self.async().promise;
-				}
-
-				if (result && result.then) {
-					self.isAsync = true;
-					timer = setTimeout(function () {
-						// Cancelling the promise will trigger errback
-						result.cancel(new CancelError('Timeout reached on ' + self.id));
-					}, self.timeout);
-				}
-
-				when(result).then(function () {
-					self.timeElapsed = Date.now() - startTime;
-					self.hasPassed = true;
-					topic.publish('/test/pass', self);
-					finishRun();
-					dfd.resolve();
-				}, handleTestError);
+				callParent('beforeEach').then(function () {
+					runTest().always(function (error) {
+						callParent('afterEach').then(function () {
+							error ? runDfd.reject(error) : runDfd.resolve();
+						}, handlePrePostError);
+					});
+				}, handlePrePostError);
 			}
 			catch (error) {
-				handleTestError(error);
+				handlePrePostError(error);
 			}
 
-			return dfd.promise;
+			return runDfd.promise;
 		},
 
 		toJSON: function () {

--- a/tests/lib/interfaces/tdd.js
+++ b/tests/lib/interfaces/tdd.js
@@ -64,13 +64,13 @@ define([
 		'Suite lifecycle methods': function () {
 			var results = [],
 				expectedResults = [
-					'before', 'before2',
-					'beforeEach', 'beforeEach2', 'afterEach', 'afterEach2',
-					'beforeEach', 'beforeEach2', 'afterEach', 'afterEach2',
-					'nested-before', 'nested-before2',
-					'beforeEach', 'beforeEach2', 'nested-beforeEach', 'nested-beforeEach2', 'afterEach', 'afterEach2', 'nested-afterEach', 'nested-afterEach2',
-					'nested-after', 'nested-after2',
-					'after', 'after2' ],
+					'outer-before', 'outer-before2',
+					'outer-beforeEach', 'outer-beforeEach2', 'outer-test', 'outer-afterEach', 'outer-afterEach2',
+					'outer-beforeEach', 'outer-beforeEach2', 'middle-test', 'outer-afterEach', 'outer-afterEach2',
+					'inner-before', 'inner-before2',
+					'outer-beforeEach', 'outer-beforeEach2', 'inner-beforeEach', 'inner-beforeEach2', 'inner-test', 'outer-afterEach', 'outer-afterEach2', 'inner-afterEach', 'inner-afterEach2',
+					'inner-after', 'inner-after2',
+					'outer-after', 'outer-after2' ],
 				lifecycleMethods = [ 'before', 'beforeEach', 'afterEach', 'after' ];
 
 			function defineMethods (prefix) {
@@ -83,18 +83,22 @@ define([
 					});
 				});
 
-				tdd.test('single test', function () {});
+				tdd.test('single test', function () {
+					results.push(prefix + 'test');
+				});
 			}
 
-			tdd.suite('root suite', function () {
+			tdd.suite('Outer', function () {
 				// A suite with before, after, beforeEach and afterEach
-				defineMethods('');
-				tdd.suite('nested suite', function () {
+				defineMethods('outer-');
+				tdd.suite('Middle', function () {
 					// A nested suite with no before, after, beforeEach or afterEach method
-					tdd.test('single test', function () {});
-					tdd.suite('nested nested suite', function () {
+					tdd.test('single test', function () {
+						results.push('middle-test');
+					});
+					tdd.suite('Inner', function () {
 						// A nested suite with before, after, beforeEach and afterEach
-						defineMethods('nested-');
+						defineMethods('inner-');
 					});
 				});
 			});


### PR DESCRIPTION
All `beforeEach` and `afterEach` methods from a test's suite hierarchy are now called for each test.  I used `instanceof` in `Suite` to differentiate between a suite and a test so calling `beforeEach` and `afterEach` could remain in `Suite#run`. 
