### PR TITLE
Add support for tunnel identification

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -137,13 +137,6 @@ define([
 			else {
 				console.error(error);
 			}
-		},
-
-		/**
-		 * Generates a string timestamp
-		 */
-		generateTimestamp: function () {
-			return String(new Date().getTime());
 		}
 	};
 });

--- a/runner.js
+++ b/runner.js
@@ -45,7 +45,7 @@ else {
 				capabilities: {
 					name: args.config,
 					'idle-timeout': 60,
-					'tunnel-identifier': util.generateTimestamp()
+					'tunnel-identifier': '' + Date.now()
 				},
 				maxConcurrency: 3,
 				proxyPort: 9000,


### PR DESCRIPTION
This pull request addresses issue #4 by adding support for [identified tunnels](https://saucelabs.com/docs/connect#tunnel-identifier). By default, each tunnel is now given an identifier, allowing multiple concurrent tunnels to use Sauce Connect without collision. The default identifier for a given tunnel can also be explicitly specified via a `tunnel-identifier` property on the `capabilities` object.
