### PR TITLE
Fix context switching between wd context methods

### DIFF
--- a/lib/wd.js
+++ b/lib/wd.js
@@ -768,10 +768,9 @@ define([
 					// Methods that might interact on elements should be modified to use the current context element
 					// as the context object
 					if (elementContextMethods[key] && self._context.length) {
-						var element = self._context[self._context.length - 1];
-						wrappedFunction = util.adapt(function() {
+						return util.adapt(function() {
 							element[key].apply(element, arguments);
-						});
+						}).apply(self, args);
 					}
 
 					// Methods that might accept an element argument should be modified to use the current context


### PR DESCRIPTION
For example context depended searching like 

```
 ... .elementByClassName("soria")
        .elementByClassName("mid")
        .end(1)
        .elementByClassName("left")
        .elementByXPath("./..")
        .getAttribute("id").then(function(id) {
             assert.equal(id, "portal-header");
     });
```

in DOM structure:

<body class="soria">
   <div id="portal-site-container">
      <div id="portal-header">
         <div class="mid">xxxx</div>
         <div class="left">yyyy</div>
       </div>
   </div>
</body>
