### PR TITLE
add bin files for easier execution and fix path problems

### DIFF
--- a/bin/intern-client
+++ b/bin/intern-client
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../client');

--- a/bin/intern-runner
+++ b/bin/intern-runner
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../runner');

--- a/client.js
+++ b/client.js
@@ -1,14 +1,12 @@
 /*jshint node:true */
 if (typeof process !== 'undefined' && typeof define === 'undefined') {
 	(function () {
-		var req = require('dojo/dojo'),
-			pathUtils = require('path'),
-			basePath = pathUtils.dirname(process.argv[1]);
+		var req = require('dojo/dojo');
 
 		req({
-			baseUrl: pathUtils.resolve(basePath, '..', '..'),
+			baseUrl: process.cwd(),
 			packages: [
-				{ name: 'intern', location: basePath }
+				{ name: 'intern', location: __dirname }
 			],
 			map: {
 				intern: {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
 		"type": "git",
 		"url": "https://github.com/theintern/intern.git"
 	},
+	"bin": {
+		"intern-client": "bin/intern-client",
+		"intern-runner": "bin/intern-runner"
+	},
 	"licenses": [
 		{ "type": "BSD-3-Clause", "url": "https://github.com/theintern/intern/blob/master/LICENSE" }
 	],

--- a/runner.js
+++ b/runner.js
@@ -1,14 +1,12 @@
 /*jshint node:true */
 if (typeof process !== 'undefined' && typeof define === 'undefined') {
 	(function () {
-		var req = require('dojo/dojo'),
-			pathUtils = require('path'),
-			basePath = pathUtils.dirname(process.argv[1]);
+		var req = require('dojo/dojo')
 
 		req({
-			baseUrl: pathUtils.resolve(basePath, '..', '..'),
+			baseUrl: process.cwd(),
 			packages: [
-				{ name: 'intern', location: basePath }
+				{ name: 'intern', location: __dirname }
 			],
 			map: {
 				intern: {


### PR DESCRIPTION
This allows you to install globally and run in any directory.

``` bash
> intern-client config=tests/intern
```

or

``` bash
> intern-runner config=tests/intern
```

This also allows you to install intern in your devDependencies and supply the npm test command since npm uses local bin files during scripts phases.

``` js
{
  "scripts": {
    "test": "intern-client config=tests/intern"
  }
}
```
