### PR TITLE
lcov cobertura/html reports

### DIFF
--- a/lib/reporters/lcovcobertura.js
+++ b/lib/reporters/lcovcobertura.js
@@ -1,0 +1,17 @@
+define([
+	'dojo/node!istanbul/lib/collector',
+	'dojo/node!istanbul/lib/report/cobertura'
+], function (Collector, Reporter) {
+	var collector = new Collector(),
+		reporter = new Reporter();
+
+	return {
+		'/coverage': function (sessionId, coverage) {
+			collector.add(coverage);
+		},
+
+		'/runner/end': function () {
+			reporter.writeReport(collector, true);
+		}
+	};
+});

--- a/lib/reporters/lcovhtml.js
+++ b/lib/reporters/lcovhtml.js
@@ -1,0 +1,18 @@
+define([
+	'dojo/node!istanbul/lib/collector',
+	'dojo/node!istanbul/lib/report/html',
+	'dojo/node!istanbul/index'
+], function (Collector, Reporter) {
+	var collector = new Collector(),
+		reporter = new Reporter();
+
+	return {
+		'/coverage': function (sessionId, coverage) {
+			collector.add(coverage);
+		},
+
+		'/runner/end': function () {
+			reporter.writeReport(collector, true);
+		}
+	};
+});


### PR DESCRIPTION
Jenkins supported reporting formats for lcov, both are simple OOTB extensions of the existing istanbul lcov reporter

See http://gotwarlost.github.io/istanbul/public/coverage/lcov-report/index.html for an example of html reports
