### PR TITLE
Expose entire chai object if included with `intern/chai!`. Fixes #107

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -4,15 +4,15 @@ define([ 'chai' ], function (chai) {
 		 * AMD plugin API interface for easy loading of chai assertion interfaces.
 		 */
 		load: function (id, parentRequire, callback) {
-			if (!chai[id]) {
+			if (id && !chai[id]) {
 				throw new Error('Invalid chai interface "' + id + '"');
 			}
 
-			if (!chai[id].AssertionError) {
+			if (id && !chai[id].AssertionError) {
 				chai[id].AssertionError = chai.AssertionError;
 			}
 
-			callback(chai[id]);
+			callback(chai[id] || chai);
 		}
 	};
 });


### PR DESCRIPTION
As per suggestion by @csnover in theintern/intern#107, using `intern/chai!` will return the entire `chai` namespace.
