### PR TITLE
Prepend intern's node_modules to NODE_PATH before spawning

### DIFF
--- a/tasks/intern.js
+++ b/tasks/intern.js
@@ -17,8 +17,11 @@ module.exports = function (grunt) {
 	grunt.registerMultiTask('intern', function () {
 		var done = this.async(),
 			opts = this.options({ runType: 'client' }),
-			args = [ require('path').join(__dirname, '..') + '/' + opts.runType + '.js' ],
-			env = {};
+			path = require('path'),
+			args = [ path.join(__dirname, '..') + '/' + opts.runType + '.js' ],
+			env = {
+				NODE_PATH: path.resolve(__dirname, '../node_modules') + (process.env.NODE_PATH ? path.delimiter + process.env.NODE_PATH : '')
+			};
 
 		[ 'config', 'proxyOnly', 'autoRun' ].forEach(function (option) {
 			opts[option] && args.push(option + '=' + opts[option]);


### PR DESCRIPTION
This works around the issue of NODE_PATH needing to be set on the command line when `useLoader` is specified in the intern config. This is only a work-around for the grunt task and not a bug-fix for the actual problem.
