### PR TITLE
Push environment arguments to the client runner

### DIFF
--- a/lib/ClientSuite.js
+++ b/lib/ClientSuite.js
@@ -33,7 +33,6 @@ define([
 					// the proxy always serves the baseUrl from the loader configuration as the root of the proxy,
 					// so ensure that baseUrl is always set to that root on the client
 					baseUrl: '/',
-					config: args.config,
 					reporters: 'webdriver',
 					sessionId: remote.sessionId
 				},
@@ -67,8 +66,13 @@ define([
 				remote.setHeartbeatInterval((timeout - 1) * 1000);
 			}
 
+			// Remove `reporters` from arguments, reporters is already set to `webdriver`
+			delete args.reporters;
+			// Combine options with options
+			var clientArgs = [ioQuery.objectToQuery(options), ioQuery.objectToQuery(args)].join('&');
+
 			remote
-				.get(config.proxyUrl + '__intern/client.html?' + ioQuery.objectToQuery(options))
+				.get(config.proxyUrl + '__intern/client.html?' + clientArgs)
 				.otherwise(clearHandles);
 
 			return dfd.promise;

--- a/tasks/intern.js
+++ b/tasks/intern.js
@@ -20,14 +20,14 @@ module.exports = function (grunt) {
 			args = [ require('path').join(__dirname, '..') + '/' + opts.runType + '.js' ],
 			env = {};
 
-		[ 'config', 'proxyOnly', 'autoRun' ].forEach(function (option) {
-			opts[option] && args.push(option + '=' + opts[option]);
-		});
-
-		[ 'reporters', 'suites' ].forEach(function (option) {
-			opts[option] && opts[option].forEach(function (value) {
-				args.push(option + '=' + value);
-			});
+		Object.keys(opts).forEach(function (option) {
+			if (Array.isArray(option)) {
+				opts[option].forEach(function (value) {
+					args.push(option + '=' + value);
+				});
+			} else {
+				args.push(option + '=' + opts[option]);
+			}
 		});
 
 		[ 'sauceUsername', 'sauceAccessKey' ].forEach(function (option) {


### PR DESCRIPTION
This adds all environment arguments from the CLI into the runner query string.

Example:

`$ node_modules/.bin/intern-runner config=tests/intern_browser fun_stuff=popcorn`

In the configuration:

```
define(['intern/lib/args'], function (args) {

var fun = args.fun_stuff;
```

Any ideas how to test this feature properly? Hopefully without spawning new processes.  

Ref: https://github.com/theintern/intern/issues/128
