### PR TITLE
Fix property and deepProperty to accommodate falsy property values (geezer)

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -846,7 +846,7 @@ define([
 			}
 
 			for (i = 0; i < parts.length; ++i) {
-				if (!object[parts[i]]) {
+				if (object[parts[i]] === undefined || (object[parts[i]] === null && i < (parts.length - 1))) {
 					return NOT_FOUND;
 				}
 
@@ -856,7 +856,7 @@ define([
 		}
 
 		assert.property = function (object, property, message) {
-			if (!object[property]) {
+			if (object[property] === undefined) {
 				fail(false, true, message ||
 					('expected ' + formatValue(object) + ' to have a property \'' + property + '\''), 'in', assert.property);
 			}

--- a/tests/assert.js
+++ b/tests/assert.js
@@ -498,8 +498,11 @@ define([
 		tdd.test('property', function () {
 			var obj = { foo: { bar: 'baz' } };
 			var simpleObj = { foo: 'bar' };
+			var falsyPropObj = { foo: { falsyProperty: '' }, falsyProperty: '' };
 			assert.property(obj, 'foo');
+			assert.property(falsyPropObj, 'falsyProperty');
 			assert.deepProperty(obj, 'foo.bar');
+			assert.deepProperty(falsyPropObj, 'foo.falsyProperty');
 			assert.notProperty(obj, 'baz');
 			assert.notProperty(obj, 'foo.bar');
 			assert.notDeepProperty(obj, 'foo.baz');


### PR DESCRIPTION
The `property` and `deepProperty` assertions fail on geezer for falsy property values. Ultimately, a fix should check for `propName in obj`, but this fix for geezer assertions compares the property value with `undefined` since that is how chai currently [behaves](https://github.com/chaijs/chai/issues/184).
