### PR TITLE
Make sure WebDriver reporter emits error with older IE.

### DIFF
--- a/lib/reporters/webdriver.js
+++ b/lib/reporters/webdriver.js
@@ -113,7 +113,7 @@ define([
 			testNode.style.color = 'red';
 
 			var errorNode = document.createElement('pre');
-			errorNode.appendChild(document.createTextNode(test.error.stack));
+			errorNode.appendChild(document.createTextNode(test.error.stack || test.error));
 			testNode.appendChild(errorNode);
 			scroll();
 		} : null


### PR DESCRIPTION
Without this fix, I see `undefined` for failed test case with older IE in Sauce Labs screencast. Older IE (9, etc.) does not have `Error#stack`.
