### PR TITLE
Bump wd dependency to v0.2.11 (latest).

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		{ "type": "BSD-3-Clause", "url": "https://github.com/theintern/intern/blob/master/LICENSE" }
 	],
 	"dependencies": {
-		"wd": "0.2.2",
+		"wd": "0.2.11",
 		"istanbul": "0.1.35",
 		"sauce-connect-launcher": "0.1.11",
 		"dojo": "https://github.com/csnover/dojo2-core/archive/2.0.tar.gz",


### PR DESCRIPTION
Bumped wd specifically to get access to the saveScreenshot method added in v0.2.3.
Tested via saucelabs on both master and geezer with no errors.
