### PR TITLE
Update sauce-connect-launcher to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"dependencies": {
 		"wd": "0.2.11",
 		"istanbul": "0.1.35",
-		"sauce-connect-launcher": "0.3.1",
+		"sauce-connect-launcher": "0.3.2",
 		"dojo": "https://github.com/csnover/dojo2-core/archive/2.0.tar.gz",
 		"chai": "1.9.0"
 	},


### PR DESCRIPTION
This should fix Windows permission errors such as this:
![](https://f.cloud.github.com/assets/128755/2369245/35075650-a7d6-11e3-9775-85d9fbfa7fc4.png) 
