### PR TITLE
Allow configuration of reporters and coverage threshold.

### DIFF
--- a/lib/realClient.js
+++ b/lib/realClient.js
@@ -82,7 +82,6 @@ define([
 						noAutoWrap: true
 					});
 
-				//TODO handle coverage thresholds
 				coverageThresholdCheck(topic, config.coverageThresholds);
 
 				hook.hookRunInThisContext(function (filename) {

--- a/lib/realClient.js
+++ b/lib/realClient.js
@@ -35,7 +35,7 @@ define([
 			}
 			args.reporters = [].concat(args.reporters).map(util.normalizeReporterId('./reporters/'));
 
-			deps = deps.concat(args.reporters.map(function(r) { return r.id;}));
+			deps = deps.concat(args.reporters.map(function(reporter) { return reporter.id;}));
 
 			// TODO: This is probably a fatal condition and so we need to let the runner know that no more
 			// information will be forthcoming from this client

--- a/lib/realClient.js
+++ b/lib/realClient.js
@@ -3,13 +3,14 @@ define([
 	'../main',
 	'./reporterManager',
 	'./Suite',
+	'./util',
 	'require',
 	'dojo/topic',
 	'dojo/has',
 	'dojo/has!host-node?dojo/node!istanbul/lib/hook',
 	'dojo/has!host-node?dojo/node!istanbul/lib/instrumenter',
 	'dojo/has!host-node?dojo/node!path'
-], function (main, reporterManager, Suite, require, topic, has, hook, Instrumenter, path) {
+], function (main, reporterManager, Suite, util, require, topic, has, hook, Instrumenter, path) {
 	return {
 		run: function (args, config) {
 			main.config = config;
@@ -31,17 +32,9 @@ define([
 					args.reporters = 'console';
 				}
 			}
+			args.reporters = [].concat(args.reporters).map(util.normalizeReporterId('./reporters/'));
 
-			args.reporters = [].concat(args.reporters).map(function (reporterModuleId) {
-				// Allow 3rd party reporters to be used simply by specifying a full mid, or built-in reporters by
-				// specifying the reporter name only
-				if (reporterModuleId.indexOf('/') === -1) {
-					reporterModuleId = './reporters/' + reporterModuleId;
-				}
-				return reporterModuleId;
-			});
-
-			deps = deps.concat(args.reporters);
+			deps = deps.concat(args.reporters.map(function(r) { return r.id;}));
 
 			// TODO: This is probably a fatal condition and so we need to let the runner know that no more
 			// information will be forthcoming from this client
@@ -102,10 +95,7 @@ define([
 			require(deps, function () {
 				// A hash map, { reporter module ID: reporter definition }
 				var firstReporterIndex = arguments.length - args.reporters.length,
-					reporters = [].slice.call(arguments, firstReporterIndex).reduce(function (map, reporter, i) {
-						map[args.reporters[i]] = reporter;
-						return map;
-					}, {});
+					reporters = [].slice.call(arguments, firstReporterIndex).reduce(util.normalizeReporterConfig(args.reporters), {});
 
 				reporterManager.add(reporters);
 				reportersReady = true;

--- a/lib/realClient.js
+++ b/lib/realClient.js
@@ -9,8 +9,9 @@ define([
 	'dojo/has',
 	'dojo/has!host-node?dojo/node!istanbul/lib/hook',
 	'dojo/has!host-node?dojo/node!istanbul/lib/instrumenter',
-	'dojo/has!host-node?dojo/node!path'
-], function (main, reporterManager, Suite, util, require, topic, has, hook, Instrumenter, path) {
+	'dojo/has!host-node?dojo/node!path',
+	'dojo/has!host-node?./thresholdCheck'
+], function (main, reporterManager, Suite, util, require, topic, has, hook, Instrumenter, path, coverageThresholdCheck) {
 	return {
 		run: function (args, config) {
 			main.config = config;
@@ -81,6 +82,9 @@ define([
 						noAutoWrap: true
 					});
 
+				//TODO handle coverage thresholds
+				coverageThresholdCheck(topic, config.coverageThresholds);
+
 				hook.hookRunInThisContext(function (filename) {
 					return !config.excludeInstrumentation ||
 						// if the string passed to `excludeInstrumentation` changes here, it must also change in
@@ -103,7 +107,7 @@ define([
 				if (has('host-node')) {
 					var hasErrors = false;
 
-					topic.subscribe('/error, /test/fail', function () {
+					topic.subscribe('/error, /test/fail, /coverage/error', function () {
 						hasErrors = true;
 					});
 

--- a/lib/reporterManager.js
+++ b/lib/reporterManager.js
@@ -11,13 +11,17 @@ define([
 		 * is added with the same ID as an existing reporter, the old reporter will be stopped and then replaced.
 		 */
 		add: function (/**Object*/ reporterMap) {
+			var reporterConfig;
 			for (var reporterId in reporterMap) {
 				if (reporterId in reporters) {
 					this.stop(reporterId);
 				}
 
+				reporterConfig = reporterMap[reporterId];
+
 				reporters[reporterId] = {
-					definition: reporterMap[reporterId],
+					definition: reporterConfig.definition,
+					config: reporterConfig.config,
 					handles: [],
 					isRunning: false
 				};
@@ -67,7 +71,7 @@ define([
 				}
 			}
 
-			reporter.definition.start && reporter.definition.start();
+			reporter.definition.start && reporter.definition.start(reporter.config);
 			reporter.isRunning = true;
 		},
 

--- a/lib/reporters/cobertura.js
+++ b/lib/reporters/cobertura.js
@@ -2,10 +2,15 @@ define([
 	'dojo/node!istanbul/lib/collector',
 	'dojo/node!istanbul/lib/report/cobertura'
 ], function (Collector, Reporter) {
-	var collector = new Collector(),
-		reporter = new Reporter();
+	var collector, reporter;
 
 	return {
+		
+		start: function (config) {
+			collector = new Collector(config);
+			reporter = new Reporter(config);
+		},
+		
 		'/coverage': function (sessionId, coverage) {
 			collector.add(coverage);
 		},

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -43,14 +43,25 @@ define([
 	};
 
 	if (has('host-node')) {
+		var hasCoverageError = false;
+
 		consoleReporter['/coverage'] = function (sessionId, coverage) {
 			var collector = new Collector();
+			if (hasCoverageError) {
+				return;
+			}
 			collector.add(coverage);
 
 			// add a newline between test results and coverage results for prettier output
 			console.log('');
 
 			(new Reporter()).writeReport(collector, true);
+		};
+
+		consoleReporter['/coverage/error'] = function (sessionId, msg) {
+			console.error('Coverage Threshold Error:');
+			console.error(msg);
+			hasCoverageError = true;
 		};
 	}
 

--- a/lib/reporters/lcov.js
+++ b/lib/reporters/lcov.js
@@ -2,10 +2,13 @@ define([
 	'dojo/node!istanbul/lib/collector',
 	'dojo/node!istanbul/lib/report/lcovonly'
 ], function (Collector, Reporter) {
-	var collector = new Collector(),
-		reporter = new Reporter();
+	var collector, reporter;
 
 	return {
+		start: function (config) {
+			collector = new Collector(config);
+			reporter = new Reporter(config);
+		},
 		'/coverage': function (sessionId, coverage) {
 			collector.add(coverage);
 		},

--- a/lib/reporters/lcovhtml.js
+++ b/lib/reporters/lcovhtml.js
@@ -3,10 +3,14 @@ define([
 	'dojo/node!istanbul/lib/report/html',
 	'dojo/node!istanbul/index'
 ], function (Collector, Reporter) {
-	var collector = new Collector(),
-		reporter = new Reporter();
+	var collector, reporter;
 
 	return {
+		start: function (config) {
+			collector = new Collector(config);
+			reporter = new Reporter(config);
+		},
+
 		'/coverage': function (sessionId, coverage) {
 			collector.add(coverage);
 		},

--- a/lib/reporters/runner.js
+++ b/lib/reporters/runner.js
@@ -32,6 +32,12 @@ define([
 			session.coverage.add(coverage);
 		},
 
+		'/coverage/error': function (sessionId, msg) {
+			console.log('Coverage Threshold Error:');
+			console.log(msg);
+			hasErrors = true;
+		},
+
 		'/suite/end': function (suite) {
 			if (suite.name === 'main') {
 				if (!sessions[suite.sessionId]) {

--- a/lib/thresholdCheck.js
+++ b/lib/thresholdCheck.js
@@ -1,0 +1,94 @@
+define([
+	'dojo/node!istanbul/lib/collector',
+	'dojo/node!istanbul/lib/object-utils'
+], function (Collector, utils) {
+
+	function reportErrors(sessionId, topic, failures) {
+		failures.length && topic.publish('/coverage/error', sessionId, failures.join('\n'));
+	}
+
+	function checkCoverage(sessionId, topic, thresholds, collector) {
+		var k, actual, actualUncovered, threshold, failures = [];
+		var actuals = utils.summarizeCoverage(collector.getFinalCoverage());
+
+		for (k in thresholds) {
+			actual = actuals[k].pct,
+			actualUncovered = actuals[k].total - actuals[k].covered;
+			threshold = thresholds[k];
+			if (threshold < 0) {
+				if (threshold * -1 < actualUncovered) {
+					failures.push('Uncovered count for ' + k + ' (' + actualUncovered + ') exceeds threshold (' + -1 * threshold + ')');
+				}
+			}
+			else {
+				if (actual < threshold) {
+					failures.push('Coverage for ' + k + ' (' + actual + '%) does not meet threshold (' + threshold + '%)');
+				}
+			}
+		}
+
+		reportErrors(sessionId, topic, failures);
+	}
+
+	function runRemoteSession(topic, thresholds) {
+		var sessions = {}, handles = [];
+
+		handles.push(topic.subscribe('/session/start', function (remote) {
+			sessions[remote.sessionId] = { remote: remote };
+		}));
+
+		handles.push(topic.subscribe('/session/end', function (remote) {
+			var session = sessions[remote.sessionId];
+			session.coverage && checkCoverage(remote.sessionId, topic, thresholds, session.coverage);
+		}));
+
+		handles.push(topic.subscribe('/coverage', function (sessionId, coverage) {
+			var session = sessions[sessionId];
+			session.coverage = session.coverage || new Collector();
+			session.coverage.add(coverage);
+		}));
+
+		return {
+			remove: function () {
+				while (handles.length) {
+					handles.pop().remove();
+				}
+			}
+		};
+
+	}
+
+	function runLocalSession(topic, thresholds) {
+		return topic.subscribe('/coverage', function (sessionId, coverage) {
+			var collector = new Collector();
+			collector.add(coverage);
+			checkCoverage(sessionId, topic, thresholds, collector);
+		});
+	}
+
+	return function (topic, options, isRemoteSesson) {
+		var thresholds, handle;
+
+		if (!options) {
+			return;
+		}
+
+		thresholds = {
+			statements: options.statements || 0,
+			branches: options.branches || 0,
+			lines: options.lines || 0,
+			functions: options.functions || 0
+		};
+
+		if (isRemoteSesson) {
+			handle = runRemoteSession(topic, thresholds);
+		}
+		else {
+			handle = runLocalSession(topic, thresholds);
+		}
+
+		return handle;
+
+	};
+
+});

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,7 +3,7 @@ define([
 	'dojo/lang',
 	'dojo/Deferred',
 	'dojo/promise/when',
-	'./EnvironmentType',
+	'./EnvironmentType'
 ], function (has, lang, Deferred, when, EnvironmentType) {
 	var slice = Array.prototype.slice;
 
@@ -12,8 +12,8 @@ define([
 		 * Adds the reporter definition to the reporter object
 		 *
 		 * @param hash containing all reporter objects
-		 * @returns function used to add the reporter definition to the 
-		 * reporter object 
+		 * @returns function used to add the reporter definition to the
+		 * reporter object
 		 */
 		normalizeReporterConfig: function(reporters) {
 			return function(map, reporter, i) {
@@ -24,14 +24,14 @@ define([
 			}
 		},
 		/**
-		 * Normalizes the id for the reporter module. 
+		 * Normalizes the id for the reporter module.
 		 *
 		 * @param pathPrefix the prefix to use when creating a module id.
-		 * @returns function used to generate reporter objects with a proper 
+		 * @returns function used to generate reporter objects with a proper
 		 * module id and config.
 		 *
 		 */
-		normalizeReporterId: function(pathPrefix) { 
+		normalizeReporterId: function(pathPrefix) {
 			return function(reporterModule) {
 				// Allow 3rd party reporters to be used simply by specifying a full mid, or built-in reporters by
 				// specifying the reporter name only

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,7 +3,7 @@ define([
 	'dojo/lang',
 	'dojo/Deferred',
 	'dojo/promise/when',
-	'./EnvironmentType'
+	'./EnvironmentType',
 ], function (has, lang, Deferred, when, EnvironmentType) {
 	var slice = Array.prototype.slice;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -9,6 +9,46 @@ define([
 
 	return {
 		/**
+		 * Adds the reporter definition to the reporter object
+		 *
+		 * @param hash containing all reporter objects
+		 * @returns function used to add the reporter definition to the 
+		 * reporter object 
+		 */
+		normalizeReporterConfig: function(reporters) {
+			return function(map, reporter, i) {
+				var reporterConfig = reporters[i];
+				reporterConfig.definition = reporter;
+				map[reporterConfig.id] = reporterConfig;
+				return map;
+			}
+		},
+		/**
+		 * Normalizes the id for the reporter module. 
+		 *
+		 * @param pathPrefix the prefix to use when creating a module id.
+		 * @returns function used to generate reporter objects with a proper 
+		 * module id and config.
+		 *
+		 */
+		normalizeReporterId: function(pathPrefix) { 
+			return function(reporterModule) {
+				// Allow 3rd party reporters to be used simply by specifying a full mid, or built-in reporters by
+				// specifying the reporter name only
+				var reporterModuleId = reporterModule.id || reporterModule;
+				var reporterModuleConfig = reporterModule.config
+
+				if (reporterModuleId.indexOf('/') === -1) {
+					reporterModuleId = pathPrefix + reporterModuleId;
+				}
+
+				return {
+					id: reporterModuleId,
+					config: reporterModuleConfig
+				};
+			}
+		},
+		/**
 		 * Creates a basic FIFO function queue to limit the number of currently executing asynchronous functions.
 		 *
 		 * @param maxConcurrency Number of functions to execute at once.

--- a/runner.js
+++ b/runner.js
@@ -278,7 +278,6 @@ else {
 							process.exit(1);
 						});
 
-						//TODO handle coverage thresholds
 						coverageThresholdCheck(topic, config.coverageThresholds, true);
 
 						topic.publish('/runner/start');

--- a/runner.js
+++ b/runner.js
@@ -113,23 +113,13 @@ else {
 				}
 			}
 
-			args.reporters = [].concat(args.reporters).map(function (reporterModuleId) {
-				// Allow 3rd party reporters to be used simply by specifying a full mid, or built-in reporters by
-				// specifying the reporter name only
-				if (reporterModuleId.indexOf('/') === -1) {
-					reporterModuleId = './lib/reporters/' + reporterModuleId;
-				}
-				return reporterModuleId;
-			});
+			args.reporters = [].concat(args.reporters).map(util.normalizeReporterId('./lib/reporters/'));
 
-			require(args.reporters, function () {
+			require(args.reporters.map(function(mc){ return mc.id;}), function () {
 				/*jshint maxcomplexity:13 */
 
 				// A hash map, { reporter module ID: reporter definition }
-				var reporters = [].slice.call(arguments, 0).reduce(function (map, reporter, i) {
-					map[args.reporters[i]] = reporter;
-					return map;
-				}, {});
+				var reporters = [].slice.call(arguments, 0).reduce(util.normalizeReporterConfig(args.reporters), {});
 
 				reporterManager.add(reporters);
 

--- a/runner.js
+++ b/runner.js
@@ -38,7 +38,8 @@ else {
 		'dojo/lang',
 		'dojo/topic',
 		'./lib/EnvironmentType',
-		'./lib/reporterManager'
+		'./lib/reporterManager',
+		'./lib/thresholdCheck'
 	], function (
 		require,
 		main,
@@ -54,7 +55,8 @@ else {
 		lang,
 		topic,
 		EnvironmentType,
-		reporterManager
+		reporterManager,
+		coverageThresholdCheck
 	) {
 		if (!args.config) {
 			throw new Error('Required option "config" not specified');
@@ -258,7 +260,7 @@ else {
 					require(config.functionalSuites || [], function () {
 						var hasErrors = false;
 
-						topic.subscribe('/error, /test/fail', function () {
+						topic.subscribe('/error, /test/fail, /coverage/error', function () {
 							hasErrors = true;
 						});
 
@@ -275,6 +277,9 @@ else {
 							topic.publish('/error', error);
 							process.exit(1);
 						});
+
+						//TODO handle coverage thresholds
+						coverageThresholdCheck(topic, config.coverageThresholds, true);
 
 						topic.publish('/runner/start');
 						main.run().always(function () {

--- a/tests/example.intern.js
+++ b/tests/example.intern.js
@@ -5,6 +5,15 @@ define({
 	// The port on which the instrumenting proxy will listen
 	proxyPort: 9000,
 
+	//Configure the test runner to fail if coverage falls below the configured
+	//thresholds.
+	coverageThresholds: {
+		statements: 74,
+		branches: 62,
+		functions: 76,
+		lines: 74
+	},
+
 	// A fully qualified URL to the Intern proxy
 	proxyUrl: 'http://localhost:9000/',
 

--- a/tests/lib/reporterManager.js
+++ b/tests/lib/reporterManager.js
@@ -20,14 +20,16 @@ define([
 
 			reporterManager.add({
 				'test': {
-					start: function () {
-						actual.push('start1');
-					},
-					'/some/topic': function () {
-						actual.push('topic1');
-					},
-					stop: function () {
-						actual.push('stop1');
+					definition: {
+						start: function () {
+							actual.push('start1');
+						},
+						'/some/topic': function () {
+							actual.push('topic1');
+						},
+						stop: function () {
+							actual.push('stop1');
+						}
 					}
 				}
 			});
@@ -41,14 +43,16 @@ define([
 
 			reporterManager.add({
 				'test': {
-					start: function () {
-						actual.push('start2');
-					},
-					'/some/topic': function () {
-						actual.push('topic2');
-					},
-					stop: function () {
-						actual.push('stop2');
+					definition: {
+						start: function () {
+							actual.push('start2');
+						},
+						'/some/topic': function () {
+							actual.push('topic2');
+						},
+						stop: function () {
+							actual.push('stop2');
+						}
 					}
 				}
 			});
@@ -84,20 +88,27 @@ define([
 
 		'start/stop lifecycle': function () {
 			var numTimesStarted = 0,
-				numTimesStopped = 0;
+				numTimesStopped = 0,
+				expectedConfig = {expected: 'value'},
+				actualConfig;
 
 			reporterManager.add({
 				'test': {
-					start: function () {
-						++numTimesStarted;
-					},
-					stop: function () {
-						++numTimesStopped;
+					config: expectedConfig,
+					definition: {
+						start: function (config) {
+							++numTimesStarted;
+							actualConfig = config;
+						},
+						stop: function () {
+							++numTimesStopped;
+						}
 					}
 				}
 			});
 
 			reporterManager.start('test');
+			assert.strictEqual(actualConfig, expectedConfig, 'Passes reporter config to start');
 			reporterManager.start('test');
 			assert.strictEqual(numTimesStarted, 1, 'Trying to start an already-started reporter should do nothing');
 
@@ -113,11 +124,13 @@ define([
 
 			function createReporter(name) {
 				return {
-					start: function () {
-						actual.push('start ' + name);
-					},
-					stop: function () {
-						actual.push('stop ' + name);
+					definition: {
+						start: function () {
+							actual.push('start ' + name);
+						},
+						stop: function () {
+							actual.push('stop ' + name);
+						}
 					}
 				};
 			}

--- a/tests/lib/reporters/lcov.js
+++ b/tests/lib/reporters/lcov.js
@@ -45,6 +45,7 @@ define([
 			};
 
 			try {
+				lcov.start();
 				lcov['/coverage'](sessionId, mockCoverage);
 				assert.isTrue(collectorCalled, 'Collector#add should be called when the reporter /coverage method is called');
 			}
@@ -63,6 +64,7 @@ define([
 			};
 
 			try {
+				lcov.start();
 				lcov.stop();
 				assert.isTrue(writeReportCalled, 'Reporter#writeReport should be called when the /runner/end method is called');
 			}
@@ -73,6 +75,7 @@ define([
 
 		'File output': function () {
 			try {
+				lcov.start();
 				lcov['/coverage'](sessionId, mockCoverage);
 				lcov.stop();
 				assert.isTrue(fs.existsSync('lcov.info'), 'lcov.info file was written to disk');
@@ -81,6 +84,28 @@ define([
 			finally {
 				fs.existsSync('lcov.info') && fs.unlinkSync('lcov.info');
 			}
+		},
+
+		'File output to configured location': function () {
+			var config = {
+				dir: 'tmp/'
+			}, 
+			fn = config.dir + 'lcov.info';
+
+			try {
+				lcov.start(config);
+				lcov['/coverage'](sessionId, mockCoverage);
+				lcov.stop();
+				assert.isTrue(fs.existsSync(fn), fn + ' file was written to disk');
+				assert(fs.statSync(fn).size > 0, fn + ' contains data');
+			}
+			finally {
+				if (fs.existsSync(fn)) {
+					fs.unlinkSync(fn);
+					fs.rmdirSync(config.dir);
+				}
+			}
 		}
+
 	});
 });

--- a/tests/lib/thresholdCheck.js
+++ b/tests/lib/thresholdCheck.js
@@ -1,0 +1,244 @@
+define([
+	'intern!object',
+	'intern/chai!assert',
+	'../../lib/thresholdCheck',
+	'dojo/Evented'
+], function (registerSuite, assert, coverageThresholdCheck, Evented) {
+
+	var thresholds = {
+		covered: {
+			expectedGood: {
+				lines: 100,
+				functions: 0,
+				statements: 32,
+				branches: 82
+			},
+			expectedBad: {
+				lines: 100,
+				functions: 1,
+				statements: 32,
+				branches: 82
+			}
+		},
+		uncovered: {
+			expectedGood: {
+				lines: -10,
+				functions: -10,
+				statements: -2,
+				branches: -2
+			},
+			expectedBad: {
+				lines: -10,
+				functions: -10,
+				statements: -1,
+				branches: -2
+			}
+		}
+
+	};
+	var mockCoverage = {
+		'test.js': {
+			'path': 'test.js',
+			's': {
+				'1': 1,
+				'2': 0,
+				'3': 0
+			},
+			'b': {
+				'1': [
+					0,1
+				],
+				'2': [
+					1,1
+				],
+				'3': [
+					1,1
+				]
+			},
+			'f': {
+				'1': 0
+			},
+			'fnMap': {
+				'1': {
+					'start': {
+						'line': 1,
+						'column': 0
+					},
+					'end': {
+						'line': 60,
+						'column': 3
+					}
+				}
+			},
+			'statementMap': {
+				'1': {
+					'start': {
+						'line': 1,
+						'column': 0
+					},
+					'end': {
+						'line': 60,
+						'column': 3
+					}
+				},
+				'2': {
+					'start': {
+						'line': 1,
+						'column': 0
+					},
+					'end': {
+						'line': 10,
+						'column': 2
+					}
+				},
+				'3': {
+					'start': {
+						'line': 1,
+						'column': 0
+					},
+					'end': {
+						'line': 10,
+						'column': 2
+					}
+				}
+			},
+			'branchMap': {
+				'1': {
+					'start': {
+						'line': 1,
+						'column': 0
+					},
+					'end': {
+						'line': 60,
+						'column': 3
+					}
+				},
+				'2': {
+					'start': {
+						'line': 1,
+						'column': 0
+					},
+					'end': {
+						'line': 10,
+						'column': 2
+					}
+				},
+				'3': {
+					'start': {
+						'line': 1,
+						'column': 0
+					},
+					'end': {
+						'line': 10,
+						'column': 2
+					}
+				}
+
+			}
+		}
+	};
+
+	function getMockTopic() {
+
+		var hub = new Evented();
+		var mock = {
+			publish: function () {
+				this.publish.called++;
+				this.publish.args.push(arguments);
+				return hub.emit.apply(hub, arguments);
+			},
+			subscribe: function () {
+				this.subscribe.called++;
+				this.subscribe.args.push(arguments);
+				return hub.on.apply(hub, arguments);
+			}
+
+		};
+
+		mock.publish.called = 0;
+		mock.publish.args = [];
+		mock.subscribe.called = 0;
+		mock.subscribe.args = [];
+
+		return mock;
+	}
+
+	function getCoverageErrors(topic) {
+		var argForCall;
+		for (var i = 0; i < topic.publish.args.length; i++) {
+			argForCall = topic.publish.args[i];
+			if (argForCall[0] === '/coverage/error') {
+				return argForCall[2];
+			}
+		}
+	}
+
+	registerSuite({
+		name: 'intern/lib/thresholdCheck',
+
+		thresholds: {
+			covered: {
+				'within': function () {
+					var topic = getMockTopic();
+					coverageThresholdCheck(topic, thresholds.covered.expectedGood);
+					topic.publish('/coverage', null, mockCoverage);
+					assert.isUndefined(getCoverageErrors(topic));
+				},
+				outside: function () {
+					var topic = getMockTopic();
+					coverageThresholdCheck(topic, thresholds.covered.expectedBad);
+					topic.publish('/coverage', null, mockCoverage);
+					assert.equal(getCoverageErrors(topic), 'Coverage for functions (0%) does not meet threshold (1%)');
+				}
+
+			},
+			uncovered: {
+				'within': function () {
+					var topic = getMockTopic();
+					coverageThresholdCheck(topic, thresholds.uncovered.expectedGood);
+					topic.publish('/coverage', null, mockCoverage);
+					assert.isUndefined(getCoverageErrors(topic));
+				},
+				outside: function () {
+					var topic = getMockTopic();
+					coverageThresholdCheck(topic, thresholds.uncovered.expectedBad);
+					topic.publish('/coverage', null, mockCoverage);
+					assert.equal(getCoverageErrors(topic), 'Uncovered count for statements (2) exceeds threshold (1)');
+				}
+			}
+		},
+
+		topics: {
+			remoteSessions: {
+				'subscribe#/coverage': function () {
+					var topic = getMockTopic();
+					coverageThresholdCheck(topic, thresholds.covered.expectedGood, true);
+					assert.equal(topic.subscribe.called, 3);
+					assert.equal(topic.subscribe.args[2][0], '/coverage');
+				},
+				'subscribe#/session/start': function () {
+					var topic = getMockTopic();
+					coverageThresholdCheck(topic, thresholds.covered.expectedGood, true);
+					assert.equal(topic.subscribe.called, 3);
+					assert.equal(topic.subscribe.args[0][0], '/session/start');
+				},
+				'subscribe#/session/end': function () {
+					var topic = getMockTopic();
+					coverageThresholdCheck(topic, thresholds.covered.expectedGood, true);
+					assert.equal(topic.subscribe.called, 3);
+					assert.equal(topic.subscribe.args[1][0], '/session/end');
+				}
+			},
+			localSession: {
+				topics: {
+					'subscribe#/coverage': function () {
+						var topic = getMockTopic();
+						coverageThresholdCheck(topic, thresholds.covered.expectedGood);
+						assert.equal(topic.subscribe.called, 1);
+						assert.equal(topic.subscribe.args[0][0], '/coverage');
+					}
+				}
+			}
+		}
+	});
+});


### PR DESCRIPTION
This pull request adds features to address the requirements outlined in https://github.com/theintern/intern/issues/141

## Pass configuration to reporters.

I have added the ability to pass configuration data to the reporters from the intern configuration file. Configuration for the reporters can now have the following structure. 

```javascript
{
	"reporters": [
		"console", {
			"id": "lcov",
			"config": {
				"dir": "./output/"
			}
		}, {
			"id": "lcovhtml",
			"config": {
				"dir": "./output/"
			}
		}
	]
}
```

The API for authoring a reporter has changed slightly. When defining the `start` function of a reporter you will be passed a configuration object from the intern configuration if provided. 

## Configure coverage thresholds

In the intern configuration you can now specify the coverage thresholds which should be met for the runner to exit successfully. The threshold settings can be provided in the intern configuration in two forms.

The coverage threshold settings follow the values allowed by istanbul 

### Percentage coverage

The minimum threshold the unit must reach to be considered passing. 

```javascript
{
	coverageThresholds: {
		statements: 74,
		branches: 62,
		functions: 76,
		lines: 74
	}
}
```

### Non-percentage coverage

The maximum allowed uncovered entities. 

```javascript
{
	coverageThresholds: {
		statements: -10,
		branches: -10,
		functions: -10,
		lines: -10
	}
}
```

When a coverage threshold is configured a new event, `/coverage/error`, is published if the threshold is not met. The subscribers will be passed a text representation of the failures determined by the threshold check. This can be used by reporter authors to report the failure of the coverage threshold check appropriately.

## Wiki updates. 

The following wiki articles should be updated when this pull request is merged. 

https://github.com/theintern/intern/wiki/Configuring-Intern  - update the reporter configuration to explain the reporter configuration option.

https://github.com/theintern/intern/wiki/Using-and-Writing-Reporters - update the reporter API to explain the reporter configuration. Also document the `/coverage/error` even which will be published if coverage threshold checks fail. 
