### PR TITLE
Exit process if Sauce tunnel fails

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -297,6 +297,7 @@ else {
 				}, function (error) {
 					console.error(error);
 					proxy.close();
+					process.exit(1);
 				});
 			});
 		});


### PR DESCRIPTION
The effort here is to fix issues where the Sauce Labs failed to initialize, but the runner exited with status 0:
![](https://camo.githubusercontent.com/f70321f2e2214e079234668297ff93ea5aedc0f9/687474703a2f2f763134642e636f6d2f692f353335666433633330663334392e6a7067)

ref https://github.com/bermi/sauce-connect-launcher/issues/24#issuecomment-41728598
