### PR TITLE
Update sauce-connect-launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"dependencies": {
 		"wd": "0.2.2",
 		"istanbul": "0.2.7",
-		"sauce-connect-launcher": "0.4.2",
+		"sauce-connect-launcher": "0.5.0",
 		"dojo": "https://github.com/csnover/dojo2-core/archive/2.0.tar.gz",
 		"chai": "1.9.1"
 	},


### PR DESCRIPTION
Changes in SCL:
"
Use Sauce Connect v4.2 by default
Allow run-time overriding of Sauce Connect Version (#25)
Always set and check execute permissions (#27)
" via https://github.com/bermi/sauce-connect-launcher#v050
