### PR TITLE
improve proxy performance of serving static files

### DIFF
--- a/lib/createProxy.js
+++ b/lib/createProxy.js
@@ -119,15 +119,16 @@ define([
 				});
 			}
 			else {
-				fs.exists(wholePath, function (exists) {
-					if (!exists) {
+				fs.stat(wholePath, function (err, stat) {
+					if (err) {
 						response.statusCode = 404;
 						response.end();
 						return;
 					}
 
 					response.writeHead(200, {
-						'Content-Type': contentType
+						'Content-Type': contentType,
+						'Content-Length': stat.size
 					});
 					var fileStream = fs.createReadStream(wholePath);
 					fileStream.pipe(response);


### PR DESCRIPTION
the patch significantly improves performance of the proxy serving static files: we reduce run time of our non-functional test suites from 36 seconds to 16 seconds
