### PR TITLE
Take functionalSuites from command-line arguments

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -102,6 +102,10 @@ else {
 					args.reporters = 'runner';
 				}
 			}
+			
+			if (args.functionalSuites) {
+				config.functionalSuites = args.functionalSuites;
+			}
 
 			if (config.tunnel.indexOf('/') === -1) {
 				config.tunnel = 'dojo/node!digdug/' + config.tunnel;


### PR DESCRIPTION
This should fix #123 and also improve the Grunt integration as it allows for specifying functionalSuites from the command-line interface, which is also used via Grunt.
