### PR TITLE
improve proxy performance by disabling TCP optimization

### DIFF
--- a/lib/createProxy.js
+++ b/lib/createProxy.js
@@ -159,6 +159,7 @@ define([
 
 		server.on('connection', function (socket) {
 			sockets.push(socket);
+			socket.setNoDelay(true);
 			socket.on('close', function () {
 				var index = sockets.indexOf(socket);
 				index !== -1 && sockets.splice(index, 1);


### PR DESCRIPTION
the patch significantly improves performance of our non-functional tests:

in FF before this patch, all our non-functional tests would take 44 seconds, while after this patch it's 20 seconds
in IE 60 seconds -> 36 seconds
