### PR TITLE
only add a ClientSuite if any suites exist

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -198,6 +198,8 @@ else {
 				CompatCommand.prototype.constructor = CompatCommand;
 				compat.applyTo(CompatCommand.prototype);
 
+				var hasClientSuites = config.suites && config.suites.length;
+
 				util.flattenEnvironments(config.capabilities, config.environments).forEach(function (environmentType) {
 					var suite = new Suite({
 						name: 'main',
@@ -238,7 +240,10 @@ else {
 						}
 					});
 
-					suite.tests.push(new ClientSuite({ parent: suite, config: config }));
+					// avoid connecting to the proxy if not needed
+					if (hasClientSuites) {
+						suite.tests.push(new ClientSuite({ parent: suite, config: config }));
+					}
 					main.suites.push(suite);
 				});
 


### PR DESCRIPTION
adding a `ClientSuite` will unconditionally try to open client.html on the proxy.  this adds a check to make sure that a ClientSuite is necessary before adding it.
