### PR TITLE
Use correct baseUrl when using a reverse proxy consisting of subdirectories

### DIFF
--- a/client.html
+++ b/client.html
@@ -14,7 +14,7 @@
 			// path for the config module (e.g. `/path/to/intern/config`) and
 			// then set `baseUrl` correctly in the `loader` configuration object
 			// of the config module
-			baseUrl: /.*\/__intern\/$/.test(basePath) === true ? basePath.replace(/__intern\/$/, '') : (basePath + '../../'),
+			baseUrl: basePath.slice(-10) === '/__intern/' ? basePath.replace(/__intern\/$/, '') : (basePath + '../../'),
 			packages: [
 				{ name: 'intern', location: basePath }
 			],

--- a/lib/ClientSuite.js
+++ b/lib/ClientSuite.js
@@ -2,10 +2,10 @@ define([
 	'dojo/lang',
 	'dojo/Deferred',
 	'dojo/topic',
-	'dojo/Url',
+	'dojo/node!url',
 	'./args',
 	'./Suite'
-], function (lang, Deferred, topic, url, args, Suite) {
+], function (lang, Deferred, topic, urlUtil, args, Suite) {
 	function objectToQuery(object) {
 		var query = [];
 		var value;
@@ -59,7 +59,7 @@ define([
 				options = lang.mixin({}, args, {
 					// the proxy always serves the baseUrl from the loader configuration as the root of the proxy,
 					// so ensure that baseUrl is always set to that root on the client
-					baseUrl: new url(config.proxyUrl).path,
+					baseUrl: urlUtil.parse(config.proxyUrl).pathname,
 					reporters: 'webdriver',
 					sessionId: remote.sessionId
 				}),


### PR DESCRIPTION
Fixes #250.
