### PR TITLE
Make basePath platform normalized

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -173,7 +173,7 @@ else {
 
 				config.proxyUrl = config.proxyUrl.replace(/\/*$/, '/');
 
-				var basePath = (config.loader.baseUrl || process.cwd()) + '/';
+				var basePath = path.normalize((config.loader.baseUrl || process.cwd()) + '/');
 				var proxy = createProxy({
 					basePath: basePath,
 					excludeInstrumentation: config.excludeInstrumentation,


### PR DESCRIPTION
The instrumentation filter in `lib/util` checkes that a given resource path begins with `basePath` via a simple string match. Non-normalized basePaths -- e.g., those that contain extraneous slashes or that end with a '/' on Windows -- won't be properly matched.
