### PR TITLE
LCOV Coveralls reporter (Work in progress)

### DIFF
--- a/lib/reporters/lcovcoveralls.js
+++ b/lib/reporters/lcovcoveralls.js
@@ -1,0 +1,26 @@
+define([
+	'dojo/node!istanbul/lib/collector',
+	'dojo/node!istanbul/lib/report/lcovonly'
+], function (Collector, Reporter) {
+	var collector = new Collector(),
+		reporter = new Reporter(),
+		internConfig;
+
+	return {
+		'/proxy/start': function (config) {
+			internConfig = config;
+		},
+
+		'/coverage': function (sessionId, coverage) {
+			var filenames = Object.keys(coverage);
+			filenames.forEach(function(filename) {
+				coverage[filename].path = coverage[filename].path.replace(internConfig.basePath, '');
+			});
+			collector.add(coverage);
+		},
+
+		stop: function () {
+			reporter.writeReport(collector, true);
+		}
+	};
+});

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -13,5 +13,6 @@ define([
 	'./lib/reporters/console',
 	'dojo/has!host-node?./lib/reporters/teamcity',
 	'dojo/has!host-node?./lib/reporters/junit',
-	'dojo/has!host-node?./lib/reporters/lcov'
+	'dojo/has!host-node?./lib/reporters/lcov',
+	'dojo/has!host-node?./lib/reporters/lcovcoveralls'
 ], function () {});

--- a/tests/unit/lib/reporters/lcovcoveralls.js
+++ b/tests/unit/lib/reporters/lcovcoveralls.js
@@ -1,0 +1,86 @@
+define([
+	'intern!object',
+	'intern/chai!assert',
+	'dojo/node!istanbul/lib/collector',
+	'dojo/node!istanbul/lib/report/lcovonly',
+	'dojo/node!fs',
+	'../../../../lib/reporters/lcovcoveralls'
+], function (registerSuite, assert, Collector, Reporter, fs, lcov) {
+	var sessionId = 'foo',
+		mockCoverage = {
+			'test.js': {
+				'path': 'test.js',
+				's': {
+					'1': 1
+				},
+				'b': {},
+				'f': {},
+				'fnMap': {},
+				'statementMap': {
+					'1': {
+						'start': {
+							'line': 1,
+							'column': 0
+						},
+						'end': {
+							'line': 60,
+							'column': 3
+						}
+					}
+				},
+				'branchMap': {}
+			}
+		};
+
+	registerSuite({
+		name: 'intern/lib/reporters/lcovcoveralls',
+
+		'/coverage': function () {
+			var collectorCalled = false,
+				oldAdd = Collector.prototype.add;
+
+			Collector.prototype.add = function (coverage) {
+				collectorCalled = true;
+				assert.deepEqual(coverage, mockCoverage, 'Collector#add should be called with the correct mockCoverage object');
+			};
+
+			try {
+				lcov['/coverage'](sessionId, mockCoverage);
+				assert.isTrue(collectorCalled, 'Collector#add should be called when the reporter /coverage method is called');
+			}
+			finally {
+				Collector.prototype.add = oldAdd;
+			}
+		},
+
+		'stop': function () {
+			var writeReportCalled = false,
+				oldWriteReport = Reporter.prototype.writeReport;
+
+			Reporter.prototype.writeReport = function (collector) {
+				writeReportCalled = true;
+				assert.instanceOf(collector, Collector, 'Reporter#writeReport should be called with a Collector');
+			};
+
+			try {
+				lcov.stop();
+				assert.isTrue(writeReportCalled, 'Reporter#writeReport should be called when the /runner/end method is called');
+			}
+			finally {
+				Reporter.prototype.writeReport = oldWriteReport;
+			}
+		},
+
+		'File output': function () {
+			try {
+				lcov['/coverage'](sessionId, mockCoverage);
+				lcov.stop();
+				assert.isTrue(fs.existsSync('lcov.info'), 'lcov.info file was written to disk');
+				assert(fs.statSync('lcov.info').size > 0, 'lcov.info contains data');
+			}
+			finally {
+				fs.existsSync('lcov.info') && fs.unlinkSync('lcov.info');
+			}
+		}
+	});
+});


### PR DESCRIPTION
This is a fix for #229 and it's achieved by removing the base path from the generated lcov file. 
However I marked this as WIP because I don't really know whether this fits in the way you'd like it to have and also because previously to rebasing on current master the tests were failing because the basePath wasn't set there. After rebasing it worked though but I don't know whether this was a false positive or not. 

Also I didn't sign the CLA yet, will do after you told me it's good to go :)
