### PR TITLE
Make empty suites & functionalSuites args override their config values

### DIFF
--- a/lib/realClient.js
+++ b/lib/realClient.js
@@ -16,7 +16,7 @@ define([
 			/*jshint maxcomplexity:13 */
 			main.config = config;
 
-			if (!args.suites) {
+			if (typeof args.suites === 'undefined') {
 				args.suites = config.suites;
 			}
 

--- a/runner.js
+++ b/runner.js
@@ -107,7 +107,7 @@ else {
 				}
 			}
 
-			if (args.functionalSuites) {
+			if (typeof args.functionalSuites !== 'undefined') {
 				config.functionalSuites = args.functionalSuites;
 			}
 


### PR DESCRIPTION
Fixes #268.

Specifying `suites=` and/or `functionalSuites=` on the commandline will skip the respective unit and/or functional suites, behaving the same as an empty array given in the config file.
