### PR TITLE
Fixes empty suites array still adding a ClientSuite

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -111,6 +111,10 @@ else {
 				config.functionalSuites = args.functionalSuites;
 			}
 
+			if (args.suites) {
+				config.suites = args.suites;
+			}
+
 			if (config.tunnel.indexOf('/') === -1) {
 				config.tunnel = 'dojo/node!digdug/' + config.tunnel;
 			}
@@ -247,7 +251,7 @@ else {
 						}
 					});
 
-					if (args.suites || typeof args.suites === "undefined" && config.suites && config.suites.length) {
+					if (config.suites) {
 						suite.tests.push(new ClientSuite({ parent: suite, config: config }));
 					}
 


### PR DESCRIPTION
Also tests against the suites argument instead if it exists, which in conjunction with https://github.com/theintern/intern/pull/269 will not add a ClientSuite when an empty suites argument is specified.

See https://github.com/theintern/intern/pull/241#issuecomment-55562168 and https://github.com/theintern/intern/commit/4a6512b408304d83e30d8dadf01055823f36d12c#commitcomment-7780521.
