### PR TITLE
Remove trailing Z to fix TeamCity runner

### DIFF
--- a/lib/reporters/teamcity.js
+++ b/lib/reporters/teamcity.js
@@ -53,7 +53,7 @@ define([], function () {
 		 */
 		_sendMessage: function (type, args) {
 			args.flowId = ++teamcity._flowId;
-			args.timestamp = new Date().toISOString();
+			args.timestamp = new Date().toISOString().slice(0,-1);
 			args = Object.keys(args).map(function (key) {
 				var value = args[key].toString();
 				return key + '=' + '\'' + teamcity._escapeString(value) + '\'';


### PR DESCRIPTION
Following off of the same fix here, pifantastic/teamcity-service-messages#10 we need to remove the trailing Z from the time stamp for TeamCity to process the service messages. Otherwise we get the following error in TeamCity version 8.1.5:

Unparseable date: "2014-10-13T17:29:39.747Z"
