### PR TITLE
Add the showDiff property to geezer assertion errors

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -478,7 +478,8 @@ define([
 			actual: actual,
 			expected: expected,
 			operator: operator,
-			stackStartFunction: stackStartFunction
+			stackStartFunction: stackStartFunction,
+			showDiff: assert.config.showDiff
 		});
 	}
 
@@ -487,6 +488,7 @@ define([
 		this.actual = options.actual;
 		this.expected = options.expected;
 		this.operator = options.operator;
+		this.showDiff = options.showDiff || false;
 
 		if (Error.captureStackTrace) {
 			Error.captureStackTrace(this, options.stackStartFunction || fail);
@@ -518,6 +520,8 @@ define([
 	}
 
 	assert.AssertionError = AssertionError;
+
+	assert.config = { showDiff: true };
 
 	assert.fail = fail;
 

--- a/chai.js
+++ b/chai.js
@@ -4,11 +4,17 @@ define([ './assert' ], function (assert) {
 		 * AMD plugin API interface for easy loading of chai assertion interfaces.
 		 */
 		load: function (id, parentRequire, callback) {
-			if (id !== 'assert') {
-				throw new Error('Invalid chai interface "' + id + '" (only "assert" is available in geezer)');
+			if (id !== 'assert' && id !== 'config') {
+				throw new Error('Invalid chai interface "' + id +
+					'" (only "assert" and "config" are available in geezer)');
 			}
 
-			callback(assert);
+			if (id === 'assert') {
+				callback(assert);
+			}
+			else {
+				callback(assert.config);
+			}
 		}
 	};
 });

--- a/tests/unit/assert.js
+++ b/tests/unit/assert.js
@@ -707,5 +707,37 @@ define([
 				assert.include(arr, undefined);
 			}, 'Array#indexOf should skip holes in arrays');
 		});
+
+		tdd.test('showDiff', function () {
+			// showDiff is true by default
+			try {
+				assert.equal(1, 2);
+			}
+			catch (error) {
+				assert.isTrue(error.showDiff);
+			}
+
+			assert.config.showDiff = false;
+			try {
+				try {
+					assert.equal(1, 2);
+				}
+				catch (error) {
+					assert.isFalse(error.showDiff);
+				}
+
+				// showDiff should be false by default
+				assert.config.showDiff = undefined;
+				try {
+					assert.equal(1, 2);
+				}
+				catch (error) {
+					assert.isFalse(error.showDiff);
+				}
+			}
+			finally {
+				assert.config.showDiff = true;
+			}
+		});
 	});
 });


### PR DESCRIPTION
Assertion errors will now have a `showDiff` property set to true by default. This can be disabled by setting the `showDiff` config property to false, the same as can be done with standard Chai:

``` js
define([ 'intern/chai!config', ... ], function (config, ...) {
    config.showDiff = false;
    ...
});
```
