### PR TITLE
Separate basePath from baseUrl

### DIFF
--- a/client.html
+++ b/client.html
@@ -5,32 +5,33 @@
 		<title>Browser test runner</title>
 		<script src="node_modules/dojo/dojo.js"></script>
 		<script>
-(function () {
-	var basePath = location.pathname.replace(/\/+[^\/]*$/, '/'),
-		internConfig = this.__internConfig = {
-			// For users running client.html directly, assume that the base path
-			// is two levels up (the parent of node_modules); this is most common.
-			// Users that need something special should provide an absolute module
-			// path for the config module (e.g. `/path/to/intern/config`) and
-			// then set `baseUrl` correctly in the `loader` configuration object
-			// of the config module
-			baseUrl: basePath.slice(-10) === '/__intern/' ? basePath.slice(0, -9) : (basePath + '../../'),
-			packages: [
-				{ name: 'intern', location: basePath }
-			],
-			map: {
-				intern: {
-					dojo: 'intern/node_modules/dojo',
-					chai: 'intern/node_modules/chai/chai'
-				},
-				'*': {
-					'intern/dojo': 'intern/node_modules/dojo'
-				}
-			}
-		};
+			(function () {
+				var basePath = location.pathname.replace(/\/+[^\/]*$/, '/');
+				var internConfig = this.__internConfig = {
+					// For users running client.html directly, assume that the base path
+					// is two levels up (the parent of node_modules); this is most common.
+					// Users that need something special should provide an absolute module
+					// path for the config module (e.g. `/path/to/intern/config`) and
+					// then set `baseUrl` correctly in the `loader` configuration object
+					// of the config module
+					baseUrl: basePath.slice(-10) === '/__intern/' ? basePath.slice(0, -9) : (basePath + '../../'),
+					packages: [
+						{ name: 'intern', location: basePath }
+					],
+					map: {
+						intern: {
+							dojo: 'intern/node_modules/dojo',
+							chai: 'intern/node_modules/chai/chai'
+						},
+						'*': {
+							'intern/dojo': 'intern/node_modules/dojo'
+						}
+					}
+				};
 
-	require(internConfig, [ 'intern/client' ]);
-})();
+				require(internConfig, [ 'intern/client' ]);
+			})();
 		</script>
 	</head>
+	<body></body>
 </html>

--- a/client.js
+++ b/client.js
@@ -40,6 +40,7 @@ else {
 		main.mode = 'client';
 
 		require([ args.config ], function (config) {
+			// jshint maxcomplexity:12
 			util.swapLoader(config.useLoader).then(function (require) {
 				if (!config.loader) {
 					config.loader = {};
@@ -53,11 +54,18 @@ else {
 					config.loader.baseUrl = args.baseUrl;
 				}
 
-				// if the client is running under Node.js, make baseUrl relative to basePath
 				if (has('host-node')) {
+					// if the client is running under Node.js, make baseUrl relative to basePath
 					config.basePath = pathUtil.resolve(config.basePath || process.cwd());
 					if (config.loader.baseUrl) {
 						config.loader.baseUrl = pathUtil.resolve(pathUtil.join(config.basePath, config.loader.baseUrl));
+					}
+				}
+				else {
+					// if the client is running in a browser, make relative baseUrls relative to the baseUrl
+					// specified in client.html, which is the directory containing node_modules
+					if (config.loader.baseUrl && config.loader.baseUrl.charAt(0) !== '/') {
+						config.loader.baseUrl = this.__internConfig.baseUrl + config.loader.baseUrl;
 					}
 				}
 

--- a/client.js
+++ b/client.js
@@ -25,8 +25,10 @@ else {
 		'./main',
 		'./lib/args',
 		'./lib/util',
-		'require'
-	], function (main, args, util, parentRequire) {
+		'require',
+		'dojo/has',
+		'dojo/has!host-node?dojo/node!path'
+	], function (main, args, util, parentRequire, has, pathUtil) {
 		if (!args.config) {
 			throw new Error('Missing "config" argument');
 		}
@@ -43,12 +45,20 @@ else {
 					config.loader = {};
 				}
 
-				// if a `baseUrl` is specified in the arguments for the page, it should have priority over what came
-				// from the configuration file. this is especially important for the runner proxy, which serves
-				// `baseUrl` as the root path and so `baseUrl` must become `/` in the client even if it was something
-				// else in the config originally (for the server-side loader)
+				if (args.basePath) {
+					config.basePath = args.basePath;
+				}
+
 				if (args.baseUrl) {
 					config.loader.baseUrl = args.baseUrl;
+				}
+
+				// if the client is running under Node.js, make baseUrl relative to basePath
+				if (has('host-node')) {
+					config.basePath = pathUtil.resolve(config.basePath || process.cwd());
+					if (config.loader.baseUrl) {
+						config.loader.baseUrl = pathUtil.resolve(pathUtil.join(config.basePath, config.loader.baseUrl));
+					}
 				}
 
 				// Most loaders expose `require.config` for configuration, but the Dojo 1 loader does not

--- a/lib/ClientSuite.js
+++ b/lib/ClientSuite.js
@@ -57,9 +57,6 @@ define([
 			var config = this.config,
 				remote = this.remote,
 				options = lang.mixin({}, args, {
-					// the proxy always serves the baseUrl from the loader configuration as the root of the proxy,
-					// so ensure that baseUrl is always set to that root on the client
-					baseUrl: urlUtil.parse(config.proxyUrl).pathname,
 					reporters: 'webdriver',
 					sessionId: remote.sessionId
 				}),

--- a/lib/realClient.js
+++ b/lib/realClient.js
@@ -97,10 +97,7 @@ define([
 
 			if (has('host-node')) {
 				// Hook up the instrumenter before any code dependencies are loaded
-				// passing `process.cwd()` to `pathUtil.resolve` since it will throw an error if `undefined` is passed
-				// (like when `baseUrl` is not explicitly set) but is a no-op for an already-absolute path
-				var basePath = pathUtil.join(pathUtil.resolve(config.loader.baseUrl || process.cwd()), '/');
-				util.setInstrumentationHooks(config, basePath);
+				util.setInstrumentationHooks(config);
 			}
 
 			var reportersReady = false;

--- a/lib/util.js
+++ b/lib/util.js
@@ -509,14 +509,17 @@ define([
 		 *
 		 * @param {Object} config The main Intern configuration.
 		 * @param {Object} instrumenter The code instrumenter.
-		 * @param {string} basePath The base path for all code.
 		 */
-		setInstrumentationHooks: function (config, basePath) {
+		setInstrumentationHooks: function (config) {
 			function hookMatcher(filename) {
-				return !config.excludeInstrumentation || (filename.indexOf(basePath) === 0 &&
+				// don't hook files outside of basePath
+				if (filename.indexOf(config.basePath) !== 0) {
+					return false;
+				}
+				return !config.excludeInstrumentation ||
 					// if the string passed to `excludeInstrumentation` changes here, it must also change in
 					// `lib/createProxy.js`
-					!config.excludeInstrumentation.test(filename.slice(basePath.length)));
+					!config.excludeInstrumentation.test(filename.slice(config.basePath.length));
 			}
 
 			function hookTransformer(code, filename) {


### PR DESCRIPTION
The PR allows the same `baseUrl` to work properly for `intern-client`, `intern-runner`, and `client.html`, assuming that intern is being run from the directory containing `node_modules` (the typical case).

- `basePath` is now a fully separate concept from `baseUrl`. Conceptually, `basePath` in the node environment is the same as the web server root when using client.html.
- `basePath` is a general Intern configuration parameter (vs. `baseUrl`, which is a loader parameter) that declares the root path from which files will be served
- `basePath` is only directly relevant to Node (runner, createProxy); it's ignored by the browser client. If not specified it defaults to process.cwd()
- If a relative `basePath` is specified in the intern config, it is relative to process.cwd()
- Relative `baseUrl`s are now relative to the directory containing `node_modules` when using `client.html`. This is different from typical dojo semantics, where a relative `baseUrl` is relative to the loading HTML doc, but it improves consistency between the node and browser environments. (In node environments a relative `baseUrl` is relative to process.cwd(), which is typically the directory containing `node_modules`.)

fixes #249