### PR TITLE
fix duplicate suite reports with junit reporter

### DIFF
--- a/lib/reporters/junit.js
+++ b/lib/reporters/junit.js
@@ -138,7 +138,11 @@ define([
 				return;
 			}
 
-			rootNode.childNodes.push(createSuiteNode(suite, sessions[suite.sessionId || '']));
+			var runId = '_' + suite.sessionId + '-run';
+			if (!this[runId]) {
+				this[runId] = true;
+				rootNode.childNodes.push(createSuiteNode(suite, sessions[suite.sessionId || '']));
+			}
 		},
 
 		start: function () {


### PR DESCRIPTION
When the junit reporter is run with the runner, the reports are duplicated. It appears that this is caused by the `/suite/end` topic being published by both `Suite` and `createProxy` (in `publishInSequence`). This appears to only be an issue with the junit reporter, as it appears to count on `/suite/end` to only be called once per suite. This fixes the duplication reported in fixes #275. This change should not affect the junit reporter when executed with client (unit test still passes).