### PR TITLE
Show critical errors in pretty reporter

### DIFF
--- a/lib/realClient.js
+++ b/lib/realClient.js
@@ -62,6 +62,7 @@ define([
 
 					topic.publish('/error', error);
 					topic.publish('/client/end', args.sessionId);
+					reporterManager.clear();
 				};
 			}
 			else if (has('host-node')) {
@@ -87,6 +88,7 @@ define([
 
 					topic.publish('/error', error);
 					topic.publish('/client/end');
+					reporterManager.clear();
 					process.exit();
 				});
 			}

--- a/lib/reporters/pretty.js
+++ b/lib/reporters/pretty.js
@@ -344,8 +344,7 @@ define([
 		},
 
 		'/error': function (error) {
-			var message = '! ' + error.message;
-			pretty.log.push(message);
+			pretty.log.push(internUtil.getErrorMessage(error));
 		},
 
 		'/deprecated': function (name, replacement) {


### PR DESCRIPTION
The pretty reporter now displays unhandled exceptions. Two supporting
changes were made:

- The pretty reporter's /error handler logs full errors instead
  of just the error message
- realClient was updated to stop the reporters on an unhandled exception

refs #319