### PR TITLE
Add the option to specify the report location for junit reporter

### DIFF
--- a/lib/reporters/junit.js
+++ b/lib/reporters/junit.js
@@ -6,7 +6,7 @@ define([
 	'intern',
 	'dojo/node!fs',
 	'../util'
-], function (fs, util) {
+], function (intern, fs, util) {
 	var sessions = {
 		'': 'Node.js'
 	};

--- a/lib/reporters/junit.js
+++ b/lib/reporters/junit.js
@@ -3,6 +3,7 @@
  * different incompatible JUnit/xUnit XSDs as possible into one reporter.
  */
 define([
+	'intern',
 	'dojo/node!fs',
 	'../util'
 ], function (fs, util) {
@@ -147,7 +148,7 @@ define([
 
 		stop: function () {
 			var report = '<?xml version="1.0" encoding="UTF-8" ?>' + rootNode.toString() + '\n';
-			fs.writeFileSync('report.xml', report);
+			fs.writeFileSync(intern.config.junitReportFile || 'report.xml', report);
 		}
 	};
 });


### PR DESCRIPTION
Optionally specify a `junitReportFile` in your configuration file to output to a specific location, or if unset, default to `report.xml` as before.