### PR TITLE
added the possibility to pass NODE_ENV environment variable via grunt config

### DIFF
--- a/tasks/intern.js
+++ b/tasks/intern.js
@@ -55,7 +55,8 @@ module.exports = function (grunt) {
 				sauceAccessKey: true,
 				sauceUsername: true,
 				testingbotKey: true,
-				testingbotSecret: true
+				testingbotSecret: true,
+				nodeEnv: true
 			};
 
 		Object.keys(opts).forEach(function (option) {
@@ -79,7 +80,8 @@ module.exports = function (grunt) {
 			'sauceAccessKey',
 			'sauceUsername',
 			'testingbotKey',
-			'testingbotSecret'
+			'testingbotSecret',
+			'nodeEnv'
 		].forEach(function (option) {
 			var value = opts[option];
 			if (value) {


### PR DESCRIPTION
Allows to pass a variable 'nodeEnv' (NODE_ENV) environment variable from the grunt config and to run intern tests with different config variables for different environments using https://github.com/lorenwest/node-config.