### PR TITLE
Update Chai to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"istanbul": "0.2.16",
 		"source-map": "0.1.33",
 		"dojo": "2.0.0-alpha.5",
-		"chai": "1.9.1",
+		"chai": "2.3.0",
 		"leadfoot": "1.4.1",
 		"digdug": "1.3.0",
 		"charm": "0.2.0",


### PR DESCRIPTION
The current version of Chai included with Intern is considerably out of date now, with features available in the docs that are unavailable in Intern's version.  This has caught me out a few times, so I'm hoping it can be updated smoothly.

I've tested updating my local Intern's Chai dependency to 2.3.0 and haven't encountered any problems, but I'm unsure how to run the tests on intern itself.