### PR TITLE
Fix for unit tests freezing in browser

### DIFF
--- a/lib/ClientSuite.js
+++ b/lib/ClientSuite.js
@@ -56,6 +56,8 @@ define([
 							suite.tests.forEach(function (test) {
 								self.tests.push(test);
 							});
+
+							receiveEvent('runEnd');
 						}
 						else {
 							forward();


### PR DESCRIPTION
Since ac46e32 unit tests run in browser freeze after they are done executing, and no other page is loaded. This commit fixes it for me.