### PR TITLE
Match backslash as separator in excludeInstrumentation.

### DIFF
--- a/tests/example.intern.js
+++ b/tests/example.intern.js
@@ -48,5 +48,5 @@ define({
 	functionalSuites: [ /* 'myPackage/tests/functional' */ ],
 
 	// A regular expression matching URLs to files that should not be included in code coverage analysis
-	excludeInstrumentation: /^(?:tests|node_modules)\//
+	excludeInstrumentation: /^(?:tests|node_modules)[\/\\]/
 });


### PR DESCRIPTION
This makes the default value function correctly on Windows.