### PR TITLE
refs #424, split third party fonts into configuration option

### DIFF
--- a/lib/reporters/Html.js
+++ b/lib/reporters/Html.js
@@ -122,7 +122,10 @@ define([
 
 			var link = document.createElement('link');
 			link.rel = 'stylesheet';
-			link.href = require.toUrl('./html/html.css');
+			// TODO: Could this be read from the config instead of URL?
+			var href = (/intranet/.test(location.search)) ?
+				'./html/html-intranet.css' : './html/html.css';
+			link.href = require.toUrl(href);
 
 			document.head.appendChild(style);
 			document.head.appendChild(link);

--- a/lib/reporters/html/base.styl
+++ b/lib/reporters/html/base.styl
@@ -1,0 +1,263 @@
+html,
+body {
+	background: $bodyBackground;
+	color: $bodyTextColor;
+	font: 14px/normal 'Open Sans', Verdana, Helvetica, Arial, sans-serif;
+	margin: 0;
+	visibility: visible;
+	padding-bottom: 2em;
+	padding-top: 0;
+}
+
+.internReportContainer {
+	margin: 0 auto;
+	width: 75%;
+}
+
+.reportHeader {
+	background: #fff;
+	box-shadow: 0px 1px 2px 0px rgba(#000, 15%);
+	margin: 0 0 1em 0;
+	padding: 0.6em;
+	text-align: center;
+
+	.headerLogo {
+		height: 45px;
+		margin-right: 10px;
+		vertical-align: middle;
+		width: 45px;
+	}
+
+	.headerTitle {
+		color: $headingColor;
+		font-size: 1em;
+		font-weight: 300;
+		padding-top: 3px;
+		vertical-align: middle;
+	}
+}
+
+.summary {
+	border-collapse: collapse;
+	margin-bottom: 2.5em;
+	width: 100%;
+
+	td {
+		color: $summaryTextColor;
+		font-size: 1em;
+		font-weight: normal;
+		padding: 0;
+		text-align: center;
+		text-transform: uppercase;
+		vertical-align: top;
+		width: 20%;
+
+		.summaryContent {
+			background: $summaryTopBackground;
+			border: 1px solid $summaryBorderColor;
+			border-radius: 6px 6px 0 0;
+			box-shadow: 0px 1px 2px 0px rgba(#000, 15%);
+			margin: 0 1em 0 auto;
+
+			&.suites {
+				summaryIcon($suiteIcon);
+			}
+
+			&.tests {
+				summaryIcon($testIcon);
+			}
+
+			&.failed {
+				background: $failedColor;
+				color: #fff;
+
+				summaryIcon($failedIcon);
+
+				.summaryTitle {
+					border-color: darken($failedColor, 20%);
+					color: $summaryTextColor;
+				}
+
+				&.success {
+					margin-right: 1em;
+				}
+			}
+
+			&.success,
+			&.successRate {
+				background: darken($passedColor, 20%);
+				color: #fff;
+				margin-right: 0;
+
+				summaryIcon($passedIcon);
+
+				.summaryTitle {
+					border-color: darken($passedColor, 20%);
+					color: $summaryTextColor;
+				}
+			}
+
+			&.duration {
+				background: $summaryTopBackground;
+
+				summaryIcon($durationIcon);
+			}
+
+			.summaryTitle {
+				background: #fff;
+				border: 1px solid $summaryBorderColor;
+				border-radius: 14px;
+				display: inline-block;
+				padding: 0.2em 1em;
+				position: relative;
+				top: 10px;
+				z-index: 1;
+			}
+
+			.summaryData {
+				background: $summaryBottomBackground;
+				box-sizing: border-box;
+				color: $summaryTextColor;
+				font-size: 36px;
+				font-weight: 300;
+				height: 75px;
+				padding: 0.5em 0.25em;
+				text-align: center;
+			}
+		}
+	}
+}
+
+.failedFilter {
+	color: $reportTextColor;
+	padding: 0 0 1em;
+
+	input {
+		margin-right: 0.5em;
+	}
+}
+
+.report {
+	background-color: #fff;
+	border-collapse: collapse;
+	color: $reportTextColor;
+	width: 100%;
+
+	td {
+		padding: 0.7em;
+		border-left: 1px solid $cellBorderColor;
+		border-right: 1px solid $cellBorderColor;
+	}
+
+	.suite {
+		background: $sectionHeadingBackground;
+
+		testStatusIcon(darken($sectionHeadingBackground, 20%), darken($sectionHeadingBackground, 70%), $suiteIcon);
+
+		td {
+			border: 1px solid darken($sectionHeadingBackground, 20%);
+
+			&.title {
+				font-size: 15px;
+				font-weight: bold;
+			}
+
+			&.duration {
+				text-align:right;
+			}
+		}
+
+		.column-info {
+			span {
+				margin-right: 1em;
+			}
+
+			.success {
+				color: darken($passedColor, 30%);
+			}
+
+			.failed {
+				color: darken($failedColor, 30%);
+			}
+		}
+
+		&.indent {
+			background: lighten($sectionHeadingBackground, 60%);
+
+			td {
+				border-color: darken($sectionHeadingBackground, 20%);
+			}
+
+			.testStatus {
+				background: darken($sectionHeadingBackground, 10%);
+
+				&:before {
+					font-size: 17px;
+				}
+			}
+		}
+	}
+
+	.testResult {
+		transition: background 0.3s ease;
+
+		td {
+			border: 1px solid $cellBorderColor;
+
+			&.duration {
+				text-align: right;
+			}
+		}
+
+		&.passed {
+			testStatusIcon(lighten($passedColor, 70%), $passedColor, $passedIcon)
+
+			&:hover {
+				background: lighten($passedColor, 90%);
+			}
+		}
+
+		&.failed {
+			background: lighten($failedColor, 65%);
+
+			testStatusIcon(lighten($failedColor, 70%), $failedColor, $failedIcon);
+
+			&:hover {
+				background:lighten(@background, 20%);
+			}
+
+			td {
+				border-color:lighten($failedColor, 40%);
+				border-bottom:0;
+			}
+
+			.testStatus {
+				border-bottom:0;
+				border-color:lighten($failedColor, 40%);
+			}
+		}
+
+		&.lastTest {
+			td,
+			.testStatus {
+				border-bottom:0;
+			}
+		}
+	}
+
+	.indent1 { padding-left: 2em; }
+	.indent2 { padding-left: 4em; }
+	.indent3 { padding-left: 6em; }
+	.indent4 { padding-left: 8em; }
+	.indent5 { padding-left: 10em; }
+}
+
+.testStatus {
+	border-bottom: 0;
+	width: 20px;
+}
+
+.hidePassed .passed,
+.hidePassed .skipped {
+	display: none;
+}

--- a/lib/reporters/html/html-intranet.css
+++ b/lib/reporters/html/html-intranet.css
@@ -1,0 +1,305 @@
+@font-face {
+  font-family: 'Pe-icon-7-stroke';
+  src: url("data:application/x-font-ttf;base64,AAEAAAAOAIAAAwBgT1MvMj4qSOsAAADsAAAAVmNtYXDQGRm1AAABRAAAAUpjdnQgAAAAAAAACOgAAAAKZnBnbYiQkFkAAAj0AAALcGdhc3AAAAAQAAAI4AAAAAhnbHlmKnPcYgAAApAAAAJ6aGVhZAMUIVkAAAUMAAAANmhoZWEHRQNZAAAFRAAAACRobXR4FAQAAAAABWgAAAAYbG9jYQKHAcIAAAWAAAAADm1heHAAnAu3AAAFkAAAACBuYW1lVT4WzAAABbAAAALZcG9zdOKqXJsAAAiMAAAAVHByZXDdawOFAAAUZAAAAHsAAQNWAZAABQAAAnoCvAAAAIwCegK8AAAB4AAxAQIAAAIABQMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUGZFZABA6ALoBgNS/2oAWgNSAJYAAAABAAAAAAAAAAAAAwAAAAMAAAAcAAEAAAAAAEQAAwABAAAAHAAEACgAAAAGAAQAAQACAADoBv//AAAAAOgC//8AABf/AAEAAAAAAAAAAAEGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAA/70DFQL/ABgAJAA0AAq3LiYfGRMLAy0rATcXNycHFwcuASc1IxUOAQceARc+ATc0JgEuASc+ATceARcOAQM1IxUOARQWFxUzNT4BNCYCsRwdI1EjHBwvd0QymsgEBNmiotkENf62lcUEBMWVlcUEBMWEIQ8TEw8hDxISAkAcHSRQIx0cKzQFREQN1Zyj2QQE2aNLhP3TBMWVlcUEBMWVlcUBidvbBhkhGQVGRgUZIRkAAwAA/70DVgL/AAsAFwAoAAq3KCESDAYAAy0rAQ4BBx4BFz4BNy4BAy4BJz4BNx4BFw4BEwEnJiIGFB8BFjY3ATY0LgEBtrHrBQXrsbHrBATrsaPZBATZo6LZBATZLv70XQgUDwdvCBQIAR0IDxQC/wTssbHrBQXrsbHs/OQE2aKi2QQE2aKi2QIQ/vxeCBATCG8IAQYBFQcUDwEAAwAA/70DVwMAAAsAFwAjAAq3HBgTDQoEAy0rEwYQFxYgNzYQJyYgAQYgJyYQNzYgFxYCAQcXBxc3FzcnNycHj3p6gQFMgHp6gP60AbR2/s92cHB2ATJ2cAH93RilpBelpBekpRikAoWB/rSAenqAAUyBev1QcHB2ATJ2cHB2/s4BVhilpBikpBikpRilAAAABAAA/84DlwLuAAMABwALAA8ADUAKDgwKCAYEAQAELSsTESERAyERISUhFSE3IRUhEwOEIvy/A0H84QL+/QJCAnn9hwJp/WUCm/2GAlhkIWQhAAAAAgAA/2oCZANSAAUACwAItQkGAwACLSsBAzMBEyMJATMDASMBjiu+/sIrvgFu/k/cNgGx3ALc/qP+YQFdAhX9yf5PAjcAAAAAAQAAAAEAABOilrJfDzz1AAsD6AAAAADQLwr8AAAAANAu0rwAAP9qA5cDUgAAAAgAAgAAAAAAAAABAAADUv9qAFoD6AAAAAADlwABAAAAAAAAAAAAAAAAAAAABgPoAAADLAAAA2sAAANrAAADqQAAAnEAAAAAAAAAWgCoAPABGgE9AAAAAQAAAAYANQAEAAAAAAACAAAAEABzAAAAHgtwAAAAAAAAABIA3gABAAAAAAAAADUAAAABAAAAAAABAAkANQABAAAAAAACAAcAPgABAAAAAAADAAkARQABAAAAAAAEAAkATgABAAAAAAAFAAsAVwABAAAAAAAGAAkAYgABAAAAAAAKACsAawABAAAAAAALABMAlgADAAEECQAAAGoAqQADAAEECQABABIBEwADAAEECQACAA4BJQADAAEECQADABIBMwADAAEECQAEABIBRQADAAEECQAFABYBVwADAAEECQAGABIBbQADAAEECQAKAFYBfwADAAEECQALACYB1UNvcHlyaWdodCAoQykgMjAxNCBieSBvcmlnaW5hbCBhdXRob3JzIEAgZm9udGVsbG8uY29tcGl4ZWRlbi03UmVndWxhcnBpeGVkZW4tN3BpeGVkZW4tN1ZlcnNpb24gMS4wcGl4ZWRlbi03R2VuZXJhdGVkIGJ5IHN2ZzJ0dGYgZnJvbSBGb250ZWxsbyBwcm9qZWN0Lmh0dHA6Ly9mb250ZWxsby5jb20AQwBvAHAAeQByAGkAZwBoAHQAIAAoAEMAKQAgADIAMAAxADQAIABiAHkAIABvAHIAaQBnAGkAbgBhAGwAIABhAHUAdABoAG8AcgBzACAAQAAgAGYAbwBuAHQAZQBsAGwAbwAuAGMAbwBtAHAAaQB4AGUAZABlAG4ALQA3AFIAZQBnAHUAbABhAHIAcABpAHgAZQBkAGUAbgAtADcAcABpAHgAZQBkAGUAbgAtADcAVgBlAHIAcwBpAG8AbgAgADEALgAwAHAAaQB4AGUAZABlAG4ALQA3AEcAZQBuAGUAcgBhAHQAZQBkACAAYgB5ACAAcwB2AGcAMgB0AHQAZgAgAGYAcgBvAG0AIABGAG8AbgB0AGUAbABsAG8AIABwAHIAbwBqAGUAYwB0AC4AaAB0AHQAcAA6AC8ALwBmAG8AbgB0AGUAbABsAG8ALgBjAG8AbQAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAECAQMBBAEFAQYIZHVyYXRpb24Hc3VjY2VzcwdmYWlsdXJlBXN1aXRlBHRlc3QAAAABAAH//wAPAAAAAAAAAAAAAAAAsAAsILAAVVhFWSAgS7gADlFLsAZTWliwNBuwKFlgZiCKVViwAiVhuQgACABjYyNiGyEhsABZsABDI0SyAAEAQ2BCLbABLLAgYGYtsAIsIGQgsMBQsAQmWrIoAQpDRWNFUltYISMhG4pYILBQUFghsEBZGyCwOFBYIbA4WVkgsQEKQ0VjRWFksChQWCGxAQpDRWNFILAwUFghsDBZGyCwwFBYIGYgiophILAKUFhgGyCwIFBYIbAKYBsgsDZQWCGwNmAbYFlZWRuwAStZWSOwAFBYZVlZLbADLCBFILAEJWFkILAFQ1BYsAUjQrAGI0IbISFZsAFgLbAELCMhIyEgZLEFYkIgsAYjQrEBCkNFY7EBCkOwAGBFY7ADKiEgsAZDIIogirABK7EwBSWwBCZRWGBQG2FSWVgjWSEgsEBTWLABKxshsEBZI7AAUFhlWS2wBSywB0MrsgACAENgQi2wBiywByNCIyCwACNCYbACYmawAWOwAWCwBSotsAcsICBFILALQ2O4BABiILAAUFiwQGBZZrABY2BEsAFgLbAILLIHCwBDRUIqIbIAAQBDYEItsAkssABDI0SyAAEAQ2BCLbAKLCAgRSCwASsjsABDsAQlYCBFiiNhIGQgsCBQWCGwABuwMFBYsCAbsEBZWSOwAFBYZVmwAyUjYUREsAFgLbALLCAgRSCwASsjsABDsAQlYCBFiiNhIGSwJFBYsAAbsEBZI7AAUFhlWbADJSNhRESwAWAtsAwsILAAI0KyCwoDRVghGyMhWSohLbANLLECAkWwZGFELbAOLLABYCAgsAxDSrAAUFggsAwjQlmwDUNKsABSWCCwDSNCWS2wDywgsBBiZrABYyC4BABjiiNhsA5DYCCKYCCwDiNCIy2wECxLVFixBGREWSSwDWUjeC2wESxLUVhLU1ixBGREWRshWSSwE2UjeC2wEiyxAA9DVVixDw9DsAFhQrAPK1mwAEOwAiVCsQwCJUKxDQIlQrABFiMgsAMlUFixAQBDYLAEJUKKiiCKI2GwDiohI7ABYSCKI2GwDiohG7EBAENgsAIlQrACJWGwDiohWbAMQ0ewDUNHYLACYiCwAFBYsEBgWWawAWMgsAtDY7gEAGIgsABQWLBAYFlmsAFjYLEAABMjRLABQ7AAPrIBAQFDYEItsBMsALEAAkVUWLAPI0IgRbALI0KwCiOwAGBCIGCwAWG1EBABAA4AQkKKYLESBiuwcisbIlktsBQssQATKy2wFSyxARMrLbAWLLECEystsBcssQMTKy2wGCyxBBMrLbAZLLEFEystsBossQYTKy2wGyyxBxMrLbAcLLEIEystsB0ssQkTKy2wHiwAsA0rsQACRVRYsA8jQiBFsAsjQrAKI7AAYEIgYLABYbUQEAEADgBCQopgsRIGK7ByKxsiWS2wHyyxAB4rLbAgLLEBHistsCEssQIeKy2wIiyxAx4rLbAjLLEEHistsCQssQUeKy2wJSyxBh4rLbAmLLEHHistsCcssQgeKy2wKCyxCR4rLbApLCA8sAFgLbAqLCBgsBBgIEMjsAFgQ7ACJWGwAWCwKSohLbArLLAqK7AqKi2wLCwgIEcgILALQ2O4BABiILAAUFiwQGBZZrABY2AjYTgjIIpVWCBHICCwC0NjuAQAYiCwAFBYsEBgWWawAWNgI2E4GyFZLbAtLACxAAJFVFiwARawLCqwARUwGyJZLbAuLACwDSuxAAJFVFiwARawLCqwARUwGyJZLbAvLCA1sAFgLbAwLACwAUVjuAQAYiCwAFBYsEBgWWawAWOwASuwC0NjuAQAYiCwAFBYsEBgWWawAWOwASuwABa0AAAAAABEPiM4sS8BFSotsDEsIDwgRyCwC0NjuAQAYiCwAFBYsEBgWWawAWNgsABDYTgtsDIsLhc8LbAzLCA8IEcgsAtDY7gEAGIgsABQWLBAYFlmsAFjYLAAQ2GwAUNjOC2wNCyxAgAWJSAuIEewACNCsAIlSYqKRyNHI2EgWGIbIVmwASNCsjMBARUUKi2wNSywABawBCWwBCVHI0cjYbAJQytlii4jICA8ijgtsDYssAAWsAQlsAQlIC5HI0cjYSCwBCNCsAlDKyCwYFBYILBAUVizAiADIBuzAiYDGllCQiMgsAhDIIojRyNHI2EjRmCwBEOwAmIgsABQWLBAYFlmsAFjYCCwASsgiophILACQ2BkI7ADQ2FkUFiwAkNhG7ADQ2BZsAMlsAJiILAAUFiwQGBZZrABY2EjICCwBCYjRmE4GyOwCENGsAIlsAhDRyNHI2FgILAEQ7ACYiCwAFBYsEBgWWawAWNgIyCwASsjsARDYLABK7AFJWGwBSWwAmIgsABQWLBAYFlmsAFjsAQmYSCwBCVgZCOwAyVgZFBYIRsjIVkjICCwBCYjRmE4WS2wNyywABYgICCwBSYgLkcjRyNhIzw4LbA4LLAAFiCwCCNCICAgRiNHsAErI2E4LbA5LLAAFrADJbACJUcjRyNhsABUWC4gPCMhG7ACJbACJUcjRyNhILAFJbAEJUcjRyNhsAYlsAUlSbACJWG5CAAIAGNjIyBYYhshWWO4BABiILAAUFiwQGBZZrABY2AjLiMgIDyKOCMhWS2wOiywABYgsAhDIC5HI0cjYSBgsCBgZrACYiCwAFBYsEBgWWawAWMjICA8ijgtsDssIyAuRrACJUZSWCA8WS6xKwEUKy2wPCwjIC5GsAIlRlBYIDxZLrErARQrLbA9LCMgLkawAiVGUlggPFkjIC5GsAIlRlBYIDxZLrErARQrLbA+LLA1KyMgLkawAiVGUlggPFkusSsBFCstsD8ssDYriiAgPLAEI0KKOCMgLkawAiVGUlggPFkusSsBFCuwBEMusCsrLbBALLAAFrAEJbAEJiAuRyNHI2GwCUMrIyA8IC4jOLErARQrLbBBLLEIBCVCsAAWsAQlsAQlIC5HI0cjYSCwBCNCsAlDKyCwYFBYILBAUVizAiADIBuzAiYDGllCQiMgR7AEQ7ACYiCwAFBYsEBgWWawAWNgILABKyCKimEgsAJDYGQjsANDYWRQWLACQ2EbsANDYFmwAyWwAmIgsABQWLBAYFlmsAFjYbACJUZhOCMgPCM4GyEgIEYjR7ABKyNhOCFZsSsBFCstsEIssDUrLrErARQrLbBDLLA2KyEjICA8sAQjQiM4sSsBFCuwBEMusCsrLbBELLAAFSBHsAAjQrIAAQEVFBMusDEqLbBFLLAAFSBHsAAjQrIAAQEVFBMusDEqLbBGLLEAARQTsDIqLbBHLLA0Ki2wSCywABZFIyAuIEaKI2E4sSsBFCstsEkssAgjQrBIKy2wSiyyAABBKy2wSyyyAAFBKy2wTCyyAQBBKy2wTSyyAQFBKy2wTiyyAABCKy2wTyyyAAFCKy2wUCyyAQBCKy2wUSyyAQFCKy2wUiyyAAA+Ky2wUyyyAAE+Ky2wVCyyAQA+Ky2wVSyyAQE+Ky2wViyyAABAKy2wVyyyAAFAKy2wWCyyAQBAKy2wWSyyAQFAKy2wWiyyAABDKy2wWyyyAAFDKy2wXCyyAQBDKy2wXSyyAQFDKy2wXiyyAAA/Ky2wXyyyAAE/Ky2wYCyyAQA/Ky2wYSyyAQE/Ky2wYiywNysusSsBFCstsGMssDcrsDsrLbBkLLA3K7A8Ky2wZSywABawNyuwPSstsGYssDgrLrErARQrLbBnLLA4K7A7Ky2waCywOCuwPCstsGkssDgrsD0rLbBqLLA5Ky6xKwEUKy2wayywOSuwOystsGwssDkrsDwrLbBtLLA5K7A9Ky2wbiywOisusSsBFCstsG8ssDorsDsrLbBwLLA6K7A8Ky2wcSywOiuwPSstsHIsswkEAgNFWCEbIyFZQiuwCGWwAyRQeLABFTAtAEu4AMhSWLEBAY5ZsAG5CAAIAGNwsQAFQrEAACqxAAVCsQAIKrEABUKxAAgqsQAFQrkAAAAJKrEABUK5AAAACSqxAwBEsSQBiFFYsECIWLEDZESxJgGIUVi6CIAAAQRAiGNUWLEDAERZWVlZsQAMKrgB/4WwBI2xAgBEAA==") format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}
+html,
+body {
+  background: #f7f6f5;
+  color: #dedede;
+  font: 14px/normal 'Open Sans', Verdana, Helvetica, Arial, sans-serif;
+  margin: 0;
+  visibility: visible;
+  padding-bottom: 2em;
+  padding-top: 0;
+}
+.internReportContainer {
+  margin: 0 auto;
+  width: 75%;
+}
+.reportHeader {
+  background: #fff;
+  box-shadow: 0px 1px 2px 0px rgba(0,0,0,0.15);
+  margin: 0 0 1em 0;
+  padding: 0.6em;
+  text-align: center;
+}
+.reportHeader .headerLogo {
+  height: 45px;
+  margin-right: 10px;
+  vertical-align: middle;
+  width: 45px;
+}
+.reportHeader .headerTitle {
+  color: #717171;
+  font-size: 1em;
+  font-weight: 300;
+  padding-top: 3px;
+  vertical-align: middle;
+}
+.summary {
+  border-collapse: collapse;
+  margin-bottom: 2.5em;
+  width: 100%;
+}
+.summary td {
+  color: #777;
+  font-size: 1em;
+  font-weight: normal;
+  padding: 0;
+  text-align: center;
+  text-transform: uppercase;
+  vertical-align: top;
+  width: 20%;
+}
+.summary td .summaryContent {
+  background: #f1f0ef;
+  border: 1px solid #dfdfdf;
+  border-radius: 6px 6px 0 0;
+  box-shadow: 0px 1px 2px 0px rgba(0,0,0,0.15);
+  margin: 0 1em 0 auto;
+}
+.summary td .summaryContent.suites:before {
+  content: '\e805';
+  display: block;
+  font: normal normal 50px/1 'Pe-icon-7-stroke', symbol;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  margin-top: 10px;
+  speak: none;
+  text-transform: none;
+}
+.summary td .summaryContent.tests:before {
+  content: '\e806';
+  display: block;
+  font: normal normal 50px/1 'Pe-icon-7-stroke', symbol;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  margin-top: 10px;
+  speak: none;
+  text-transform: none;
+}
+.summary td .summaryContent.failed {
+  background: #f15064;
+  color: #fff;
+}
+.summary td .summaryContent.failed:before {
+  content: '\e804';
+  display: block;
+  font: normal normal 50px/1 'Pe-icon-7-stroke', symbol;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  margin-top: 10px;
+  speak: none;
+  text-transform: none;
+}
+.summary td .summaryContent.failed .summaryTitle {
+  border-color: #ec152f;
+  color: #777;
+}
+.summary td .summaryContent.failed.success {
+  margin-right: 1em;
+}
+.summary td .summaryContent.success,
+.summary td .summaryContent.successRate {
+  background: #31a234;
+  color: #fff;
+  margin-right: 0;
+}
+.summary td .summaryContent.success:before,
+.summary td .summaryContent.successRate:before {
+  content: '\e803';
+  display: block;
+  font: normal normal 50px/1 'Pe-icon-7-stroke', symbol;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  margin-top: 10px;
+  speak: none;
+  text-transform: none;
+}
+.summary td .summaryContent.success .summaryTitle,
+.summary td .summaryContent.successRate .summaryTitle {
+  border-color: #31a234;
+  color: #777;
+}
+.summary td .summaryContent.duration {
+  background: #f1f0ef;
+}
+.summary td .summaryContent.duration:before {
+  content: '\e802';
+  display: block;
+  font: normal normal 50px/1 'Pe-icon-7-stroke', symbol;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  margin-top: 10px;
+  speak: none;
+  text-transform: none;
+}
+.summary td .summaryContent .summaryTitle {
+  background: #fff;
+  border: 1px solid #dfdfdf;
+  border-radius: 14px;
+  display: inline-block;
+  padding: 0.2em 1em;
+  position: relative;
+  top: 10px;
+  z-index: 1;
+}
+.summary td .summaryContent .summaryData {
+  background: #fff;
+  box-sizing: border-box;
+  color: #777;
+  font-size: 36px;
+  font-weight: 300;
+  height: 75px;
+  padding: 0.5em 0.25em;
+  text-align: center;
+}
+.failedFilter {
+  color: #3c3c3c;
+  padding: 0 0 1em;
+}
+.failedFilter input {
+  margin-right: 0.5em;
+}
+.report {
+  background-color: #fff;
+  border-collapse: collapse;
+  color: #3c3c3c;
+  width: 100%;
+}
+.report td {
+  padding: 0.7em;
+  border-left: 1px solid #dedede;
+  border-right: 1px solid #dedede;
+}
+.report .suite {
+  background: #c4e5e5;
+}
+.report .suite .testStatus {
+  background: #89cbcb;
+  border: 1px solid #5ab6b6;
+  color: #275959;
+  text-align: center;
+}
+.report .suite .testStatus:before {
+  content: '\e805';
+  display: block;
+  font: normal normal 21px/normal 'Pe-icon-7-stroke', symbol;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  text-decoration: inherit;
+}
+.report .suite td {
+  border: 1px solid #89cbcb;
+}
+.report .suite td.title {
+  font-size: 15px;
+  font-weight: bold;
+}
+.report .suite td.duration {
+  text-align: right;
+}
+.report .suite .column-info span {
+  margin-right: 1em;
+}
+.report .suite .column-info .success {
+  color: #2a8e2d;
+}
+.report .suite .column-info .failed {
+  color: #d01128;
+}
+.report .suite.indent {
+  background: #e7f5f5;
+}
+.report .suite.indent td {
+  border-color: #89cbcb;
+}
+.report .suite.indent .testStatus {
+  background: #a7d8d8;
+}
+.report .suite.indent .testStatus:before {
+  font-size: 17px;
+}
+.report .testResult {
+  transition: background 0.3s ease;
+}
+.report .testResult td {
+  border: 1px solid #dedede;
+}
+.report .testResult td.duration {
+  text-align: right;
+}
+.report .testResult.passed .testStatus {
+  background: #c6eec7;
+  border: 1px solid #83da85;
+  color: #41c645;
+  text-align: center;
+}
+.report .testResult.passed .testStatus:before {
+  content: '\e803';
+  display: block;
+  font: normal normal 21px/normal 'Pe-icon-7-stroke', symbol;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  text-decoration: inherit;
+}
+.report .testResult.passed:hover {
+  background: #ecf9ec;
+}
+.report .testResult.failed {
+  background: #fac2c9;
+}
+.report .testResult.failed .testStatus {
+  background: #fbcbd1;
+  border: 1px solid #f57786;
+  color: #f15064;
+  text-align: center;
+}
+.report .testResult.failed .testStatus:before {
+  content: '\e804';
+  display: block;
+  font: normal normal 21px/normal 'Pe-icon-7-stroke', symbol;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  text-decoration: inherit;
+}
+.report .testResult.failed:hover {
+  background: #fbced4;
+}
+.report .testResult.failed td {
+  border-color: #f796a2;
+  border-bottom: 0;
+}
+.report .testResult.failed .testStatus {
+  border-bottom: 0;
+  border-color: #f796a2;
+}
+.report .testResult.lastTest td,
+.report .testResult.lastTest .testStatus {
+  border-bottom: 0;
+}
+.report .indent1 {
+  padding-left: 2em;
+}
+.report .indent2 {
+  padding-left: 4em;
+}
+.report .indent3 {
+  padding-left: 6em;
+}
+.report .indent4 {
+  padding-left: 8em;
+}
+.report .indent5 {
+  padding-left: 10em;
+}
+.testStatus {
+  border-bottom: 0;
+  width: 20px;
+}
+.hidePassed .passed,
+.hidePassed .skipped {
+  display: none;
+}

--- a/lib/reporters/html/html-intranet.styl
+++ b/lib/reporters/html/html-intranet.styl
@@ -1,3 +1,2 @@
-@import 'opensans';
 @import 'variables';
 @import 'base';

--- a/lib/reporters/html/opensans.styl
+++ b/lib/reporters/html/opensans.styl
@@ -1,0 +1,1 @@
+@import url('//fonts.googleapis.com/css?family=Open+Sans:700,400,300');

--- a/lib/reporters/html/variables.styl
+++ b/lib/reporters/html/variables.styl
@@ -1,5 +1,3 @@
-@import url('//fonts.googleapis.com/css?family=Open+Sans:700,400,300');
-
 // http://www.pixeden.com/license
 @font-face {
 	font-family: 'Pe-icon-7-stroke';


### PR DESCRIPTION
A fairly simple solution for #424... given that Intern is used inside of corporate intranets, it seems like a reasonable configuration option to provide.

My check is naive (and assumes that window.location exists), but I figured I'd submit this first, and see if the better option is to include the user's config, and read a setting from there.