### PR TITLE
Access WebDriver sourceNode more safely when reference is lost

### DIFF
--- a/lib/reporters/WebDriver.js
+++ b/lib/reporters/WebDriver.js
@@ -48,7 +48,8 @@ define([
 
 		suiteEnd: function () {
 			if (this.writeHtml) {
-				this.suiteNode = this.suiteNode.parentNode.parentNode || document.body;
+				this.suiteNode = this.suiteNode && this.suiteNode.parentNode &&
+					this.suiteNode.parentNode.parentNode || document.body;
 			}
 
 			return this._sendEvent('suiteEnd', arguments);


### PR DESCRIPTION
Fixes #435 