### PR TITLE
refs #455, use platform path.sep in Proxy.js

### DIFF
--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -95,7 +95,7 @@ define([
 				wholePath = path.join(this.config.basePath, file);
 			}
 
-			if (wholePath.charAt(wholePath.length - 1) === '/') {
+			if (wholePath.charAt(wholePath.length - 1) === path.sep) {
 				wholePath += 'index.html';
 			}
 


### PR DESCRIPTION
#455 

The `Proxy.js` code only checks for '/':

`if (wholePath.charAt(wholePath.length - 1) === '/') {`

But on Windows, this last character would be '\'.

So use path.sep in comparison.