### PR TITLE
Flatten arrays before iterating over them

### DIFF
--- a/tasks/intern.js
+++ b/tasks/intern.js
@@ -75,7 +75,7 @@ module.exports = function (grunt) {
 			var value = opts[option];
 
 			if (Array.isArray(value)) {
-				value.forEach(function (value) {
+				grunt.util._.flatten(value).forEach(function (value) {
 					args.push(option + '=' + serialize(value));
 				});
 			}


### PR DESCRIPTION
Grunt automatically flattens nested arrays when they are used in any approved file format. Otherwise, arrays must be flattened by third-party tasks. Currently, Intern does not flatten arrays coming from Grunt. This would be helpful for configurations such as the following:

```js
grunt.initConfig({
    defaultReporters: [ 'TeamCity', 'LcovHtml' ],
    intern: {
        options: {
            runType: 'runner',
            config: 'tests/intern'
        },
        client: {
            runType: 'client',
            reporters: [ 'Console', '<%= defaultReporters %>' ]
        },
        runner: {
            reporters: [ 'Runner', '<%= defaultReporters %>' ]
        },
        local: {
            config: 'tests/intern-local',
            reporters: [ 'Runner', '<%= defaultReporters %>' ]
        }
    }
});
```

Without flattening, the value for `intern.client.reporters` would be `[ 'Console', [ 'TeamCity', 'LcovHtml' ] ]`, the Grunt task will treat the second item in the array as a string, and Intern will crash saying that it cannot find the module at `intern/lib/reporters/["TeamCity","LcovHtml"].js`. With flattening, the value for `intern.client.reporters` would be `[ 'Console', 'TeamCity', 'LcovHtml' ]` and is properly processed by the Grunt task and Intern.