### PR TITLE
Add message buffering

### DIFF
--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -59,10 +59,17 @@ define([
 
 				var self = this;
 				request.on('end', function () {
-					var message = JSON.parse(data);
-					var runnerReporterPromise = self._publishInSequence(message);
+					var messages = JSON.parse(data).map(function (messageString) {
+						return JSON.parse(messageString);
+					});
 
-					var shouldWait = util.getShouldWait(self.waitForRunner, message);
+					var runnerReporterPromise = Promise.all(messages.map(function (message) {
+						return self._publishInSequence(message);
+					}));
+
+					var shouldWait = messages.some(function (message) {
+						return util.getShouldWait(self.waitForRunner, message);
+					});
 
 					if (shouldWait) {
 						runnerReporterPromise.then(function () {

--- a/lib/reporters/WebDriver.js
+++ b/lib/reporters/WebDriver.js
@@ -24,9 +24,7 @@ define([
 			this.suiteNode = document.body;
 		}
 
-		if (this.waitForRunner) {
-			this.enqueue = util.createQueue(4);
-		}
+		this._messageBuffer = [];
 	}
 
 	WebDriver.prototype = {
@@ -133,44 +131,63 @@ define([
 		_send: function (data) {
 			var self = this;
 
+			// Send a message, or schedule it to be sent. Return a promise that resolves when the message has been sent.
+			function sendRequest() {
+				// Send all buffered messages and empty the buffer. Note that the posted data will always be an array of
+				// objects.
+				function send() {
+					self._activeRequest = request.post(self.url, {
+						headers: {
+							'Content-Type': 'application/json'
+						},
+						data: JSON.stringify(self._messageBuffer)
+					}).then(function (data) {
+						self._activeRequest = null;
+						return data;
+					});
+
+					self._messageBuffer = [];
+
+					return self._activeRequest;
+				}
+
+				if (self._activeRequest) {
+					if (!self._pendingRequest) {
+						// Schedule another request after the active one completes
+						self._pendingRequest = self._activeRequest.then(function () {
+							self._pendingRequest = null;
+							return send();
+						});
+					}
+					return self._pendingRequest;
+				}
+				else {
+					return send();
+				}
+			}
+
 			data = data.map(function (item) {
 				return item instanceof Error ?
 					{ name: item.name, message: item.message, stack: item.stack } : item;
 			});
 
-			function sendRequest() {
-				var response = request.post(self.url, {
-					headers: {
-						'Content-Type': 'application/json'
-					},
-					data: JSON.stringify({
-						sequence: self.sequence,
-						// Although sessionId is passed as part of the payload, it is passed in the message object as
-						// well to allow the conduit to be fully separate and encapsulated from the rest of the code
-						sessionId: self.sessionId,
-						payload: data
-					})
-				});
+			this._messageBuffer.push(JSON.stringify({
+				sequence: this.sequence,
+				// Although sessionId is passed as part of the payload, it is passed in the message object as
+				// well to allow the conduit to be fully separate and encapsulated from the rest of the code
+				sessionId: this.sessionId,
+				payload: data
+			}));
 
-				// The sequence must not be incremented until after the data is successfully serialised, since an error
-				// during serialisation might occur, which would mean the request is never sent, which would mean the
-				// dispatcher on the server-side will stall because the sequence numbering will be wrong
-				++self.sequence;
-
-				return response;
-			}
+			// The sequence must not be incremented until after the data is successfully serialised, since an error
+			// during serialisation might occur, which would mean the request is never sent, which would mean the
+			// dispatcher on the server-side will stall because the sequence numbering will be wrong
+			this.sequence++;
 
 			var shouldWait = util.getShouldWait(this.waitForRunner, data);
 
 			if (shouldWait) {
-				return new Promise(this.enqueue(function (resolve) {
-					var response = sendRequest();
-					resolve(response);
-
-					// The queuer needs to know when this request finishes, and it does that by receiving a promise
-					// returned by the queued function
-					return response;
-				}));
+				return sendRequest();
 			}
 			else {
 				sendRequest();


### PR DESCRIPTION
This PR changes how lifecycle messages are sent from the client to Intern. Currently, each message is sent in an individual request. Doing so can result in many requests being active at a time, which can starve other parts of the testing system that involve requests (like tests). With this PR, only one message request is ever active at a time. While a request is in progress, new messages are buffered. As soon as the current request completes, a new one is started to send all the messages buffered up to that point.