### PR TITLE
Use relative symlinks on POSIX, for reliability.

### DIFF
--- a/support/fixdeps.js
+++ b/support/fixdeps.js
@@ -30,6 +30,6 @@ if (!fs.existsSync(expected)) {
 	var actualPath = path.dirname(require.resolve(path.join(dependency, 'package.json')));
 
 	if (actualPath.indexOf(expectedPath) !== 0) {
-		fs.symlinkSync(actualPath, expectedPath, 'junction');
+		fs.symlinkSync(path.relative(path.dirname(expectedPath), actualPath), expectedPath, 'junction');
 	}
 });


### PR DESCRIPTION
This changes the symlinks for Intern's AMD dependencies from absolute to relative, so that changes in the dependent project's path (such as re-naming) will not break them. Fixes #510.