### PR TITLE
waitForRunner updates

### DIFF
--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -68,7 +68,7 @@ define([
 					}));
 
 					var shouldWait = messages.some(function (message) {
-						return util.getShouldWait(self.waitForRunner, message);
+						return util.getShouldWait(self.config.waitForRunner, message.payload);
 					});
 
 					if (shouldWait) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -657,8 +657,9 @@ define([
 
 		getShouldWait: function (waitMode, message) {
 			var shouldWait = false;
+			var eventName = message[0];
+
 			if (waitMode === 'fail') {
-				var eventName = message[0];
 				if (
 					eventName === 'testFail' ||
 					eventName === 'suiteError' ||
@@ -667,7 +668,10 @@ define([
 					shouldWait = true;
 				}
 			}
-			else if (waitMode) {
+			else if (waitMode === true) {
+				shouldWait = true;
+			}
+			else if (Array.isArray(waitMode) && waitMode.indexOf(eventName) !== -1) {
 				shouldWait = true;
 			}
 


### PR DESCRIPTION
- `lib/Proxy.js` now looks for waitForRunner in the correct location
  (self.config rather than self).
- `lib/Proxy.js` now passes the message payload (which is what
  contains the event name) to getShouldWait
- Allow waitForRunner to be an array specifying which events to wait
  for. The existing behavior for values of `true` and 'fail' is
  unchanged.