### PR TITLE
Fix the missing suiteError in Pretty report mode

### DIFF
--- a/lib/reporters/Pretty.js
+++ b/lib/reporters/Pretty.js
@@ -194,7 +194,9 @@ define([
 		},
 
 		suiteError: function (suite, error) {
-			var message = '! ' + error.message;
+			this._record(suite.sessionId, FAIL);
+
+			var message = '! ' + suite.id;
 			this.log.push(message + '\n' + internUtil.getErrorMessage(error));
 		},
 


### PR DESCRIPTION
Mark suite as FAIL when we got suiteError + fix the error message to include the suite id