### PR TITLE
Inline source map

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,3 +1,4 @@
+/* jshint node: true */
 define([
 	'dojo/has',
 	'dojo/lang',
@@ -294,6 +295,7 @@ define([
 		var lines;
 		var lastLine;
 		var match;
+		var sourceMapRegEx = /(?:\/{2}[#@]{1,2}|\/\*)\s+sourceMappingURL\s*=\s*(data:(?:[^;]+;)+base64,)?(\S+)/;
 
 		if (filepath in fileSourceMaps) {
 			return fileSourceMaps[filepath];
@@ -311,14 +313,18 @@ define([
 			lines = data.trim().split('\n');
 			lastLine = lines[lines.length - 1];
 
-			if ((match = /\/\/[@#] sourceMappingURL=(.*)$/.exec(lastLine))) {
-				// treat map file path as relative to the source file
-				var mapFile = pathUtil.join(pathUtil.dirname(filepath), match[1]);
-				if (!(mapFile in fileSourceMaps)) {
-					data = fs.readFileSync(mapFile);
-					fileSourceMaps[mapFile] = loadSourceMap(data.toString('utf-8'));
+			if ((match = sourceMapRegEx.exec(lastLine))) {
+				if (match[1]) {
+					data = JSON.parse((new Buffer(match[2], 'base64').toString('utf8')));
+					fileSourceMaps[filepath] = loadSourceMap(data);
 				}
-				return fileSourceMaps[mapFile];
+				else {
+					// treat map file path as relative to the source file
+					var mapFile = pathUtil.join(pathUtil.dirname(filepath), match[2]);
+					data = fs.readFileSync(mapFile);
+					fileSourceMaps[filepath] = loadSourceMap(data.toString('utf-8'));
+				}
+				return fileSourceMaps[filepath];
 			}
 		}
 		catch (error) {

--- a/tests/selftest.intern.js
+++ b/tests/selftest.intern.js
@@ -14,7 +14,7 @@ define({
 		{ browserName: 'chrome', version: '38', platform: [ 'WINDOWS', 'MAC' ], fixSessionCapabilities: false }
 	],
 
-	maxConcurrency: 2,
+	maxConcurrency: 1,
 	tunnel: 'BrowserStackTunnel',
 
 	loaderOptions: {

--- a/tests/selftest.intern.js
+++ b/tests/selftest.intern.js
@@ -14,7 +14,7 @@ define({
 		{ browserName: 'chrome', version: '38', platform: [ 'WINDOWS', 'MAC' ], fixSessionCapabilities: false }
 	],
 
-	maxConcurrency: 1,
+	maxConcurrency: 2,
 	tunnel: 'BrowserStackTunnel',
 
 	loaderOptions: {

--- a/tests/unit/data/lib/util/baz.js
+++ b/tests/unit/data/lib/util/baz.js
@@ -1,0 +1,13 @@
+define(["require", "exports"], function (require, exports) {
+    var Baz = (function () {
+        function Baz() {
+            this.hasRun = false;
+        }
+        Baz.prototype.run = function () {
+            throw new Error('foo');
+        };
+        return Baz;
+    })();
+    return Baz;
+});
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiYmF6LmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiYmF6LnRzIl0sIm5hbWVzIjpbIkJheiIsIkJhei5jb25zdHJ1Y3RvciIsIkJhei5ydW4iXSwibWFwcGluZ3MiOiI7SUFBQTtRQUFBQTtZQUNDQyxXQUFNQSxHQUFXQSxLQUFLQSxDQUFDQTtRQUt4QkEsQ0FBQ0E7UUFIQUQsaUJBQUdBLEdBQUhBO1lBQ0NFLE1BQU1BLElBQUlBLEtBQUtBLENBQUNBLEtBQUtBLENBQUNBLENBQUNBO1FBQ3hCQSxDQUFDQTtRQUNGRixVQUFDQTtJQUFEQSxDQUFDQSxBQU5ELElBTUM7SUFFRCxPQUFTLEdBQUcsQ0FBQyJ9

--- a/tests/unit/data/lib/util/baz.ts
+++ b/tests/unit/data/lib/util/baz.ts
@@ -1,0 +1,9 @@
+class Baz {
+	hasRun:boolean = false;
+
+	run() {
+		throw new Error('foo');
+	}
+}
+
+export = Baz;

--- a/tests/unit/lib/util.js
+++ b/tests/unit/lib/util.js
@@ -175,6 +175,24 @@ define([
 				}));
 			},
 
+			'source map from inline': function () {
+				if (!has('host-node')) {
+					this.skip('requires Node.js');
+				}
+
+				var dfd = this.async();
+
+				require([ '../data/lib/util/baz' ], dfd.callback(function (Baz) {
+					var baz = new Baz();
+					try {
+						baz.run();
+					}
+					catch (error) {
+						assert.match(util.getErrorMessage(error), /\bbaz.ts:5\b/);
+					}
+				}));
+			},
+
 			'object diff': function () {
 				var error = {
 					name: 'Error',


### PR DESCRIPTION
This adds the feature that detects if a sourceMap is included inline in the file and properly decodes them to remap back.

Also, I believe I addressed a logic error in the code.  On [lib/util.js:298](https://github.com/theintern/intern/blob/aff8eb9b01bf35335a2c2a6c4f1df7b6af527375/lib/util.js#L298) the code tried to detect the existence of the map in the hash based on the `filepath` but whenever the map was [set in the hash](https://github.com/theintern/intern/blob/aff8eb9b01bf35335a2c2a6c4f1df7b6af527375/lib/util.js#L319) it used instead the filename of the map file.  This resulted in the first block of code never being executed (and a fairly inefficient situation where you would always parse the name of the mapfile.

Since, obviously, there is no filename for inline sources, I have changed the `fileSourcesMaps` to be indexed on `filepath` this also then eliminated another if statement where the hash was being checked again if the file was in there.