### PR TITLE
Replace limited internal mimetype-map by external dependency

### DIFF
--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -5,23 +5,13 @@ define([
 	'dojo/node!http',
 	'dojo/node!path',
 	'dojo/node!fs',
+	'dojo/node!mimetype',
 	'dojo/aspect',
 	'./util'
-], function (require, lang, Promise, http, path, fs, aspect, util) {
+], function (require, lang, Promise, http, path, fs, mimetype, aspect, util) {
 	/* jshint node:true */
 
 	function Proxy(config) {
-		this.contentTypes = {
-			'': 'application/octet-stream',
-			'.css': 'text/css',
-			'.gif': 'image/gif',
-			'.html': 'text/html',
-			'.jpg': 'image/jpeg',
-			'.js': 'text/javascript',
-			'.json': 'application/json',
-			'.png': 'image/png'
-		};
-
 		this.config = config;
 	}
 
@@ -131,7 +121,7 @@ define([
 				instrument = false;
 			}
 
-			var contentType = this.contentTypes[path.extname(wholePath)] || this.contentTypes[''];
+			var contentType = mimetype.lookup(path.basename(wholePath)) || 'application/octet-stream';
 			if (instrument) {
 				if (self._codeCache[wholePath]) {
 					send(contentType, self._codeCache[wholePath]);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"source-map": "0.1.33",
 		"dojo": "2.0.0-alpha.6",
 		"chai": "3.0.0",
+		"mimetype": "0.0.8",
 		"leadfoot": "1.6.4",
 		"digdug": "1.3.2",
 		"charm": "0.2.0",


### PR DESCRIPTION
I was having trouble with resources not loading and crashing the test (because Chrome's UI suggested files needed to be downloaded). It turned out that Intern's web server (or "Proxy") had a *very* limited understanding of file types. This PR replaces the internal mapping with [mimetype](https://github.com/rsdoiel/mimetype-js) (BSD-2-Clause) which provides a simple API for the included [mime.types](https://github.com/rsdoiel/mimetype-js/blob/master/extras/mime.types) map (probably copied from Apache).

If this - or any other similar - package cannot be included in Intern, we should talk about exposing the Proxy server, so mapping can be extended in user-space.

---

Since your package.json does not list any scripts regarding linting or testing, none of that was performed on my side. The CLA was signed.