### PR TITLE
Update istanbul to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"license": "BSD-3-Clause",
 	"dependencies": {
-		"istanbul": "0.3.17",
+		"istanbul": "0.4.1",
 		"source-map": "0.1.33",
 		"dojo": "2.0.0-alpha.6",
 		"chai": "3.0.0",


### PR DESCRIPTION
As of istanbul 0.4.0 the LcovHtml reporter is updated with a new look and feel.

https://github.com/gotwarlost/istanbul/blob/master/CHANGELOG.md

The other changes since the current version of instanbul are minor and include bug fixes, bumping dependency versions, and adding additional es6 support.

I've tested out 0.4.1 on my local version of intern with local selenium / phantomjs reports with no issues.