### PR TITLE
Add result parser to grunt task

### DIFF
--- a/tasks/intern.js
+++ b/tasks/intern.js
@@ -64,7 +64,8 @@ module.exports = function (grunt) {
 				sauceUsername: true,
 				testingbotKey: true,
 				testingbotSecret: true,
-				nodeEnv: true
+				nodeEnv: true,
+				resultParser: true
 			};
 
 		Object.keys(opts).forEach(function (option) {
@@ -96,7 +97,8 @@ module.exports = function (grunt) {
 			'sauceUsername',
 			'testingbotKey',
 			'testingbotSecret',
-			'nodeEnv'
+			'nodeEnv',
+			'resultParser'
 		].forEach(function (option) {
 			var value = opts[option];
 			if (value) {
@@ -114,10 +116,18 @@ module.exports = function (grunt) {
 				cwd: process.cwd(),
 				env: env
 			}
-		}, function (error) {
-			// The error object from grunt.util.spawn contains information
-			// that we already logged, so hide it from the user
-			done(error ? new Error('Test failure; check output above for details.') : null);
+		}, function (error, result) {
+			// The stdout and stderr of grunt.util.spawn are already being logged
+			// If error then return an error object to grunt
+			if (error) {
+				return done(new Error('Test failure; check output above for details.'));
+			}
+			// If a result parser function was passed in return result of function call
+			if (typeof env.RESULT_PARSER === 'function') {
+				return done(env.RESULT_PARSER(result));
+			}
+			// Return grunt callback with no error
+			return done(null);
 		});
 
 		child.stdout.on('data', readOutput);


### PR DESCRIPTION
Adds 'resultParser' option for the intern grunt task.
resultParser is a function that takes in the result from spawning istanbul. The function is called after the istanbul task has completed without errors. The function should return null if there are no issues with the results, or return an Error if the results aren't as expected.

Here's an example use case to enforce an overall coverage percentage:
```javascript
var testThreshold = 70;
/**
 * @name resultParser
 * @description checks results from istanbul to confirm expected results
 * @param { object } result, result from gulp.util.spawn callback
 * @returns { error } if unexpected result
 * @returns { null } if result is expected
 **/
var resultParser = function (result) {
    // ansi colors regexp from http://stackoverflow.com/a/29497680
    var colors = /[\u001b\u009b][\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
        // Get total coverage line from istanbul tables
        coverage = result.stdout
            .replace(colors, '')
            .split('\n')
            .filter(function (el) {
                return el.indexOf('All files') > -1;
            });
    // Get each coverage type's column value from the last match
    coverage = coverage[coverage.length - 1]
        .split('|')
        .map(function (el) {
            return !isNaN(parseFloat(el.trim())) ? parseFloat(el.trim()) : null;
        })
        .filter(function (el) {
            return el !== null;
        });
    // Get the average coverage
    coverage = coverage.reduce(function (total, next) {
        return total + next;
    }) / coverage.length;
    // Compare coverage to threshold
    if (coverage < testThreshold) {
        grunt.log.error('Coverage: ' + coverage + '%');
        return new Error('Coverage below ' + testThreshold + '% threshold!');
    } else  {
        grunt.log.ok('Coverage: ' + coverage + '%');
    }
    return null;
};

grunt.initConfig({
    intern: {
        all: {
            options: {
                runType: 'runner', // defaults to 'client'a
                config: 'tests/intern',
                resultParser: resultParser
            }
        }
    }
});
```