### PR TITLE
Add GruntCoverage reporter

### DIFF
--- a/lib/ProxiedSession.js
+++ b/lib/ProxiedSession.js
@@ -78,21 +78,29 @@ define([
 			}
 
 			if (this.coverageEnabled) {
+				var promise;
+
 				// At least Safari will not inject user scripts for non http/https URLs, so we can't get coverage data.
 				if (this.capabilities.brokenExecuteForNonHttpUrl) {
-					return this.getCurrentUrl().then(function (url) {
-						if ((/^https?:/i).test(url)) {
-							return self.execute(getCoverageData, [ self.coverageVariable ])
-								.then(function (coverageData) {
-									return coverageData &&
-									self.reporterManager.emit('coverage', self.sessionId, JSON.parse(coverageData));
-								}).finally(function () {
-									return _super.get.apply(self, args);
-								});
-						}
-						return _super.get.apply(self, args);
+					promise = this.getCurrentUrl().then(function (url) {
+						return (/^https?:/i).test(url);
 					});
 				}
+				else {
+					promise = Promise.resolve(true);
+				}
+
+				return promise.then(function (shouldGetCoverage) {
+					if (shouldGetCoverage) {
+						return self.execute(getCoverageData, [ self.coverageVariable ])
+							.then(function (coverageData) {
+								return coverageData &&
+								self.reporterManager.emit('coverage', self.sessionId, JSON.parse(coverageData));
+							});
+					}
+				}).finally(function () {
+					return _super.get.apply(self, args);
+				});
 			}
 
 			return _super.get.apply(self, args);

--- a/lib/ProxiedSession.js
+++ b/lib/ProxiedSession.js
@@ -78,17 +78,24 @@ define([
 			}
 
 			if (this.coverageEnabled) {
-				return this.execute(getCoverageData, [ this.coverageVariable ])
-					.then(function (coverageData) {
-						return coverageData &&
-							self.reporterManager.emit('coverage', self.sessionId, JSON.parse(coverageData));
-					}).finally(function () {
+				// At least Safari will not inject user scripts for non http/https URLs, so we can't get coverage data.
+				if (this.capabilities.brokenExecuteForNonHttpUrl) {
+					return this.getCurrentUrl().then(function (url) {
+						if ((/^https?:/i).test(url)) {
+							return self.execute(getCoverageData, [ self.coverageVariable ])
+								.then(function (coverageData) {
+									return coverageData &&
+									self.reporterManager.emit('coverage', self.sessionId, JSON.parse(coverageData));
+								}).finally(function () {
+									return _super.get.apply(self, args);
+								});
+						}
 						return _super.get.apply(self, args);
 					});
+				}
 			}
-			else {
-				return _super.get.apply(self, args);
-			}
+
+			return _super.get.apply(self, args);
 		},
 
 		/**

--- a/lib/reporters/CoverageThreshold.js
+++ b/lib/reporters/CoverageThreshold.js
@@ -1,0 +1,73 @@
+define([
+    'dojo/node!istanbul/lib/collector',
+    'dojo/node!istanbul/lib/object-utils',
+    'dojo/node!istanbul/lib/report/common/defaults'
+], function (Collector, utils, defaults) {
+    var logger;
+    function CoverageThreshold(config) {
+        var defaultThresholds = defaults.watermarks();
+
+        for (var key in defaultThresholds) {
+            defaultThresholds[key] = defaultThresholds[key][0];
+        }
+
+        this.config = config || {};
+        logger = this.config.logger ? this.config.logger : console;
+
+        config.threshold = config.threshold || defaultThresholds;
+        this._collector = new Collector();
+    }
+
+    function enforceThreshold(threshold, actual, expected) {
+        var name = threshold[0].toUpperCase() + threshold.slice(1);
+        var success = actual >= expected;
+        var placing = success ? 'above' : 'below';
+        var passed = success ? 'PASSED! ' : 'FAILED! ';
+        var status = success ? 'log' : 'error';
+        var msg = passed + name + ': ' + actual + '%, ' + placing + ' threshold of ' + expected + '%';
+
+        logger[status](msg);
+        return success;
+    }
+
+    CoverageThreshold.prototype.coverage = function (sessionId, coverage) {
+        this._collector.add(coverage);
+    };
+
+    CoverageThreshold.prototype.runEnd = function () {
+        var collector = this._collector;
+        var summaries = [];
+        var total = 0;
+        var overall = 0;
+        var success = true;
+        var finalSummary;
+
+        collector.files().forEach(function (file) {
+            summaries.push(utils.summarizeFileCoverage(collector.fileCoverageFor(file)));
+        });
+
+        finalSummary = utils.mergeSummaryObjects.apply(null, summaries);
+
+        for (var key in finalSummary) {
+            if (finalSummary[key].pct) {
+                if (key in this.config.threshold) {
+                    success = success && enforceThreshold(key, finalSummary[key].pct, this.config.threshold[key]);
+                }
+                overall += finalSummary[key].pct;
+                total++;
+            }
+        }
+
+        overall = overall / total;
+
+        if (this.config.threshold.overall) {
+            success = success && enforceThreshold('Overall', overall, this.config.threshold.overall);
+        }
+
+        if (!success) {
+            logger.error('Coverage threshold not met!');
+        }
+    };
+
+    return CoverageThreshold;
+});

--- a/lib/reporters/WebDriver.js
+++ b/lib/reporters/WebDriver.js
@@ -19,6 +19,7 @@ define([
 		this.writeHtml = config.writeHtml !== false;
 		this.sessionId = config.internConfig.sessionId;
 		this.waitForRunner = config.waitForRunner;
+		this.maxPostSize = config.maxPostSize || 50000;
 
 		if (this.writeHtml) {
 			this.suiteNode = document.body;
@@ -136,22 +137,44 @@ define([
 				// Send all buffered messages and empty the buffer. Note that the posted data will always be an array of
 				// objects.
 				function send() {
-					self._activeRequest = request.post(self.url, {
-						headers: {
-							'Content-Type': 'application/json'
-						},
-						data: JSON.stringify(self._messageBuffer)
-					}).then(function (data) {
-						self._activeRequest = null;
-						return data;
-					});
+					// Some testing services have problems handling large message POSTs, so limit the maximum size of
+					// each POST body to maxPostSize bytes. Always send at least one message, even if it's more than
+					// maxPostSize bytes.
+					function sendNextBlock() {
+						var block = [ messages.shift() ];
+						var size = block[0].length;
+						while (messages.length > 0 && size + messages[0].length < self.maxPostSize) {
+							size += messages[0].length;
+							block.push(messages.shift());
+						}
 
+						return request.post(self.url, {
+							headers: { 'Content-Type': 'application/json' },
+							data: JSON.stringify(block)
+						}).then(function () {
+							if (messages.length > 0) {
+								return sendNextBlock();
+							}
+						});
+					}
+
+					var messages = self._messageBuffer;
 					self._messageBuffer = [];
+
+					self._activeRequest = new Promise(function (resolve, reject) {
+						return sendNextBlock().then(function () {
+							self._activeRequest = null;
+							resolve();
+						}).catch(function (error) {
+							self._activeRequest = null;
+							reject(error);
+						});
+					});
 
 					return self._activeRequest;
 				}
 
-				if (self._activeRequest) {
+				if (self._activeRequest || self._pendingRequest) {
 					if (!self._pendingRequest) {
 						// Schedule another request after the active one completes
 						self._pendingRequest = self._activeRequest.then(function () {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dojo": "2.0.0-alpha.7",
     "glob": "7.0.3",
     "istanbul": "0.4.1",
-    "leadfoot": "1.6.9",
+    "leadfoot": "1.6.10",
     "mimetype": "0.0.8",
     "source-map": "0.1.33"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dojo": "2.0.0-alpha.7",
     "glob": "7.0.3",
     "istanbul": "0.4.1",
-    "leadfoot": "1.6.8",
+    "leadfoot": "1.6.9",
     "mimetype": "0.0.8",
     "source-map": "0.1.33"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intern",
-  "version": "3.2.3-pre",
+  "version": "3.2.3",
   "main": "main",
   "description": "Intern. A next-generation code testing stack for JavaScript.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intern",
-  "version": "3.2.2-pre",
+  "version": "3.2.2",
   "main": "main",
   "description": "Intern. A next-generation code testing stack for JavaScript.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intern",
-  "version": "3.2.0",
+  "version": "3.2.1-pre",
   "main": "main",
   "description": "Intern. A next-generation code testing stack for JavaScript.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intern",
-  "version": "3.2.1-pre",
+  "version": "3.2.1",
   "main": "main",
   "description": "Intern. A next-generation code testing stack for JavaScript.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intern",
-  "version": "3.2.2",
+  "version": "3.2.3-pre",
   "main": "main",
   "description": "Intern. A next-generation code testing stack for JavaScript.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dojo": "2.0.0-alpha.7",
     "glob": "7.0.3",
     "istanbul": "0.4.1",
-    "leadfoot": "1.6.7",
+    "leadfoot": "1.6.8",
     "mimetype": "0.0.8",
     "source-map": "0.1.33"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intern",
-  "version": "3.2.1",
+  "version": "3.2.2-pre",
   "main": "main",
   "description": "Intern. A next-generation code testing stack for JavaScript.",
   "repository": {


### PR DESCRIPTION
Hello,

I had previously raised a pull request to allow a function to parse stdout https://github.com/theintern/intern/pull/545. @csnover mentioned "I’d rather add a new configuration to Intern itself that will make it fail the test run if code coverage is below a certain, configurable amount."

In response I've created a reporter that takes in the coverage results and compares them against threshold config that's passed in.

This reporter requires a threshold config object containing the keys of the coverage types and threshold value to compare against. In the example below shows all possible threshold types, including an 'overall' option that will compare the average of the four primary coverage types against the passed value. None of the threshold options are mandatory, the end user can include any combination of coverage options. If no threshold config is passed in it defaults to `{ overall: 75 }`. Only the coverage options included in the config will be enforced and reported on.

Example reporters config:
```
    reporters: [
        "Runner",
        {
            id: "GruntCoverage",
            threshold: {
                statements: 75,
                branches: 65,
                functions: 75,
                lines: 75,
                overall: 75
            }
        }
    ]
```

Example output:
```
-----------------------------------------------------------|----------|----------|----------|----------|----------------|
All files                                                  |    75.89 |    68.73 |    76.75 |    76.07 |                |
-----------------------------------------------------------|----------|----------|----------|----------|----------------|

>> TOTAL: tested 1 platforms, 0/589 tests failed
>> PASSED! Lines: 76.07%, above threshold of 75%
>> PASSED! Statements: 75.89%, above threshold of 75%
>> PASSED! Functions: 76.75%, above threshold of 75%
>> PASSED! Branches: 68.73%, above threshold of 65%
>> FAILED! Overall: 74.36%, below threshold of 75%
Warning: Coverage threshold not met! Use --force to continue.
```
**Note:** This reporter requires grunt, which isn't currently a dependency for Intern, even though Intern includes a grunt task. I'm unable to add tests for this reporters because grunt won't be available, unless it's desired to be added. Since I was able to achieve this functionality by only using a reporter I'm not sure if it's desired for this reporter to be included with intern, because of the grunt dependency, or if it should be a separate external/custom reporter that can be added in optionally.

@csnover let me know if this is what you had in mind, or if this should go in another direction that doesn't require grunt. I made this require grunt because I was intending to use it in conjunction with the intern grunt task.

I went in this direction, using a reporter to enforce coverage, because the reporters always receive the coverage and runEnd events, but I don't see a clear way to get reporters to cause the spawned intern task to report a failure without causing a stack trace, thats why I incorporated grunt to have that control. 