### PR TITLE
Update Chai to v3.4.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"istanbul": "0.4.1",
 		"source-map": "0.1.33",
 		"dojo": "2.0.0-alpha.6",
-		"chai": "3.0.0",
+		"chai": "3.4.1",
 		"mimetype": "0.0.8",
 		"leadfoot": "1.6.4",
 		"digdug": "1.3.2",

--- a/typings/chai/chai.d.ts
+++ b/typings/chai/chai.d.ts
@@ -1,9 +1,13 @@
-// Type definitions for chai 2.0.0
+// Type definitions for chai 3.4.0
 // Project: http://chaijs.com/
 // Definitions by: Jed Mao <https://github.com/jedmao/>,
 //                 Bart van der Schoor <https://github.com/Bartvds>,
-//                 Andrew Brown <https://github.com/AGBrown>
+//                 Andrew Brown <https://github.com/AGBrown>,
+//                 Olivier Chevet <https://github.com/olivr70>,
+//                 Matt Wistrand <https://github.com/mwistrand>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+// <reference path="../assertion-error/assertion-error.d.ts"/>
 
 declare module Chai {
 
@@ -16,9 +20,11 @@ declare module Chai {
         use(fn: (chai: any, utils: any) => void): any;
         assert: AssertStatic;
         config: Config;
+        AssertionError: typeof AssertionError;
     }
 
     export interface ExpectStatic extends AssertionStatic {
+        fail(actual?: any, expected?: any, message?: string, operator?: string): void;
     }
 
     export interface AssertStatic extends Assert {
@@ -49,15 +55,20 @@ declare module Chai {
     interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
         not: Assertion;
         deep: Deep;
+        any: KeyFilter;
+        all: KeyFilter;
         a: TypeComparison;
         an: TypeComparison;
         include: Include;
+        includes: Include;
         contain: Include;
+        contains: Include;
         ok: Assertion;
         true: Assertion;
         false: Assertion;
         null: Assertion;
         undefined: Assertion;
+        NaN: Assertion;
         exist: Assertion;
         empty: Assertion;
         arguments: Assertion;
@@ -70,20 +81,36 @@ declare module Chai {
         property: Property;
         ownProperty: OwnProperty;
         haveOwnProperty: OwnProperty;
+        ownPropertyDescriptor: OwnPropertyDescriptor;
+        haveOwnPropertyDescriptor: OwnPropertyDescriptor;
         length: Length;
         lengthOf: Length;
-        match(regexp: RegExp|string, message?: string): Assertion;
+        match: Match;
+        matches: Match;
         string(string: string, message?: string): Assertion;
         keys: Keys;
         key(string: string): Assertion;
         throw: Throw;
         throws: Throw;
         Throw: Throw;
-        respondTo(method: string, message?: string): Assertion;
+        respondTo: RespondTo;
+        respondsTo: RespondTo;
         itself: Assertion;
-        satisfy(matcher: Function, message?: string): Assertion;
-        closeTo(expected: number, delta: number, message?: string): Assertion;
+        satisfy: Satisfy;
+        satisfies: Satisfy;
+        closeTo: CloseTo;
+        approximately: CloseTo;
         members: Members;
+        increase: PropertyChange;
+        increases: PropertyChange;
+        decrease: PropertyChange;
+        decreases: PropertyChange;
+        change: PropertyChange;
+        changes: PropertyChange;
+        extensible: Assertion;
+        sealed: Assertion;
+        frozen: Assertion;
+        oneOf(list: any[], message?: string): Assertion;
     }
 
     interface LanguageChains {
@@ -130,10 +157,19 @@ declare module Chai {
         (constructor: Object, message?: string): Assertion;
     }
 
+    interface CloseTo {
+        (expected: number, delta: number, message?: string): Assertion;
+    }
+
     interface Deep {
         equal: Equal;
         include: Include;
         property: Property;
+        members: Members;
+    }
+
+    interface KeyFilter {
+        keys: Keys;
     }
 
     interface Equal {
@@ -148,6 +184,11 @@ declare module Chai {
         (name: string, message?: string): Assertion;
     }
 
+    interface OwnPropertyDescriptor {
+        (name: string, descriptor: PropertyDescriptor, message?: string): Assertion;
+        (name: string, message?: string): Assertion;
+    }
+
     interface Length extends LanguageChains, NumericComparison {
         (length: number, message?: string): Assertion;
     }
@@ -158,11 +199,18 @@ declare module Chai {
         (value: number, message?: string): Assertion;
         keys: Keys;
         members: Members;
+        any: KeyFilter;
+        all: KeyFilter;
+    }
+
+    interface Match {
+        (regexp: RegExp|string, message?: string): Assertion;
     }
 
     interface Keys {
         (...keys: string[]): Assertion;
         (keys: any[]): Assertion;
+        (keys: Object): Assertion;
     }
 
     interface Throw {
@@ -175,8 +223,20 @@ declare module Chai {
         (constructor: Function, expected?: RegExp, message?: string): Assertion;
     }
 
+    interface RespondTo {
+        (method: string, message?: string): Assertion;
+    }
+
+    interface Satisfy {
+        (matcher: Function, message?: string): Assertion;
+    }
+
     interface Members {
         (set: any[], message?: string): Assertion;
+    }
+
+    interface PropertyChange {
+        (object: Object, prop: string, msg?: string): Assertion;
     }
 
     export interface Assert {
@@ -189,7 +249,9 @@ declare module Chai {
         fail(actual?: any, expected?: any, msg?: string, operator?: string): void;
 
         ok(val: any, msg?: string): void;
+        isOk(val: any, msg?: string): void;
         notOk(val: any, msg?: string): void;
+        isNotOk(val: any, msg?: string): void;
 
         equal(act: any, exp: any, msg?: string): void;
         notEqual(act: any, exp: any, msg?: string): void;
@@ -203,11 +265,23 @@ declare module Chai {
         isTrue(val: any, msg?: string): void;
         isFalse(val: any, msg?: string): void;
 
+        isNotTrue(val: any, msg?: string): void;
+        isNotFalse(val: any, msg?: string): void;
+
         isNull(val: any, msg?: string): void;
         isNotNull(val: any, msg?: string): void;
 
         isUndefined(val: any, msg?: string): void;
         isDefined(val: any, msg?: string): void;
+
+        isNaN(val: any, msg?: string): void;
+        isNotNaN(val: any, msg?: string): void;
+
+        isAbove(val: number, abv: number, msg?: string): void;
+        isBelow(val: number, blw: number, msg?: string): void;
+
+        isAtLeast(val: number, atlst: number, msg?: string): void;
+        isAtMost(val: number, atmst: number, msg?: string): void;
 
         isFunction(val: any, msg?: string): void;
         isNotFunction(val: any, msg?: string): void;
@@ -277,11 +351,30 @@ declare module Chai {
 
         operator(val: any, operator: string, val2: any, msg?: string): void;
         closeTo(act: number, exp: number, delta: number, msg?: string): void;
+        approximately(act: number, exp: number, delta: number, msg?: string): void;
 
         sameMembers(set1: any[], set2: any[], msg?: string): void;
-        includeMembers(set1: any[], set2: any[], msg?: string): void;
+        sameDeepMembers(set1: any[], set2: any[], msg?: string): void;
+        includeMembers(superset: any[], subset: any[], msg?: string): void;
 
         ifError(val: any, msg?: string): void;
+
+        isExtensible(obj: {}, msg?: string): void;
+        extensible(obj: {}, msg?: string): void;
+        isNotExtensible(obj: {}, msg?: string): void;
+        notExtensible(obj: {}, msg?: string): void;
+
+        isSealed(obj: {}, msg?: string): void;
+        sealed(obj: {}, msg?: string): void;
+        isNotSealed(obj: {}, msg?: string): void;
+        notSealed(obj: {}, msg?: string): void;
+
+        isFrozen(obj: Object, msg?: string): void;
+        frozen(obj: Object, msg?: string): void;
+        isNotFrozen(obj: Object, msg?: string): void;
+        notFrozen(obj: Object, msg?: string): void;
+
+        oneOf(inList: any, list: any[], msg?: string): void;
     }
 
     export interface Config {


### PR DESCRIPTION
Updates Intern to use the latest version of Chai available on npm (v3.4.1), and includes updates to the corresponding `chai.d.ts`.