### PR TITLE
Add OS and NPM generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,17 @@
+# Ignore NPM generated files
+node_modules/
+npm-debug.log
+
+# Ignore OS generated files
+.DS_Store*
+Thumbs.db
+
+# Ignore Istanbul generated files
 lcov.info
 html-report
-node_modules
+coverage-final.json
+
+# Ignore Cloud Service generated files
 saucelabs
 testingbot
 browserstack
-coverage-final.json


### PR DESCRIPTION
I kept having .DS_Store appearing as a changed file, so I updated the .gitignore to include OS Generated files and npm-debug.log. I also categorized the files being ignored to make things more clear for anyone looking at the .gitignore