### PR TITLE
Handle globs in suite lists

### DIFF
--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -6,9 +6,10 @@ define([
 	'dojo/node!path',
 	'dojo/node!fs',
 	'dojo/node!mimetype',
+	'dojo/node!url',
 	'dojo/aspect',
 	'./util'
-], function (require, lang, Promise, http, path, fs, mimetype, aspect, util) {
+], function (require, lang, Promise, http, path, fs, mimetype, url, aspect, util) {
 	/* jshint node:true */
 
 	function Proxy(config) {
@@ -32,7 +33,10 @@ define([
 
 		_handler: function (request, response) {
 			if (request.method === 'GET') {
-				if (/\.js(?:$|\?)/.test(request.url)) {
+				if (/\/__resolveSuites__\?/.test(request.url)) {
+					this._resolveSuites(request, response);
+				}
+				else if (/\.js(?:$|\?)/.test(request.url)) {
 					this._handleFile(request, response, this.config.instrument);
 				}
 				else {
@@ -204,6 +208,17 @@ define([
 			while ((message = session.queue[message.sequence + 1]));
 
 			return triggerMessage.resolver.promise;
+		},
+
+		_resolveSuites: function (request, response) {
+			var query = url.parse(request.url, true).query;
+			var suites = JSON.parse(query.suites);
+			var resolvedSuites = JSON.stringify(util.resolveModuleIds(suites));
+			response.writeHead(200, {
+				'Content-Type': 'application/json',
+				'Content-Length': resolvedSuites.length
+			});
+			response.end(resolvedSuites);
 		},
 
 		_send404: function (response) {

--- a/lib/executors/PreExecutor.js
+++ b/lib/executors/PreExecutor.js
@@ -4,12 +4,13 @@ define([
 	'dojo/lang',
 	'dojo/Promise',
 	'dojo/has!host-browser?dojo/request',
+	'dojo/has!host-browser?dojo/io-query',
 	'dojo/has!host-node?dojo/node!path',
 	'../../main',
 	'../parseArgs',
 	'../util',
 	'require'
-], function (aspect, has, lang, Promise, request, pathUtil, main, parseArgs, util, require) {
+], function (aspect, has, lang, Promise, request, ioQuery, pathUtil, main, parseArgs, util, require) {
 	/**
 	 * For testing sessions running through the Intern proxy, tells the remote test system that an error occured when
 	 * attempting to set up this environment.
@@ -378,6 +379,45 @@ define([
 				});
 			}
 
+			/**
+			 * Expand any globs in the suites and functionalSuites lists
+			 */
+			function resolveSuites(loader) {
+				var promise;
+
+				if (has('host-node')) {
+					promise = new Promise(function (resolve) {
+						config.suites = util.resolveModuleIds(config.suites.slice());
+						config.functionalSuites = util.resolveModuleIds(config.functionalSuites.slice());
+						resolve();
+					});
+				}
+				else if (has('host-browser')) {
+					var query = ioQuery.objectToQuery({ suites: JSON.stringify(config.suites) });
+					var url = require.toUrl('intern/__resolveSuites__') + '?' + query;
+
+					promise = request(url, {
+						method: 'GET'
+					}).then(function (response) {
+						if (response.statusCode !== 200) {
+							console.warn('The Intern proxy is not available -- suite wildcard ' +
+								'resolution will not be performed');
+						}
+						else {
+							config.suites = JSON.parse(response.data);
+						}
+					});
+				}
+				else {
+					promise = Promise.resolve();
+				}
+
+				return promise.then(function () {
+					// pass-through the loader argument
+					return loader;
+				});
+			}
+
 			function runExecutor(Executor) {
 				executor = new Executor(config, self);
 				self._earlyEvents.forEach(function (event) {
@@ -393,6 +433,7 @@ define([
 			var promise = Promise.resolve()
 				.then(getConfig)
 				.then(swapLoader)
+				.then(resolveSuites)
 				.then(populateMainModule)
 				.then(loadExecutorWithLoader)
 				.then(runExecutor)

--- a/lib/reporters/Html.js
+++ b/lib/reporters/Html.js
@@ -1,6 +1,7 @@
 define([
-	'require'
-], function (require) {
+	'require',
+	'../util',
+], function (require, util) {
 	function pad(value, size) {
 		var padded = String(value);
 
@@ -129,6 +130,15 @@ define([
 		}
 
 		var runningSuites = {};
+
+		this.fatalError = function (error) {
+			var htmlError = util.getErrorMessage(error).replace(/&/g, '&amp;').replace(/</g, '&lt;');
+			var errorNode = document.createElement('div');
+			errorNode.style.cssText = 'color: red; font-family: sans-serif;';
+			errorNode.innerHTML = '<h1>Fatal error</h1>' +
+				'<pre style="padding: 1em; background-color: #f0f0f0;">' + htmlError + '</pre>';
+			document.body.appendChild(errorNode);
+		};
 
 		this.run = function () {
 			/* jshint maxlen:false */

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,6 +5,7 @@ define([
 	'dojo/Promise',
 	'./EnvironmentType',
 	'diff',
+	'dojo/has!host-node?dojo/node!glob',
 	'dojo/has!host-node?dojo/node!path',
 	'dojo/has!host-node?dojo/node!istanbul/lib/hook',
 	'dojo/has!host-node?dojo/node!istanbul/lib/instrumenter',
@@ -16,6 +17,7 @@ define([
 	Promise,
 	EnvironmentType,
 	diffUtil,
+	glob,
 	pathUtil,
 	hook,
 	Instrumenter,
@@ -724,6 +726,47 @@ define([
 				filename = filename.replace(/\\/g, '/');
 			}
 			return filename;
+		},
+
+		/**
+		 * Resolve a list of module IDs that may contain wildcard entries.
+		 *
+		 * @param {string[]} mids
+		 */
+		resolveModuleIds: function (mids) {
+			function moduleIdToPath(moduleId, package, packageLocation) {
+				return packageLocation + moduleId.slice(package.length);
+			}
+
+			function pathToModuleId(path, package, packageLocation) {
+				return package + path.slice(packageLocation.length, path.length - 3);
+			}
+
+			var resolved = [];
+
+			mids.forEach(function (moduleId) {
+				// The module ID has a glob character
+				if (glob.hasMagic(moduleId)) {
+					var package = moduleId.slice(0, moduleId.indexOf('/'));
+					var packageLocation = require.toUrl(package);
+					var modulePath = moduleIdToPath(moduleId, package, packageLocation);
+
+					// Ensure only JS files are considered
+					if (!/\.js$/.test(modulePath)) {
+						modulePath += '.js';
+					}
+
+					glob.sync(modulePath).forEach(function (file) {
+						resolved.push(pathToModuleId(file, package, packageLocation));
+					});
+				}
+				// The module ID is an actual ID
+				else {
+					resolved.push(moduleId);
+				}
+			});
+
+			return resolved;
 		},
 
 		retry: function (callback, numRetries) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 		"leadfoot": "1.6.4",
 		"digdug": "1.3.2",
 		"charm": "0.2.0",
-		"diff": "1.1.0"
+		"diff": "1.1.0",
+		"glob": "7.0.3"
 	},
 	"devDependencies": {
 		"intern": "3.0.6"

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -11,6 +11,7 @@ define([
 	'./lib/interfaces/object',
 	'./lib/interfaces/qunit',
 	'./lib/reporters/Console',
+	'dojo/has!host-node?./lib/Proxy',
 	'dojo/has!host-node?./lib/reporters/Pretty',
 	'dojo/has!host-node?./lib/reporters/TeamCity',
 	'dojo/has!host-node?./lib/reporters/JUnit',

--- a/tests/unit/lib/Proxy.js
+++ b/tests/unit/lib/Proxy.js
@@ -1,0 +1,154 @@
+define([
+	'require',
+	'intern!object',
+	'intern/chai!assert',
+	'../../../lib/Proxy',
+	'dojo/Promise',
+	'dojo/node!fs',
+	'dojo/node!querystring'
+], function (
+	require,
+	registerSuite,
+	assert,
+	Proxy,
+	Promise,
+	fs,
+	querystring
+) {
+	function createRequest(url) {
+		return {
+			method: 'GET',
+			url: url
+		};
+	}
+
+	function createResponse(done) {
+		return {
+			data: '',
+			end: function (data) {
+				if (data) {
+					this.data += data;
+				}
+				done && done.call(this);
+			},
+			write: function (data) {
+				this.data += data;
+				return true;
+			},
+			writeHead: function (head) {
+				this.headers = head;
+			},
+
+			// WritableStream interface methods
+			on: function () {},
+			once: function () {},
+			emit: function () {}
+		};
+	}
+
+	registerSuite({
+		name: 'lib/Proxy',
+
+		_handle: {
+			'correct handler called': function () {
+				var proxy = new Proxy({ instrument: false });
+				proxy._resolveSuites = function () {
+					calls.push('resolveSuites');
+				};
+				proxy._handleFile = function () {
+					calls.push('handleFile');
+				};
+				var request = createRequest();
+				var response = createResponse();
+				var query = querystring.stringify({ suites: [ 'intern-selftest/tests/unit/*' ] });
+
+				var calls = [];
+				request.url = '/__intern/__resolveSuites__?' + query;
+				proxy._handler(request, response);
+				assert.deepEqual(calls, [ 'resolveSuites' ], '__resolveSuites__ request sent to unexpected handler');
+
+				calls = [];
+				request.url = '/__intern/package/module.js';
+				proxy._handler(request, response);
+				assert.deepEqual(calls, [ 'handleFile' ], 'File request sent to unexpected handler');
+
+				calls = [];
+				request.url = '/__intern/package/module';
+				proxy._handler(request, response);
+				assert.deepEqual(calls, [ 'handleFile' ], 'Module ID request sent to unexpected handler');
+			}
+		},
+
+		_handleFile: function () {
+			var proxy = new Proxy({
+				excludeInstrumentation: true,
+				// Use empty basePath for path resolution
+				basePath: '/'
+			});
+			// A value for the proxy.server is required for _handleFile to actually handle a file
+			proxy.server = true;
+
+			var dfd = new Promise.Deferred();
+			var url = require.toUrl('../../../lib/util.js');
+			var expected = fs.readFileSync(url, { encoding: 'utf8' });
+			var request = createRequest();
+
+			var response = createResponse(function () {
+				dfd.resolve(this.data);
+			});
+
+			request.url = url;
+			proxy._handleFile(request, response);
+
+			return dfd.promise.then(function (data) {
+				assert.equal(data, expected);
+			});
+		},
+
+		_resolveSuites: {
+			'invalid package': function () {
+				var proxy = new Proxy();
+				var query = querystring.stringify({ suites: JSON.stringify([ 'intern-selftests/tests/unit/*' ]) });
+				var request = createRequest('/__intern/__resolveSuites__?' + query);
+				var response = createResponse();
+
+				proxy._resolveSuites(request, response);
+
+				// Ensure returned value is JSON
+				var resolvedSuites;
+				assert.doesNotThrow(function () {
+					resolvedSuites = JSON.parse(response.data);
+				}, 'Returned data should have been a serialized JSON value');
+
+				// If an invalid suite or glob is provided, an empty list should be returned
+				assert.lengthOf(resolvedSuites, 0, 'Expected resolved suites list to be empty');
+			},
+
+			'valid package': function () {
+				var proxy = new Proxy();
+				var query = querystring.stringify({ suites: JSON.stringify([
+					'intern-selftest/tests/unit/*',
+					'intern-selftest/tests/functional/**/*',
+				]) });
+				var request = createRequest('/__intern/__resolveSuites__?' + query);
+				var expected = [
+					'intern-selftest/tests/unit/all',
+					'intern-selftest/tests/unit/main',
+					'intern-selftest/tests/unit/order',
+					'intern-selftest/tests/functional/lib/ProxiedSession'
+				];
+				var response = createResponse();
+
+				proxy._resolveSuites(request, response);
+
+				// Ensure returned value is JSON
+				var resolvedSuites;
+				assert.doesNotThrow(function () {
+					resolvedSuites = JSON.parse(response.data);
+				}, 'Returned data should have been a serialized JSON value');
+
+				assert.deepEqual(resolvedSuites, expected);
+			}
+		}
+	});
+});

--- a/tests/unit/lib/util.js
+++ b/tests/unit/lib/util.js
@@ -230,6 +230,68 @@ define([
 			}
 		},
 
+		'.resolveModuleIds': {
+			'non-glob': function () {
+				if (!has('host-node')) {
+					this.skip('requires Node.js');
+				}
+
+				var moduleIds = [
+					'intern-selftest/tests/unit/lib/util'
+				];
+				var expected = [
+					'intern-selftest/tests/unit/lib/util',
+				];
+				var actual = util.resolveModuleIds(moduleIds);
+				assert.deepEqual(actual, expected, 'Non-glob MID should have been returned unchanged');
+			},
+
+			'single-level': function () {
+				if (!has('host-node')) {
+					this.skip('requires Node.js');
+				}
+
+				var moduleIds = [
+					'intern-selftest/tests/unit/*'
+				];
+				var expected = [
+					'intern-selftest/tests/unit/all',
+					'intern-selftest/tests/unit/main',
+					'intern-selftest/tests/unit/order'
+				];
+				var actual = util.resolveModuleIds(moduleIds);
+				assert.deepEqual(actual, expected, 'Unexpected resolution for single-level glob');
+			},
+
+			'multi-level': function () {
+				if (!has('host-node')) {
+					this.skip('requires Node.js');
+				}
+
+				var moduleIds = [
+					'intern-selftest/tests/functional/**/*'
+				];
+				var expected = [
+					'intern-selftest/tests/functional/lib/ProxiedSession'
+				];
+				var actual = util.resolveModuleIds(moduleIds);
+				assert.deepEqual(actual, expected, 'Unexpected resolution for multi-level glob');
+			},
+
+			'non-JS files': function () {
+				if (!has('host-node')) {
+					this.skip('requires Node.js');
+				}
+
+				var moduleIds = [
+					'intern-selftest/tests/unit/lib/data/repoters/**/*'
+				];
+				var expected = [];
+				var actual = util.resolveModuleIds(moduleIds);
+				assert.deepEqual(actual, expected, 'Non-JS files should not be include in resolved values');
+			}
+		},
+
 		'.retry': {
 			'until failure': function () {
 				var numAttempts = 0;


### PR DESCRIPTION
Glob entries of the form 'package/dir/**/*' are now resolved to lists of module IDs. In a Node.js context, Intern will resolve the package name to its filesystem path and use the `glob` package to find all matching modules. These modules will be converted back to module IDs and added to the Intern config. Both `suites` and `functionalSuites` are handled this way.

In the browser context, the `suites` list is now always sent back to a special `__resolveSuites__` endpoint on Intern's proxy for resolution. The list is resolved in the same manner as in the Node client, and the resolved suites list is returned to the browser and added to Intern's config.

Resolution happens in `PreExecutor` just after loader swapping, so loader maps are in effect

Fixes #359