### PR TITLE
Improve suite error handling in WebDriver reporter

### DIFF
--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -177,7 +177,7 @@ define([
 
 		_publishInSequence: function (message) {
 			var session = this._getSession(message.sessionId);
-			if (!isFatalErrorFromPreExecutor(message) && message.sequence <= session.lastSequence) {
+			if (message.sequence <= session.lastSequence && !isFatalErrorFromPreExecutor(message)) {
 				throw new Error('Repeated sequence for session ' + message.sessionId + ': ' + session.lastSequence +
 					' last ' + message.sequence + ' cur');
 			}

--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -11,6 +11,10 @@ define([
 ], function (require, lang, Promise, http, path, fs, mimetype, aspect, util) {
 	/* jshint node:true */
 
+	function isFatalErrorFromPreExecutor(message) {
+		return message.payload[0] === 'fatalError' && message.sequence === 0;
+	}
+
 	function Proxy(config) {
 		this.config = config;
 	}
@@ -173,8 +177,7 @@ define([
 
 		_publishInSequence: function (message) {
 			var session = this._getSession(message.sessionId);
-
-			if (message.sequence <= session.lastSequence) {
+			if (!isFatalErrorFromPreExecutor(message) && message.sequence <= session.lastSequence) {
 				throw new Error('Repeated sequence for session ' + message.sessionId + ': ' + session.lastSequence +
 					' last ' + message.sequence + ' cur');
 			}

--- a/lib/Suite.js
+++ b/lib/Suite.js
@@ -302,7 +302,7 @@ define([
 						function reportAndContinue(error) {
 							// An error may be associated with a deeper test already, in which case we do not
 							// want to reassociate it with a more generic parent
-							if (!error.relatedTest) {
+							if (!error.relatedTest && !(test instanceof Suite)) {
 								error.relatedTest = test;
 							}
 						}

--- a/lib/executors/Executor.js
+++ b/lib/executors/Executor.js
@@ -297,10 +297,6 @@ define([
 				})
 				.finally(lang.bind(self, '_afterRun'))
 				.then(function () {
-					if (self._hasSuiteErrors) {
-						throw new Error('One or more suite errors occurred during testing');
-					}
-
 					return self.suites.reduce(function (numFailedTests, suite) {
 						return numFailedTests + suite.numFailedTests;
 					}, 0);

--- a/lib/executors/Executor.js
+++ b/lib/executors/Executor.js
@@ -297,6 +297,9 @@ define([
 				})
 				.finally(lang.bind(self, '_afterRun'))
 				.then(function () {
+					if (self._hasSuiteErrors) {
+						throw new Error('One or more suite errors occurred during testing');
+					}
 					return self.suites.reduce(function (numFailedTests, suite) {
 						return numFailedTests + suite.numFailedTests;
 					}, 0);

--- a/lib/executors/PreExecutor.js
+++ b/lib/executors/PreExecutor.js
@@ -32,7 +32,7 @@ define([
 				headers: {
 					'Content-Type': 'application/json'
 				},
-				data: JSON.stringify({
+				data: JSON.stringify([JSON.stringify({
 					sequence: sequence,
 					sessionId: sessionId,
 					payload: [
@@ -41,7 +41,7 @@ define([
 						// a fatal error with a particular environment
 						{ name: error.name, message: error.message, stack: error.stack, sessionId: sessionId }
 					]
-				})
+				})])
 			});
 
 			// The sequence must not be incremented until after the data is successfully serialised, since an error

--- a/lib/reporters/Runner.js
+++ b/lib/reporters/Runner.js
@@ -16,7 +16,8 @@ define([
 		config = config || {};
 
 		this.sessions = {};
-		this.hasErrors = false;
+		this.hasFatalErrors = false;
+		this.hasSuiteErrors = false;
 		this.proxyOnly = Boolean(config.internConfig.proxyOnly);
 		this.reporter = new Reporter({
 			watermarks: config.watermarks
@@ -68,7 +69,7 @@ define([
 				.display('reset')
 				.write('\n');
 
-			this.hasErrors = true;
+			this.hasFatalErrors = true;
 		},
 
 		proxyStart: function (proxy) {
@@ -113,13 +114,17 @@ define([
 				message += ' (' + numSkippedTests + ' skipped)';
 			}
 
-			if (this.hasErrors && !numFailedTests) {
+			if (this.hasFatalErrors && !numFailedTests) {
 				message += '; fatal error occurred';
+			}
+
+			if (this.hasSuiteErrors) {
+				message += '; suite error occured';
 			}
 
 			this.charm
 				.display('bright')
-				.background(numFailedTests > 0 || this.hasErrors ? 'red' : 'green')
+				.background(numFailedTests > 0 || (this.hasFatalErrors || this.hasSuiteErrors) ? 'red' : 'green')
 				.write(nodeUtil.format(message, numEnvironments, numFailedTests, numTests))
 				.display('reset')
 				.write('\n');
@@ -175,7 +180,7 @@ define([
 				}
 
 				if (hasError) {
-					summary += '; fatal error occurred';
+					summary += '; suite error occurred';
 				}
 
 				this.charm
@@ -196,7 +201,7 @@ define([
 				.display('reset')
 				.write('\n');
 
-			this.hasErrors = true;
+			this.hasSuiteErrors = true;
 		},
 
 		suiteStart: function (suite) {

--- a/lib/reporters/WebDriver.js
+++ b/lib/reporters/WebDriver.js
@@ -76,6 +76,21 @@ define([
 			return this._sendEvent('suiteStart', arguments);
 		},
 
+		suiteError: function(suite, error) {
+			if (this.writeHtml) {
+				this.suiteNode.appendChild(document.createTextNode('Suite ' + suite.name + ' failed'));
+				this.suiteNode.style.color = 'red';
+
+				var errorNode = document.createElement('pre');
+				errorNode.appendChild(document.createTextNode(error));
+				this.suiteNode.appendChild(errorNode);
+				this.suiteNode = this.suiteNode.parentNode.parentNode || document.body;
+				scroll();
+			}
+
+			return this._sendEvent('suiteError', arguments);
+		},
+
 		testStart: function (test) {
 			if (this.writeHtml) {
 				this.testNode = document.createElement('li');


### PR DESCRIPTION
Fix proposal for issues described in #525.
- Add suiteError handler to WebDriver reporter.
- Detect fatal error messages in `Proxy.js`. Test execution broke when a fatal error message arrived, as there is an assert `message.sequence <= session.lastSequence`, which is not true for fatal error messages  (sequence number is 0 for fatal error messages).
- Do not set `error.relatedTest` if the test is a `Suite`. This caused infinite loops during JSON serialization (`error.relatedTest` pointed to the `Suite` itself, because that is where the error occured).
- Do not throw fatal errors if a suite error occured.
- Differentiate between suite errors and fatal errors in `Runner`.

Please review thoroughly.
