### PR TITLE
Updates to Geezer Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
 		"istanbul": "0.2.16",
 		"source-map": "0.1.33",
 		"dojo": "1.9.4",
-		"leadfoot": "1.2.1",
-		"digdug": "1.2.1",
+		"leadfoot": "1.6.4",
+		"digdug": "1.3.2",
 		"charm": "0.2.0",
 		"diff": "1.1.0"
 	},


### PR DESCRIPTION
SauceLabs tunnel appears to "broken" on Node 0.10 and Geezer appears to be broken on Node 0.12+.  Allow infinite recursion to occur.  This patch updates the dependencies to DigDug and LeadFoot which appear to introduce no regressions (although the self tests can't run, because they use Geezer 2.2.2 which is broken on SauceLabs :confounded:).