### PR TITLE
Allow suites to be skipped

### DIFF
--- a/lib/ClientSuite.js
+++ b/lib/ClientSuite.js
@@ -62,6 +62,8 @@ define([
 
 					case 'suiteEnd':
 						suite = arguments[1];
+						self.skipped = suite.skipped;
+
 						// The suite sent by the server is the root suite for the client-side unit tests; update the
 						// existing test objects with the new ones from the server that reflect all the test results
 						if (!suite.hasParent) {

--- a/lib/Suite.js
+++ b/lib/Suite.js
@@ -1,7 +1,7 @@
 define([
 	'dojo/Promise',
-	'dojo/lang'
-], function (Promise, lang) {
+	'./Test'
+], function (Promise, Test) {
 	function Suite(kwArgs) {
 		this.tests = [];
 		for (var k in kwArgs) {
@@ -318,12 +318,23 @@ define([
 							}
 						}
 
+						// If the suite will be skipped, mark the current test as skipped. This will skip both
+						// individual tests and nested suites.
+						if (self.skipped != null) {
+							test.skipped = self.skipped;
+						}
+
+						// test is a suite
 						if (test.tests) {
 							current = runWithCatch();
 						}
+						// test is a single test
 						else {
 							if (!self.grep.test(test.id)) {
 								test.skipped = 'grep';
+							}
+
+							if (test.skipped != null) {
 								reporterManager.emit('testSkip', test).then(next);
 								return;
 							}
@@ -349,7 +360,11 @@ define([
 			function setup() {
 				return new Promise(function (resolve) {
 					resolve(self.setup && self.setup());
-				}).catch(reportSuiteError);
+				}).catch(function (error) {
+					if (error !== Test.SKIP) {
+						return reportSuiteError(error);
+					}
+				});
 			}
 
 			function start() {
@@ -391,6 +406,18 @@ define([
 			});
 		},
 
+		/**
+		 * Skips this suite.
+		 *
+		 * @param {String} message
+		 * If provided, will be stored in this suite's `skipped` property.
+		 */
+		skip: function (message) {
+			this.skipped = message || 'suite skipped';
+			// Use the SKIP constant from Test so that calling Suite#skip from a test won't fail the test.
+			throw Test.SKIP;
+		},
+
 		toJSON: function () {
 			return {
 				name: this.name,
@@ -404,6 +431,7 @@ define([
 				numTests: this.numTests,
 				numFailedTests: this.numFailedTests,
 				numSkippedTests: this.numSkippedTests,
+				skipped: this.skipped,
 				error: this.error ? {
 					name: this.error.name,
 					message: this.error.message,

--- a/lib/Test.js
+++ b/lib/Test.js
@@ -9,8 +9,6 @@ define([
 		this.reporterManager && this.reporterManager.emit('newTest', this);
 	}
 
-	var SKIP = {};
-
 	Test.prototype = {
 		constructor: Test,
 		name: null,
@@ -258,7 +256,7 @@ define([
 					self.hasPassed = true;
 					return report('testPass');
 				}, function (error) {
-					if (error === SKIP) {
+					if (error === Test.SKIP) {
 						return report('testSkip');
 					}
 					else {
@@ -281,7 +279,7 @@ define([
 		 */
 		skip: function (message) {
 			this.skipped = message || '';
-			throw SKIP;
+			throw Test.SKIP;
 		},
 
 		toJSON: function () {
@@ -301,6 +299,8 @@ define([
 			};
 		}
 	};
+
+	Test.SKIP = {};
 
 	return Test;
 });


### PR DESCRIPTION
Add suite skip support

- Add a `Suite#skip` method to skip a suite. This method may be called from within a suite lifecycle method or from within a test (as `this.parent.skip()`).
- Support a new `Suite#skipped` property on suites. This property behaves similarly to `Test#skipped`. Setting it to a non-null value will cause the remainder of a suite (all tests and nested suites) to be skipped.

References #386