### PR TITLE
Add check for if excludeInstrumentation is a string

### DIFF
--- a/lib/executors/PreExecutor.js
+++ b/lib/executors/PreExecutor.js
@@ -119,6 +119,12 @@ define([
 				}
 			});
 
+            if (kwArgs.excludeInstrumentation === 'true') {
+                kwArgs.excludeInstrumentation = true;
+            } else if (typeof kwArgs.excludeInstrumentation === 'string') {
+                kwArgs.excludeInstrumentation = new RegExp(kwArgs.excludeInstrumentation);
+            }
+
 			this.getArguments = function () {
 				return kwArgs;
 			};


### PR DESCRIPTION
Currently intern expects excludeInstrumentation to be a regular expression or a boolean true. When using intern as a grunt task and attempting to override your config file's default excludeInstrumentation value, grunt will spawn the task with the excludeInstrumentation option through the command line, converting the option to a string. This is never checked, and causes an error for /lib/util.js:760 (texcludeInstrumentation.test is not a function).

The fix that I've implemented checks the config.excludeInstrumentation variable before enableInstrumentaiton() is called in /lib/executors/Executor. If excludeInstrumentation is a string it will try to parse it (to see if it's a Boolean value), otherwise it will create a RegExp from the string. This also provides additional flexibility for intern config files, excludeInstrumentation can now either be a regular expression, or a string that will get parsed as a regular expression.