### PR TITLE
Add suite async support

### DIFF
--- a/lib/Suite.js
+++ b/lib/Suite.js
@@ -1,7 +1,7 @@
 define([
 	'dojo/Promise',
-	'dojo/lang'
-], function (Promise, lang) {
+	'./util'
+], function (Promise, util) {
 	function Suite(kwArgs) {
 		this.tests = [];
 		for (var k in kwArgs) {
@@ -188,6 +188,59 @@ define([
 			var self = this;
 			var startTime;
 
+			function runLifecycleMethod(suite, name, args) {
+				return new Promise(function (resolve) {
+					var dfd;
+					var timeout;
+
+					// Provide a new Suite#async method for each call of a lifecycle method since there's no concept of
+					// a Suite-wide async deferred as there is for Tests.
+					suite.async = function (_timeout) {
+						timeout = _timeout;
+
+						dfd = util.createDeferred();
+
+						suite.async = function () {
+							return dfd;
+						};
+
+						return dfd;
+					};
+
+					var returnValue = suite[name] && suite[name].apply(suite, args);
+
+					if (dfd) {
+						// If a timeout was set, async was called, so we should use the dfd created by the call to
+						// manage the timeout.
+						if (timeout) {
+							var timer = setTimeout(function () {
+								dfd.reject(new Error('Timeout reached on ' + suite.id + '#' + name));
+							}, timeout);
+
+							dfd.promise.finally(function () {
+								timer && clearTimeout(timer);
+							});
+						}
+
+						// If the return value looks like a promise, resolve the dfd if the return value resolves
+						if (returnValue && returnValue.then) {
+							returnValue.then(
+								function (value) {
+									dfd.resolve(value);
+								},
+								function (error) {
+									dfd.reject(error);
+								}
+							);
+						}
+
+						returnValue = dfd.promise;
+					}
+
+					resolve(returnValue);
+				}).catch(reportSuiteError);
+			}
+
 			function end() {
 				self.timeElapsed = Date.now() - startTime;
 				return report('suiteEnd');
@@ -259,9 +312,7 @@ define([
 						}
 
 						function runWithCatch() {
-							return new Promise(function (resolve) {
-								resolve(suite[name] && suite[name](test));
-							}).catch(reportSuiteError);
+							return runLifecycleMethod(suite, name, [ test ]);
 						}
 
 						current = runWithCatch().then(next, handleError);
@@ -347,9 +398,7 @@ define([
 			}
 
 			function setup() {
-				return new Promise(function (resolve) {
-					resolve(self.setup && self.setup());
-				}).catch(reportSuiteError);
+				return runLifecycleMethod(self, 'setup');
 			}
 
 			function start() {
@@ -359,9 +408,7 @@ define([
 			}
 
 			function teardown() {
-				return new Promise(function (resolve) {
-					resolve(self.teardown && self.teardown());
-				}).catch(reportSuiteError);
+				return runLifecycleMethod(self, 'teardown');
 			}
 
 			// Reset some state in case someone tries to re-run the same suite

--- a/lib/Test.js
+++ b/lib/Test.js
@@ -1,6 +1,7 @@
 define([
-	'dojo/Promise'
-], function (Promise) {
+	'dojo/Promise',
+	'./util',
+], function (Promise, util) {
 	function Test(kwArgs) {
 		for (var k in kwArgs) {
 			this[k] = kwArgs[k];
@@ -93,9 +94,7 @@ define([
 				numCallsUntilResolution = 1;
 			}
 
-			var dfd = new Promise.Deferred(function (reason) {
-				throw reason;
-			});
+			var dfd = util.createDeferred();
 			var oldResolve = dfd.resolve;
 
 			/**
@@ -110,33 +109,6 @@ define([
 				else if (numCallsUntilResolution < 0) {
 					throw new Error('resolve called too many times');
 				}
-			};
-
-			/**
-			 * Wraps any callback to resolve the deferred so long as the callback executes without throwing any Errors.
-			 */
-			dfd.callback = function (callback) {
-				var self = this;
-				return self.rejectOnError(function () {
-					var returnValue = callback.apply(this, arguments);
-					self.resolve();
-					return returnValue;
-				});
-			};
-
-			/**
-			 * Wraps a callback to reject the deferred if the callback throws an Error.
-			 */
-			dfd.rejectOnError = function (callback) {
-				var self = this;
-				return function () {
-					try {
-						return callback.apply(this, arguments);
-					}
-					catch (error) {
-						self.reject(error);
-					}
-				};
 			};
 
 			// A test may call this function multiple times and should always get the same Deferred

--- a/lib/util.js
+++ b/lib/util.js
@@ -496,6 +496,44 @@ define([
 		},
 
 		/**
+		 * Create a Deferred with some additional utility methods.
+		 */
+		createDeferred: function () {
+			var dfd = new Promise.Deferred(function (reason) {
+				throw reason;
+			});
+
+			/**
+			 * Wraps any callback to resolve the deferred so long as the callback executes without throwing any Errors.
+			 */
+			dfd.callback = function (callback) {
+				var self = this;
+				return self.rejectOnError(function () {
+					var returnValue = callback.apply(this, arguments);
+					self.resolve();
+					return returnValue;
+				});
+			};
+
+			/**
+			 * Wraps a callback to reject the deferred if the callback throws an Error.
+			 */
+			dfd.rejectOnError = function (callback) {
+				var self = this;
+				return function () {
+					try {
+						return callback.apply(this, arguments);
+					}
+					catch (error) {
+						self.reject(error);
+					}
+				};
+			};
+
+			return dfd;
+		},
+
+		/**
 		 * Creates a basic FIFO function queue to limit the number of currently executing asynchronous functions.
 		 *
 		 * @param maxConcurrency Number of functions to execute at once.


### PR DESCRIPTION
- Suite lifecycle methods can now call `this.async` to enable async
  functionality. Calling `this.async` only affects the particular
  lifecycle method call in progress.
- The lib/Suite unit tests were reorganized, and async tests were added
  for the lifecycle methods.

References #289 