### PR TITLE
Add fail-fast and test retry functionality

### DIFF
--- a/lib/ClientSuite.js
+++ b/lib/ClientSuite.js
@@ -62,6 +62,8 @@ define([
 
 					case 'suiteEnd':
 						suite = arguments[1];
+						self.skipped = suite.skipped;
+
 						// The suite sent by the server is the root suite for the client-side unit tests; update the
 						// existing test objects with the new ones from the server that reflect all the test results
 						if (!suite.hasParent) {

--- a/lib/Suite.js
+++ b/lib/Suite.js
@@ -11,6 +11,10 @@ define([
 		this.reporterManager && this.reporterManager.emit('newSuite', this);
 	}
 
+	// FAIL_FAST_REASON needs to be a string so that Intern can tell when a remote has skipped unit tests so that it can
+	// skip functional tests.
+	var FAIL_FAST_REASON = 'fail fast';
+
 	Suite.prototype = {
 		constructor: Suite,
 		name: null,
@@ -22,16 +26,29 @@ define([
 		teardown: null,
 		error: null,
 		timeElapsed: null,
+		_failFast: null,
 		_grep: null,
 		_remote: null,
 		_environmentType: null,
 		_reporterManager: null,
+		_retries: null,
 
 		/**
 		 * If true, the suite will only publish its start topic after the setup callback has finished,
 		 * and will publish its end topic before the teardown callback has finished.
 		 */
 		publishAfterSetup: false,
+
+		/**
+		 * A flag used to indicate whether a test run shoudl stop after a failed test.
+		 */
+		get failFast() {
+			return this._failFast || (this.parent && this.parent.failFast);
+		},
+
+		set failFast(value) {
+			this._failFast = value;
+		},
 
 		/**
 		 * A regular expression used to filter, by test ID, which tests are run.
@@ -73,6 +90,20 @@ define([
 			}
 
 			Object.defineProperty(this, '_remote', { value: value });
+		},
+
+		/**
+		 * The number of times to retry failed tests
+		 */
+		get retries() {
+			return this._retries || (this.parent && this.parent.retries) || 0;
+		},
+
+		set retries(value) {
+			if (value && isNaN(value)) {
+				throw new Error('retry count must be a number');
+			}
+			this._retries = value || 0;
 		},
 
 		/**
@@ -291,8 +322,8 @@ define([
 						throw reason;
 					});
 
-					function next() {
-						var test = tests[i++];
+					function next(test) {
+						test = test || tests[i++];
 
 						if (!test) {
 							firstError ? reject(firstError) : resolve();
@@ -350,7 +381,29 @@ define([
 								});
 						}
 
-						current.then(next);
+						current.then(function () {
+							if (test.error) {
+								// Test isn't a suite and has a non-zero number of retries
+								if (!test.tests && test.retries) {
+									test.retries--;
+									test.error = null;
+									next(test);
+									return;
+								}
+
+								// If failFast mode is enabled, skip the rest of the suite
+								if (self.failFast) {
+									self.skipped = self.skipped != null ? self.skipped : FAIL_FAST_REASON;
+								}
+							}
+							// If the test was a suite and the suite was skipped due to failFast, skip the rest of this
+							// suite
+							else if (test.tests && test.skipped === FAIL_FAST_REASON) {
+								self.skipped = self.skipped != null ? self.skipped : test.skipped;
+							}
+
+							next();
+						});
 					}
 
 					next();

--- a/lib/Suite.js
+++ b/lib/Suite.js
@@ -11,9 +11,9 @@ define([
 		this.reporterManager && this.reporterManager.emit('newSuite', this);
 	}
 
-	// FAIL_FAST_REASON needs to be a string so that Intern can tell when a remote has skipped unit tests so that it can
-	// skip functional tests.
-	var FAIL_FAST_REASON = 'fail fast';
+	// BAIL_REASON needs to be a string so that Intern can tell when a remote has bailed during unit tests so that it
+	// can skip functional tests.
+	var BAIL_REASON = 'bailed';
 
 	Suite.prototype = {
 		constructor: Suite,
@@ -26,7 +26,7 @@ define([
 		teardown: null,
 		error: null,
 		timeElapsed: null,
-		_failFast: null,
+		_bail: null,
 		_grep: null,
 		_remote: null,
 		_environmentType: null,
@@ -42,12 +42,12 @@ define([
 		/**
 		 * A flag used to indicate whether a test run shoudl stop after a failed test.
 		 */
-		get failFast() {
-			return this._failFast || (this.parent && this.parent.failFast);
+		get bail() {
+			return this._bail || (this.parent && this.parent.bail);
 		},
 
-		set failFast(value) {
-			this._failFast = value;
+		set bail(value) {
+			this._bail = value;
 		},
 
 		/**
@@ -93,14 +93,14 @@ define([
 		},
 
 		/**
-		 * The number of times to retry failed tests
+		 * The number of times to retry failed tests in this suite. The default is 0.
 		 */
 		get retries() {
 			return this._retries || (this.parent && this.parent.retries) || 0;
 		},
 
 		set retries(value) {
-			if (value && isNaN(value)) {
+			if (value != null && isNaN(value)) {
 				throw new Error('retry count must be a number');
 			}
 			this._retries = value || 0;
@@ -391,14 +391,14 @@ define([
 									return;
 								}
 
-								// If failFast mode is enabled, skip the rest of the suite
-								if (self.failFast) {
-									self.skipped = self.skipped != null ? self.skipped : FAIL_FAST_REASON;
+								// If bail mode is enabled, skip the rest of the suite
+								if (self.bail) {
+									self.skipped = self.skipped != null ? self.skipped : BAIL_REASON;
 								}
 							}
-							// If the test was a suite and the suite was skipped due to failFast, skip the rest of this
+							// If the test was a suite and the suite was skipped due to bailing, skip the rest of this
 							// suite
-							else if (test.tests && test.skipped === FAIL_FAST_REASON) {
+							else if (test.tests && test.skipped === BAIL_REASON) {
 								self.skipped = self.skipped != null ? self.skipped : test.skipped;
 							}
 

--- a/lib/Suite.js
+++ b/lib/Suite.js
@@ -1,7 +1,7 @@
 define([
 	'dojo/Promise',
-	'dojo/lang'
-], function (Promise, lang) {
+	'./Test'
+], function (Promise, Test) {
 	function Suite(kwArgs) {
 		this.tests = [];
 		for (var k in kwArgs) {
@@ -318,12 +318,23 @@ define([
 							}
 						}
 
+						// If the suite will be skipped, mark the current test as skipped. This will skip both
+						// individual tests and nested suites.
+						if (self.skipped != null) {
+							test.skipped = self.skipped;
+						}
+
+						// test is a suite
 						if (test.tests) {
 							current = runWithCatch();
 						}
+						// test is a single test
 						else {
 							if (!self.grep.test(test.id)) {
 								test.skipped = 'grep';
+							}
+
+							if (test.skipped != null) {
 								reporterManager.emit('testSkip', test).then(next);
 								return;
 							}
@@ -349,7 +360,11 @@ define([
 			function setup() {
 				return new Promise(function (resolve) {
 					resolve(self.setup && self.setup());
-				}).catch(reportSuiteError);
+				}).catch(function (error) {
+					if (error !== Test.SKIP) {
+						return reportSuiteError(error);
+					}
+				});
 			}
 
 			function start() {
@@ -391,6 +406,18 @@ define([
 			});
 		},
 
+		/**
+		 * Skips this suite.
+		 *
+		 * @param {String} message
+		 * If provided, will be stored in this suite's `skipped` property.
+		 */
+		skip: function (message) {
+			this.skipped = message || 'suite skipped';
+			// Use the SKIP constant from Test so that calling Suite#skip from a test won't fail the test.
+			throw Test.SKIP;
+		},
+
 		toJSON: function () {
 			return {
 				name: this.name,
@@ -404,6 +431,7 @@ define([
 				numTests: this.numTests,
 				numFailedTests: this.numFailedTests,
 				numSkippedTests: this.numSkippedTests,
+				skipped: this.skipped,
 				error: this.error ? {
 					name: this.error.name,
 					message: this.error.message,

--- a/lib/Test.js
+++ b/lib/Test.js
@@ -9,8 +9,6 @@ define([
 		this.reporterManager && this.reporterManager.emit('newTest', this);
 	}
 
-	var SKIP = {};
-
 	Test.prototype = {
 		constructor: Test,
 		name: null,
@@ -258,7 +256,7 @@ define([
 					self.hasPassed = true;
 					return report('testPass');
 				}, function (error) {
-					if (error === SKIP) {
+					if (error === Test.SKIP) {
 						return report('testSkip');
 					}
 					else {
@@ -281,7 +279,7 @@ define([
 		 */
 		skip: function (message) {
 			this.skipped = message || '';
-			throw SKIP;
+			throw Test.SKIP;
 		},
 
 		toJSON: function () {
@@ -311,6 +309,8 @@ define([
 			};
 		}
 	};
+
+	Test.SKIP = {};
 
 	return Test;
 });

--- a/lib/Test.js
+++ b/lib/Test.js
@@ -46,6 +46,14 @@ define([
 			return this.parent && this.parent.reporterManager;
 		},
 
+		get retries() {
+			return this._retries == null ? this.parent.retries : this._retries;
+		},
+
+		set retries(value) {
+			this._retries = value;
+		},
+
 		get sessionId() {
 			return this.parent.sessionId;
 		},

--- a/lib/executors/Client.js
+++ b/lib/executors/Client.js
@@ -51,7 +51,7 @@ define([
 				sessionId: config.sessionId,
 				timeout: config.defaultTimeout,
 				reporterManager: this.reporterManager,
-				failFast: config.failFast,
+				bail: config.bail,
 				retries: config.retries
 			});
 

--- a/lib/executors/Client.js
+++ b/lib/executors/Client.js
@@ -50,7 +50,9 @@ define([
 				grep: config.grep,
 				sessionId: config.sessionId,
 				timeout: config.defaultTimeout,
-				reporterManager: this.reporterManager
+				reporterManager: this.reporterManager,
+				failFast: config.failFast,
+				retries: config.retries
 			});
 
 			this.suites = [ suite ];

--- a/lib/executors/Runner.js
+++ b/lib/executors/Runner.js
@@ -184,7 +184,7 @@ define([
 					reporterManager: reporterManager,
 					publishAfterSetup: true,
 					grep: config.grep,
-					failFast: config.failFast,
+					bail: config.bail,
 					timeout: config.defaultTimeout,
 					setup: function () {
 						return util.retry(function () {

--- a/lib/executors/Runner.js
+++ b/lib/executors/Runner.js
@@ -184,6 +184,7 @@ define([
 					reporterManager: reporterManager,
 					publishAfterSetup: true,
 					grep: config.grep,
+					failFast: config.failFast,
 					timeout: config.defaultTimeout,
 					setup: function () {
 						return util.retry(function () {

--- a/tests/unit/lib/Suite.js
+++ b/tests/unit/lib/Suite.js
@@ -644,6 +644,105 @@ define([
 			}));
 		},
 
+		'Suite#run failFast': function () {
+			var dfd = this.async(5000);
+			var suite = createSuite({
+				failFast: true
+			});
+			var testsRun = [];
+			var fooTest = new Test({
+				name: 'foo',
+				parent: suite,
+				test: function () {
+					testsRun.push(this);
+				}
+			});
+			var barSuite = createSuite({
+				name: 'bar',
+				parent: suite,
+				tests: [
+					new Test({
+						name: 'foo',
+						test: function () {
+							testsRun.push(this);
+							// Fail this test; everything after this should not run
+							throw new Error('fail');
+						}
+					}),
+					new Test({
+						name: 'baz',
+						test: function () {
+							testsRun.push(this);
+						}
+					})
+				]
+			});
+			var foodTest = new Test({
+				name: 'food',
+				parent: suite,
+				test: function () {
+					testsRun.push(this);
+				}
+			});
+
+			suite.tests.push(fooTest);
+			suite.tests.push(barSuite);
+			suite.tests.push(foodTest);
+
+			suite.run().then(dfd.callback(function () {
+				assert.deepEqual(testsRun, [ fooTest, barSuite.tests[0] ],
+					'Only tests before failing test should have run');
+			}, function () {
+				dfd.reject(new assert.AssertionError('Suite should not fail'));
+			}));
+		},
+
+		'Suite#run retry': function () {
+			var dfd = this.async(5000);
+			var suite = createSuite({
+				retries: 4
+			});
+			var testsRun = { foo: 0, bar: 0, baz: 0 };
+			var fooTest = new Test({
+				name: 'foo',
+				parent: suite,
+				test: function () {
+					testsRun.foo++;
+					throw new Error('foo');
+				}
+			});
+			var barTest = new Test({
+				name: 'bar',
+				parent: suite,
+				test: function () {
+					testsRun.bar++;
+					// Simulate a test that passes the second time it's run
+					if (testsRun.bar < 2) {
+						throw new Error('bar');
+					}
+				}
+			});
+			var bazTest = new Test({
+				name: 'baz',
+				parent: suite,
+				test: function () {
+					testsRun.baz++;
+				}
+			});
+			var expectedRuns = { foo: 5, bar: 2, baz: 1 };
+
+			suite.tests.push(fooTest);
+			suite.tests.push(barTest);
+			suite.tests.push(bazTest);
+
+			suite.run().then(dfd.callback(function () {
+				assert.deepEqual(testsRun, expectedRuns,
+					'Tests should have run expected number of times');
+			}, function () {
+				dfd.reject(new assert.AssertionError('Suite should not fail'));
+			}));
+		},
+
 		'Suite#run skip': function () {
 			var dfd = this.async(5000);
 			var suite = createSuite();

--- a/tests/unit/lib/Suite.js
+++ b/tests/unit/lib/Suite.js
@@ -644,10 +644,10 @@ define([
 			}));
 		},
 
-		'Suite#run failFast': function () {
+		'Suite#run bail': function () {
 			var dfd = this.async(5000);
 			var suite = createSuite({
-				failFast: true
+				bail: true
 			});
 			var testsRun = [];
 			var fooTest = new Test({


### PR DESCRIPTION
- Add a new config option `failFast`. Setting this to a truthy value
  will cause all subsequent tests after a failing test to be skipped.
- A new config option `retries` that specifies the number of
  times a test should be retried if it fails. This value may also be set
  for individual tests or suites within the test or a suite lifecycle function.

References #413, #340