### PR TITLE
[util] fixes #584 - Consistent handling for URLs during path normalization

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -690,7 +690,8 @@ define([
 			}
 
 			var parts = path.replace(/\\/g, '/').split('/');
-			var result = [];
+            var isUrl = parts.length > 2 && parts[0].match(/^(https?|ftps?|file)[:]$/) && !parts[1];
+			var result = isUrl? parts.splice(0,2): [];
 			for (var i = 0; i < parts.length; ++i) {
 				var part = parts[i];
 


### PR DESCRIPTION
Detects whether input path is a URL and preserves <scheme>:// prefix .