### PR TITLE
Fix handling of null/undefined suites/functionSuites

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -795,6 +795,10 @@ define([
 		 * @returns {string[]} a list of resolved module IDs
 		 */
 		resolveModuleIds: function (moduleIds) {
+			if (!moduleIds) {
+				return [];
+			}
+
 			function moduleIdToPath(moduleId, package, packageLocation) {
 				return packageLocation + moduleId.slice(package.length);
 			}

--- a/tests/unit/lib/util.js
+++ b/tests/unit/lib/util.js
@@ -262,6 +262,15 @@ define([
 		},
 
 		'.resolveModuleIds': {
+			'null or undefined': function () {
+				var expected = [];
+				var nullActual = util.resolveModuleIds(null);
+				assert.deepEqual(nullActual, expected, 'Unexpected resolution for null');
+
+				var undefinedActual = util.resolveModuleIds(undefined);
+				assert.deepEqual(undefinedActual, expected, 'Unexpected resolution for undefined');
+			},
+
 			'non-glob': function () {
 				if (!has('host-node')) {
 					this.skip('requires Node.js');


### PR DESCRIPTION
This fixes #600

`suites`/`functionalSuites` should be able to be `null` or `undefined`.