### PR TITLE
Allow nodeOptions (eg --harmony) to be passed to the new node process

### DIFF
--- a/tasks/intern.js
+++ b/tasks/intern.js
@@ -65,8 +65,18 @@ module.exports = function (grunt) {
 				testingbotKey: true,
 				testingbotSecret: true,
 				nodeEnv: true,
-				cwd: true
+				cwd: true,
+				nodeFlags: true
 			};
+
+		if (opts.nodeFlags) {
+			// Node Flags need to go at the beginning
+			if (Array.isArray(opts.nodeFlags)) {
+				Array.prototype.unshift.apply(args, opts.nodeFlags);
+			} else {
+				args.unshift(opts.nodeFlags);
+			}
+		}
 
 		Object.keys(opts).forEach(function (option) {
 			if (skipOptions[option]) {
@@ -107,7 +117,7 @@ module.exports = function (grunt) {
 
 		// force colored output for istanbul report
 		env.FORCE_COLOR = true;
-		
+
 		var child = grunt.util.spawn({
 			cmd: process.argv[0],
 			args: args,

--- a/tasks/intern.js
+++ b/tasks/intern.js
@@ -66,15 +66,15 @@ module.exports = function (grunt) {
 				testingbotSecret: true,
 				nodeEnv: true,
 				cwd: true,
-				nodeFlags: true
+				nodeOptions: true
 			};
 
-		if (opts.nodeFlags) {
-			// Node Flags need to go at the beginning
-			if (Array.isArray(opts.nodeFlags)) {
-				Array.prototype.unshift.apply(args, opts.nodeFlags);
+		if (opts.nodeOptions) {
+			// Node Options need to go at the beginning
+			if (Array.isArray(opts.nodeOptions)) {
+				Array.prototype.unshift.apply(args, opts.nodeOptions);
 			} else {
-				args.unshift(opts.nodeFlags);
+				args.unshift(opts.nodeOptions);
 			}
 		}
 


### PR DESCRIPTION
This change allows node options for `harmony` and other ES6 features to be passed to the child process in which `intern` is ran when using the `grunt intern` task.

This is required to enable testing of `ES6` code as per https://github.com/dojo/meta/issues/25

Sample usage:

``` javascript
grunt.registerTask('test-es6', function () {
	tsOptions.target = 'es6';
	grunt.config('intern.options. nodeOptions', [
		'--harmony',
		'--harmony_default_parameters'
	]);
	grunt.task.run('test');
});
```

Note:  Also allows passing `debug-brk` which is pretty handy