### PR TITLE
Hide coverage table when list of files is empty

### DIFF
--- a/lib/reporters/Pretty.js
+++ b/lib/reporters/Pretty.js
@@ -170,10 +170,12 @@ define([
 			this._render(true);
 
 			// Display coverage information
-			charm.write('\n');
-			(new Reporter({
-				watermarks: this.watermarks
-			})).writeReport(this.total.coverage, true);
+			if(typeof this.total.coverage.store.keys()[0] !== 'undefined'){
+				charm.write('\n');
+				(new Reporter({
+					watermarks: this.watermarks
+				})).writeReport(this.total.coverage, true);
+			}
 		},
 
 		coverage: function (sessionId, coverage) {


### PR DESCRIPTION
This PR fixes the issue https://github.com/theintern/intern/issues/606
It hides the coverage table not only when excludeInstrumentation set to true, but in more generic cases - when the list of files is empty