### PR TITLE
Allow passing in options for istanbul's Instrumenter through intern's configuration.

### DIFF
--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -153,7 +153,6 @@ define([
 						data = self._codeCache[wholePath] = util.instrument(
 							data.toString('utf-8'),
 							wholePath,
-							self.config.coverageVariable,
 							self.config.instrumenterOptions
 						);
 						send(contentType, data);

--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -153,7 +153,8 @@ define([
 						data = self._codeCache[wholePath] = util.instrument(
 							data.toString('utf-8'),
 							wholePath,
-							self.config.coverageVariable
+							self.config.coverageVariable,
+							self.config.instrumenterOptions
 						);
 						send(contentType, data);
 					});

--- a/lib/executors/Executor.js
+++ b/lib/executors/Executor.js
@@ -30,7 +30,9 @@ define([
 		 * @type {Object}
 		 */
 		config: {
-			coverageVariable: '__internCoverage',
+			instrumenterOptions: {
+				coverageVariable: '__internCoverage'
+			},
 			defaultTimeout: 30000,
 			reporters: []
 		},
@@ -86,7 +88,6 @@ define([
 					return self.enableInstrumentation(
 						config.basePath,
 						config.excludeInstrumentation,
-						config.coverageVariable,
 						config.instrumenterOptions
 					);
 				}
@@ -115,13 +116,12 @@ define([
 		 * @param {string} basePath The base path to use to calculate absolute paths for use by lcov.
 		 * @param {RegExp} excludePaths A regular expression matching paths, relative to `basePath`, that should not be
 		 * instrumented.
-		 * @param {string} coverageVariable The global variable that should be used to store code coverage data.
 		 * @param {Object} instrumenterOptions Extra options for the instrumenter
 		 * @returns {Handle} Remove handle.
 		 */
-		enableInstrumentation: function (basePath, excludePaths, coverageVariable, instrumenterOptions) {
+		enableInstrumentation: function (basePath, excludePaths, instrumenterOptions) {
 			if (has('host-node')) {
-				return util.setInstrumentationHooks(excludePaths, basePath, coverageVariable, instrumenterOptions);
+				return util.setInstrumentationHooks(excludePaths, basePath, instrumenterOptions);
 			}
 		},
 
@@ -352,7 +352,7 @@ define([
 				function emitLocalCoverage() {
 					var error = new Error('Run failed due to one or more suite errors');
 
-					var coverageData = (function () { return this; })()[self.config.coverageVariable];
+					var coverageData = (function () { return this; })()[self.config.instrumenterOptions.coverageVariable];
 					if (coverageData) {
 						return self.reporterManager.emit('coverage', null, coverageData).then(function () {
 							if (hasError) {

--- a/lib/executors/Executor.js
+++ b/lib/executors/Executor.js
@@ -86,7 +86,8 @@ define([
 					return self.enableInstrumentation(
 						config.basePath,
 						config.excludeInstrumentation,
-						config.coverageVariable
+						config.coverageVariable,
+						config.instrumenterOptions
 					);
 				}
 			}
@@ -115,11 +116,12 @@ define([
 		 * @param {RegExp} excludePaths A regular expression matching paths, relative to `basePath`, that should not be
 		 * instrumented.
 		 * @param {string} coverageVariable The global variable that should be used to store code coverage data.
+		 * @param {Object} instrumenterOptions Extra options for the instrumenter
 		 * @returns {Handle} Remove handle.
 		 */
-		enableInstrumentation: function (basePath, excludePaths, coverageVariable) {
+		enableInstrumentation: function (basePath, excludePaths, coverageVariable, instrumenterOptions) {
 			if (has('host-node')) {
-				return util.setInstrumentationHooks(excludePaths, basePath, coverageVariable);
+				return util.setInstrumentationHooks(excludePaths, basePath, coverageVariable, instrumenterOptions);
 			}
 		},
 

--- a/lib/executors/PreExecutor.js
+++ b/lib/executors/PreExecutor.js
@@ -250,6 +250,12 @@ define([
 					util.assertSafeModuleId(args.loaders['host-browser']);
 				}
 
+				config.instrumenterOptions = config.instrumenterOptions || {};
+
+				if (config.coverageVariable) {
+					config.instrumenterOptions.coverageVariable = config.coverageVariable;
+				}
+
 				return config;
 			});
 

--- a/lib/executors/Runner.js
+++ b/lib/executors/Runner.js
@@ -259,6 +259,7 @@ define([
 			return new Proxy({
 				basePath: config.basePath,
 				coverageVariable: config.coverageVariable,
+				instrumenterOptions: config.instrumenterOptions,
 				excludeInstrumentation: config.excludeInstrumentation,
 				instrument: true,
 				waitForRunner: config.runnerClientReporter.waitForRunner,

--- a/lib/executors/Runner.js
+++ b/lib/executors/Runner.js
@@ -191,7 +191,7 @@ define([
 							return server.createSession(environmentType);
 						}, config.environmentRetries).then(function (session) {
 							session.coverageEnabled = config.excludeInstrumentation !== true;
-							session.coverageVariable = config.coverageVariable;
+							session.coverageVariable = config.instrumenterOptions.coverageVariable;
 							session.proxyUrl = config.proxyUrl;
 							session.proxyBasePathLength = config.basePath.length;
 							session.reporterManager = reporterManager;
@@ -258,7 +258,6 @@ define([
 		_createProxy: function (config) {
 			return new Proxy({
 				basePath: config.basePath,
-				coverageVariable: config.coverageVariable,
 				instrumenterOptions: config.instrumenterOptions,
 				excludeInstrumentation: config.excludeInstrumentation,
 				instrument: true,

--- a/lib/util.js
+++ b/lib/util.js
@@ -210,9 +210,9 @@ define([
 	/**
 	 * Return the instrumenter, creating it if necessary.
 	 */
-	function getInstrumenter(coverageVariable) {
+	function getInstrumenter(coverageVariable, instrumenterOptions) {
 		if (!instrumenters[coverageVariable]) {
-			instrumenters[coverageVariable] = new Instrumenter({
+			var opts = {
 				// coverage variable is changed primarily to avoid any jshint complaints, but also to make
 				// it clearer where the global is coming from
 				coverageVariable: coverageVariable,
@@ -222,7 +222,15 @@ define([
 
 				// auto-wrap breaks code
 				noAutoWrap: true
-			});
+			};
+
+			if (instrumenterOptions) {
+				Object.keys(instrumenterOptions).forEach(function (key) {
+					opts[key] = instrumenterOptions[key];
+				});
+			}
+
+			instrumenters[coverageVariable] = new Instrumenter(opts);
 		}
 		return instrumenters[coverageVariable];
 	}
@@ -848,10 +856,10 @@ define([
 		 * Adds hooks for code coverage instrumentation in the Node.js loader.
 		 *
 		 * @param {Object} config The main Intern configuration.
-		 * @param {Object} instrumenter The code instrumenter.
 		 * @param {string} basePath The base path for all code.
+		 * @param {Object} instrumenterOptions Extra options for the instrumenter
 		 */
-		setInstrumentationHooks: function (excludeInstrumentation, basePath, coverageVariable) {
+		setInstrumentationHooks: function (excludeInstrumentation, basePath, coverageVariable, instrumenterOptions) {
 			var self = this;
 
 			basePath = self.normalizePath(pathUtil.resolve(basePath || '') + pathUtil.sep);
@@ -868,7 +876,7 @@ define([
 			}
 
 			function hookTransformer(code, filename) {
-				return self.instrument(code, pathUtil.resolve(filename), coverageVariable);
+				return self.instrument(code, pathUtil.resolve(filename), coverageVariable, instrumenterOptions);
 			}
 
 			hook.hookRunInThisContext(hookMatcher, hookTransformer);
@@ -888,16 +896,22 @@ define([
 		 *
 		 * @param filedata Text of file being instrumented
 		 * @param filepath Full path of file being instrumented
+		 * @param coverageVariable The global variable that should be used to store code coverage data
+		 * @param instrumenterOptions Extra options for the instrumenter
 		 *
 		 * @returns {string} A string of instrumented code
 		 */
-		instrument: function (filedata, filepath, coverageVariable) {
-			var instrumenter = getInstrumenter(coverageVariable);
+		instrument: function (filedata, filepath, coverageVariable, instrumenterOptions) {
+			var instrumenter = getInstrumenter(coverageVariable, instrumenterOptions);
+
 			var opts = instrumenter.opts;
-			opts.codeGenerationOptions = {
-				sourceMap: pathUtil.normalize(filepath),
-				sourceMapWithCode: true
-			};
+
+			if (!opts.codeGenerationOptions) {
+				opts.codeGenerationOptions = {};
+			}
+			opts.codeGenerationOptions.sourceMap = pathUtil.normalize(filepath);
+			opts.codeGenerationOptions.sourceMapWithCode = true;
+
 			var code = instrumenter.instrumentSync(filedata, pathUtil.normalize(filepath));
 			var map = instrumenter.lastSourceMap();
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -210,7 +210,9 @@ define([
 	/**
 	 * Return the instrumenter, creating it if necessary.
 	 */
-	function getInstrumenter(coverageVariable, instrumenterOptions) {
+	function getInstrumenter(instrumenterOptions) {
+		var coverageVariable = instrumenterOptions.coverageVariable;
+
 		if (!instrumenters[coverageVariable]) {
 			var opts = {
 				// coverage variable is changed primarily to avoid any jshint complaints, but also to make
@@ -224,11 +226,9 @@ define([
 				noAutoWrap: true
 			};
 
-			if (instrumenterOptions) {
-				Object.keys(instrumenterOptions).forEach(function (key) {
-					opts[key] = instrumenterOptions[key];
-				});
-			}
+			Object.keys(instrumenterOptions).forEach(function (key) {
+				opts[key] = instrumenterOptions[key];
+			});
 
 			instrumenters[coverageVariable] = new Instrumenter(opts);
 		}
@@ -859,7 +859,7 @@ define([
 		 * @param {string} basePath The base path for all code.
 		 * @param {Object} instrumenterOptions Extra options for the instrumenter
 		 */
-		setInstrumentationHooks: function (excludeInstrumentation, basePath, coverageVariable, instrumenterOptions) {
+		setInstrumentationHooks: function (excludeInstrumentation, basePath, instrumenterOptions) {
 			var self = this;
 
 			basePath = self.normalizePath(pathUtil.resolve(basePath || '') + pathUtil.sep);
@@ -876,7 +876,7 @@ define([
 			}
 
 			function hookTransformer(code, filename) {
-				return self.instrument(code, pathUtil.resolve(filename), coverageVariable, instrumenterOptions);
+				return self.instrument(code, pathUtil.resolve(filename), instrumenterOptions);
 			}
 
 			hook.hookRunInThisContext(hookMatcher, hookTransformer);
@@ -896,13 +896,16 @@ define([
 		 *
 		 * @param filedata Text of file being instrumented
 		 * @param filepath Full path of file being instrumented
-		 * @param coverageVariable The global variable that should be used to store code coverage data
 		 * @param instrumenterOptions Extra options for the instrumenter
 		 *
 		 * @returns {string} A string of instrumented code
 		 */
-		instrument: function (filedata, filepath, coverageVariable, instrumenterOptions) {
-			var instrumenter = getInstrumenter(coverageVariable, instrumenterOptions);
+		instrument: function (filedata, filepath, instrumenterOptions) {
+			if (!instrumenterOptions) {
+				instrumenterOptions = {};
+			}
+
+			var instrumenter = getInstrumenter(instrumenterOptions);
 
 			var opts = instrumenter.opts;
 


### PR DESCRIPTION
The instrumentOptions property will be merged into the default options object passed to istanbul's Instrumenter constructor.

---

intern 3.1 uses istanbul 0.4.1 which uses escodegen 1.7.x. Starting from this version escodegen converts unicode string literals to utf-8 bytes more frequently, and requires an option `verbatim: "raw"` to revert to the old behavior. This breaks my testing and I've opened https://github.com/gotwarlost/istanbul/issues/591 to get their view on whether istanbul should set this by default or users of istanbul should.

Regardless of how that's decided, specifying arbitrary options for `Instrumenter` may be useful for other people for other reasons in the future, so I figured I'd make it available in any case.

```irc
<Arnavion> Does anyone have an opinion on   https://github.com/gotwarlost/istanbul/issues/591   ? i.e. should it be istanbul's responsibility to enable `verbatim: "raw"` in the options it gives to escodegen by default? Or should intern specify it in the options it gives to istanbul? Or should intern accept this option from the user?
<Arnavion> As it currently stands I'm unable to move from intern@3.0.x to 3.1.x because of this
<jason0x43> So the previous behavior was the equivalent of setting `verbatim: 'raw'`, and if the option can be set as an option during Instrumenter creation, I think it's reasonable for Intern to do that (and, in fact, is desirable since it would restore the previous default behavior).
<jason0x43> *So if the previous behavior…
<jason0x43> Although Istanbul doing it would make more sense if it was a breaking change from previous versions.
<Arnavion> If my case is a fringe case I'm more than happy to pass in the option myself to intern and have it propagated to istanbul
<Arnavion> (Regardless of this particular setting, intern might want to allow that in any case)
```