### PR TITLE
Add new 'rawIO' option to disable stderr/stdio piping

### DIFF
--- a/tasks/intern.js
+++ b/tasks/intern.js
@@ -113,7 +113,8 @@ module.exports = function (grunt) {
 			args: args,
 			opts: {
 				cwd: opts.cwd || process.cwd(),
-				env: env
+				env: env,
+				stdio: opts.rawIO ? 'inherit' : 'pipe'
 			}
 		}, function (error) {
 			// The error object from grunt.util.spawn contains information
@@ -121,7 +122,9 @@ module.exports = function (grunt) {
 			done(error ? new Error('Test failure; check output above for details.') : null);
 		});
 
-		child.stdout.on('data', readOutput);
-		child.stderr.on('data', readOutput);
+		if (!opts.rawIO) {   
+			child.stdout.on('data', readOutput);
+			child.stderr.on('data', readOutput);
+		}
 	});
 };


### PR DESCRIPTION
By default, the Node.JS stdio is piped through to a function to handle it—`logOutput()`—however this causes a problem with [my custom reporter](https://github.com/Alfresco/Aikau/blob/master/aikau/src/test/resources/reporters/ConcurrentReporter.js). Specifically, not all `console.log()` outputs are emitted prior to any stderr writes. What this means is that, when [outputting a large set of results to the console](https://github.com/Alfresco/Aikau/blob/master/aikau/src/test/resources/reporters/ConcurrentReporter.js#L886), and if any errors occurred in any suites, then the Executor will throw an error just as the results are starting to be output, swallowing the remaining results. For an hour-long test run with maybe a hundred or more lines of detailed test failures/errors, this is disastrous. By directly passing console output through to the parent process, my custom reporter is able to complete its output before the `self._hasSuiteErrors` test in `Executor.js` throws an error to the console, breaking the stdout output.

As further confirmation of this issue, if I have a `console.error()` statement after all of my `console.log()` statements, then that statement will output immediately prior to this Executor error, even though the majority of the preceding `console.log()` statements never make it to the console.

The fix is to permit an extra option to be passed in—`rawIO`—which allows the parent process to directly receive these statements, rather than having them piped through an event mechanism which seems to inaccurately flush its queues (this is an educated guess, but by no means prescriptive of the issue). Because this is a new option, it cannot affect any existing usage of Intern by anyone. This absolutely does fix my test case using my custom reporter.

_Full disclosure: SIGINT behaviour seems to be to kill the grunt task as well, so using `rawIO` will have that caveat until this is resolved (I can't find a quick solution at the moment)._

