### PR TITLE
Ignore code cache after modification

### DIFF
--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -132,53 +132,59 @@ define([
 			}
 
 			var contentType = mimetype.lookup(path.basename(wholePath)) || 'application/octet-stream';
-			if (instrument) {
-				if (self._codeCache[wholePath]) {
-					send(contentType, self._codeCache[wholePath]);
+			fs.stat(wholePath, function (error, status) {
+				// The proxy server was stopped in the middle of the file stat
+				if (!self.server) {
+					return;
+				}
+
+				if (error) {
+					self._send404(response);
+					return;
+				}
+
+				if (instrument) {
+					var mtime = status.mtime.getTime();
+					if (self._codeCache[wholePath] && self._codeCache[wholePath].mtime === mtime) {
+						send(contentType, self._codeCache[wholePath].data);
+					}
+					else {
+						fs.readFile(wholePath, 'utf8', function (error, data) {
+							// The proxy server was stopped in the middle of the file read
+							if (!self.server) {
+								return;
+							}
+
+							if (error) {
+								self._send404(response);
+								return;
+							}
+
+							// providing `wholePath` to the instrumenter instead of a partial filename is necessary because
+							// lcov.info requires full path names as per the lcov spec
+							data = util.instrument(
+								data.toString('utf-8'),
+								wholePath,
+								self.config.instrumenterOptions
+							);
+							self._codeCache[wholePath] = {
+								// strictly speaking mtime could reflect a previous version, assume those race conditions are rare
+								mtime: mtime,
+								data: data
+							};
+							send(contentType, data);
+						});
+					}
 				}
 				else {
-					fs.readFile(wholePath, 'utf8', function (error, data) {
-						// The proxy server was stopped in the middle of the file read
-						if (!self.server) {
-							return;
-						}
-
-						if (error) {
-							self._send404(response);
-							return;
-						}
-
-						// providing `wholePath` to the instrumenter instead of a partial filename is necessary because
-						// lcov.info requires full path names as per the lcov spec
-						data = self._codeCache[wholePath] = util.instrument(
-							data.toString('utf-8'),
-							wholePath,
-							self.config.instrumenterOptions
-						);
-						send(contentType, data);
-					});
-				}
-			}
-			else {
-				fs.stat(wholePath, function (error, status) {
-					// The proxy server was stopped in the middle of the file stat
-					if (!self.server) {
-						return;
-					}
-
-					if (error) {
-						self._send404(response);
-						return;
-					}
-
 					response.writeHead(200, {
 						'Content-Type': contentType,
 						'Content-Length': status.size
 					});
 
 					fs.createReadStream(wholePath).pipe(response);
-				});
-			}
+				}
+			});
 		},
 
 		_publishInSequence: function (message) {


### PR DESCRIPTION
The code cache in the proxy contains instrumented code. Store the mtime of the original file along with the instrumentation data. When serving the file, if the mtime has changed ignore the cached data and instrument the code again.

Fixes #624.

I couldn't quite see whether this logic has test coverage, or indeed run the test suite locally. The change detection worked with my local project. Let me know if you want me to add tests, and where.