### PR TITLE
Fix wrong numFailedTests in Pretty

### DIFF
--- a/lib/Suite.js
+++ b/lib/Suite.js
@@ -260,6 +260,9 @@ define([
 					suite.async = undefined;
 
 					if (error !== Test.SKIP) {
+						if (name === "beforeEach"){
+							error.relatedTest = args[0];
+						}
 						return reportSuiteError(error);
 					}
 				});

--- a/lib/reporters/Pretty.js
+++ b/lib/reporters/Pretty.js
@@ -54,18 +54,24 @@ define([
 			return this.results.length;
 		},
 
-		record: function (result) {
-			this.results.push(result);
+		record: function (result, numTests) {
+			// by default numTests = 1
+			numTests = numTests !== undefined ? numTests : 1;
+
+			for(var i = 0; i < numTests; i++){
+				this.results.push(result);
+			}
+
 			switch (result) {
-			case PASS:
-				++this.numPassed;
-				break;
-			case SKIP:
-				++this.numSkipped;
-				break;
-			case FAIL:
-				++this.numFailed;
-				break;
+				case PASS:
+					this.numPassed += numTests;
+					break;
+				case SKIP:
+					this.numSkipped += numTests;
+					break;
+				case FAIL:
+					this.numFailed += numTests;
+					break;
 			}
 		},
 
@@ -196,7 +202,14 @@ define([
 		},
 
 		suiteError: function (suite, error) {
-			this._record(suite.sessionId, FAIL);
+			var numTests = 1;
+
+			if (!suite.error.relatedTest) {
+				// when suite has error in `before`, all tests in that suite are going to be recorded as FAIL
+				numTests = suite.numTests;
+			}
+
+			this._record(suite.sessionId, FAIL, numTests);
 
 			var message = '! ' + suite.id;
 			this.log.push(message + '\n' + internUtil.getErrorMessage(error));
@@ -274,10 +287,10 @@ define([
 			return charm;
 		},
 
-		_record: function (sessionId, result) {
+		_record: function (sessionId, result, numTests) {
 			var reporter = this.reporters[sessionId];
-			reporter && reporter.record(result);
-			this.total.record(result);
+			reporter && reporter.record(result, numTests);
+			this.total.record(result, numTests);
 		},
 
 		/**


### PR DESCRIPTION
This PR is supposed to fix the wrong numFailedTests in Pretty reporter of the issue #629 

Currently we have the same treatment for suiteError which happens in `before` and `beforeEach`. But it causes the numFailedTests to be off, because with the error in `before`, that suite will run only 1 time and 1 fail will be recorded.
By adding `relatedTest` information to the suiteError for the `beforeEach` case, we can count the numFailedTests in the reporter correctly.

