### PR TITLE
Implement callback api to TDD and BDD interfaces

### DIFF
--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -33,6 +33,24 @@ define([
 		},
 
 		test: function (name, test) {
+			// If the test function takes an argument, wrap it with deffered object to
+			// gently run asynchronous tests against callback-style
+			// for the compatibility with other test frameworks
+			if (test.length === 1) {
+				var oldTest = test;
+
+				test = function () {
+					var dfd = this.async();
+					var callback = dfd.callback(function (error) {
+						if (error) {
+							throw error;
+						}
+					});
+
+					return oldTest(callback);
+				};
+			}
+
 			currentSuite.tests.push(new Test({ name: name, test: test, parent: currentSuite }));
 		},
 

--- a/tests/unit/lib/interfaces/tdd.js
+++ b/tests/unit/lib/interfaces/tdd.js
@@ -103,6 +103,32 @@ define([
 				assert.deepEqual(results, expectedResults,
 					'TDD interface should correctly register special lifecycle methods on the Suite');
 			});
+		},
+
+		'Async test case with callback function': function () {
+			var error = new Error();
+
+			tdd.suite('root suite', function () {
+				tdd.test('async test', function (done) {
+					setTimeout(function () {
+						done();
+					}, 0);
+				});
+
+				tdd.test('async test with error', function (done) {
+					setTimeout(function () {
+						done(error);
+					}, 0);
+				});
+			});
+
+			return rootSuites[0].run().then(function () {
+				assert.strictEqual(rootSuites[0].tests[0].tests[0].isAsync, true);
+				assert.strictEqual(rootSuites[0].tests[0].tests[0].error, null);
+
+				assert.strictEqual(rootSuites[0].tests[0].tests[1].isAsync, true);
+				assert.strictEqual(rootSuites[0].tests[0].tests[1].error, error);
+			});
 		}
 	});
 });


### PR DESCRIPTION
Hello. I'm a student from Japan accepted for this year's GSoC program of Intern. I'm sending this pull request as my practice for diving into Intern's codebase.

Anyway, I recently migrated my JavaScript test codes written for mocha into Intern. It was almost nicely done, but I found some difficulty when my code uses asynchronous test cases.

Though Intern's user guide states that "Intern always uses Promise," it will be nice to have callback-style syntax for TDD and BDD interfaces as "non-recommended way" to preserve compatibility with such test codes, especially for the people who already have test suites like mocha and Jasmine.

I simply wrapped the provided test function with another function which returns deferred object when the test function takes an argument. So this may be compatible with the traditional callback-style syntax at least used in mocha or Jasmine.