### PR TITLE
Use test/suite [name] instead of [id] in TeamCity report

### DIFF
--- a/lib/reporters/TeamCity.js
+++ b/lib/reporters/TeamCity.js
@@ -64,16 +64,16 @@ define(['../util'], function (util) {
 		},
 
 		testStart: function (test) {
-			this._sendMessage('testStarted', { name: test.id, flowId: test.sessionId });
+			this._sendMessage('testStarted', { name: test.name, flowId: test.sessionId });
 		},
 
 		testSkip: function (test) {
-			this._sendMessage('testIgnored', { name: test.id, flowId: test.sessionId });
+			this._sendMessage('testIgnored', { name: test.name, flowId: test.sessionId });
 		},
 
 		testEnd: function (test) {
 			this._sendMessage('testFinished', {
-				name: test.id,
+				name: test.name,
 				duration: test.timeElapsed,
 				flowId: test.sessionId
 			});
@@ -81,7 +81,7 @@ define(['../util'], function (util) {
 
 		testFail: function (test) {
 			var message = {
-				name: test.id,
+				name: test.name,
 				message: util.getErrorMessage(test.error),
 				flowId: test.sessionId
 			};
@@ -96,24 +96,16 @@ define(['../util'], function (util) {
 		},
 
 		suiteStart: function (suite) {
-			if (!suite.parent) {
-				return;
-			}
-
 			this._sendMessage('testSuiteStarted', {
-				name: suite.id,
+				name: suite.name,
 				startDate: new Date(),
 				flowId: suite.sessionId
 			});
 		},
 
 		suiteEnd: function (suite) {
-			if (!suite.parent) {
-				return;
-			}
-
 			this._sendMessage('testSuiteFinished', {
-				name: suite.id,
+				name: suite.name,
 				duration: suite.timeElapsed,
 				flowId: suite.sessionId
 			});
@@ -121,7 +113,7 @@ define(['../util'], function (util) {
 
 		suiteError: function (suite) {
 			this._sendMessage('message', {
-				name: suite.id,
+				name: suite.name,
 				flowId: suite.sessionId,
 				text: 'SUITE ERROR',
 				errorDetails: util.getErrorMessage(suite.error),

--- a/tests/unit/lib/reporters/TeamCity.js
+++ b/tests/unit/lib/reporters/TeamCity.js
@@ -8,18 +8,18 @@ define([
 	'../../../../lib/util'
 ], function (registerSuite, assert, MockStream, Suite, Test, TeamCity, util) {
 	var messagePatterns = {
-		suiteStart: '^##teamcity\\[testSuiteStarted name=\'{id}\'',
-		suiteEnd: '^##teamcity\\[testSuiteFinished name=\'{id}\' duration=\'\\d+\'',
-		testStart: '^##teamcity\\[testStarted name=\'{id}\'',
-		testSkip: '^##teamcity\\[testIgnored name=\'{id}\'',
-		testEnd: '^##teamcity\\[testFinished name=\'{id}\' duration=\'\\d+\'',
-		testFail: '^##teamcity\\[testFailed name=\'{id}\' message=\'{message}\''
+		suiteStart: '^##teamcity\\[testSuiteStarted name=\'{name}\'',
+		suiteEnd: '^##teamcity\\[testSuiteFinished name=\'{name}\' duration=\'\\d+\'',
+		testStart: '^##teamcity\\[testStarted name=\'{name}\'',
+		testSkip: '^##teamcity\\[testIgnored name=\'{name}\'',
+		testEnd: '^##teamcity\\[testFinished name=\'{name}\' duration=\'\\d+\'',
+		testFail: '^##teamcity\\[testFailed name=\'{name}\' message=\'{message}\''
 	};
 
 	function testSuite(suite, topic, type) {
 		var output = new MockStream();
 		var reporter = new TeamCity({ output: output });
-		var expected = messagePatterns[topic].replace('{id}', suite.id);
+		var expected = messagePatterns[topic].replace('{name}', suite.name);
 
 		reporter[topic](suite);
 		assert.ok(output.data, 'Data should be output when the reporter ' + topic + ' method is called');
@@ -32,7 +32,7 @@ define([
 	function testTest(test, topic, type) {
 		var output = new MockStream();
 		var reporter = new TeamCity({ output: output });
-		var expected = messagePatterns[topic].replace('{id}', test.id);
+		var expected = messagePatterns[topic].replace('{name}', test.name);
 
 		if (test.error) {
 			// n.b., only the `testFail` messagePattern has a `{message}` placeholder


### PR DESCRIPTION
TeamCity report wraps tests by suite. Currently in Intern we use test/suite `id` (which are made by adding the parent suite name to the current test/suite name) to display tests in the report. You can see that the reports look quite a mess with repeated information.
By using `name`, the reports will look much cleaner.
Before:
![teamcity_before](https://cloud.githubusercontent.com/assets/4546284/17098471/dd589aba-5262-11e6-96c2-e99d54b00ac7.PNG)
After:
![teamcity_after](https://cloud.githubusercontent.com/assets/4546284/17098476/e18e96b6-5262-11e6-85fd-165d423859e1.PNG)

One more thing you can notice is when the test name becomes too long (because of nested suites), TeamCity will give a wrong test number. (In my example, TeamCity says 18 tests instead of 26)
