### PR TITLE
fix(proxy): allow HEAD requests

### DIFF
--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -43,6 +43,9 @@ define([
 					this._handleFile(request, response);
 				}
 			}
+			else if (request.method === 'HEAD') {
+				this._handleFile(request, response, false, true);
+			}
 			else if (request.method === 'POST') {
 				request.setEncoding('utf8');
 
@@ -92,7 +95,7 @@ define([
 			}
 		},
 
-		_handleFile: function (request, response, instrument) {
+		_handleFile: function (request, response, instrument, omitContent) {
 			function send(contentType, data) {
 				response.writeHead(200, {
 					'Content-Type': contentType,
@@ -176,7 +179,11 @@ define([
 						'Content-Length': status.size
 					});
 
-					fs.createReadStream(wholePath).pipe(response);
+					if (omitContent) {
+						response.end();
+					} else {
+						fs.createReadStream(wholePath).pipe(response);	
+					}
 				});
 			}
 		},


### PR DESCRIPTION
In some situations a browser will make a [HEAD](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4) request prior to the GET request to actually fetch the resource.

This is the case for `<object type="image/svg+xml" data="test.svg">` in Internet Explorer. Without properly answering the HEAD request IE will *not* load the SVG.