### PR TITLE
fix(reporter.html): hide fully passed suites

### DIFF
--- a/lib/reporters/Html.js
+++ b/lib/reporters/Html.js
@@ -318,6 +318,10 @@ define([
 				cellNode.appendChild(testsPassed);
 			}
 
+			if (!numFailedTests) {
+				rowNode.className += ' passed';
+			}
+
 			cellNode.className = 'column-info';
 			rowNode.appendChild(cellNode);
 


### PR DESCRIPTION
The HTML reporter has an option »Show only failed tests« which is meant to hide all passed *tests*. This change also hides the *suites* not having any failed tests. This is extremely helpful when working with *many* suites.