### PR TITLE
fix(html reporter): toggle visibility in IE10

### DIFF
--- a/lib/reporters/Html.js
+++ b/lib/reporters/Html.js
@@ -211,7 +211,7 @@ define([
 				}
 
 				// Only show children one level under the suite being updated when expanding
-				node.style.display = (!collapsed && indentDelta === 1) ? null : 'none';
+				node.style.display = (!collapsed && indentDelta === 1) ? '' : 'none';
 			}
 		}
 


### PR DESCRIPTION
it turns out that setting the property to `null` does nothing in IE10. You need to set the value to the empty string in order to overwrite it.