### PR TITLE
Moved @types into devDependencies in package.json (from dependencies)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
     "lodash-amd": "4.16.4",
     "mimetype": "0.0.8",
     "platform": "1.3.1",
-    "source-map": "0.1.33",
-    "@types/chai": "3.4.34",
-    "@types/node": "6.0.48"
+    "source-map": "0.1.33"
   },
   "devDependencies": {
-    "intern": "3.2.3"
+    "intern": "3.2.3",
+    "@types/chai": "3.4.34",
+    "@types/node": "6.0.48"
   },
   "scripts": {
     "install": "node support/fixdeps.js",


### PR DESCRIPTION
Was there a specific reason for having @types/node and @types/chai in package.json's dependencies rather than devDependencies? Having them in package.json's dependencies causes compiler warnings/errors when building Typescript projects (version 2 and up tested) that are not using node_modules/@types to store type definitions. Manually removing the folders gets rid of the errors, but every time a new package is installed, they return.

Type definitions should be in devDependencies anyway, especially for definitions as widely used as Node's.