### PR TITLE
config.benchmarkSuites should be an array, not a string

### DIFF
--- a/lib/executors/PreExecutor.js
+++ b/lib/executors/PreExecutor.js
@@ -103,7 +103,7 @@ define([
 				kwArgs = parseArgs.fromCommandLine(process.argv.slice(2));
 			}
 
-			[ 'environments', 'functionalSuites', 'reporters', 'suites' ].forEach(function (name) {
+			[ 'environments', 'functionalSuites', 'reporters', 'suites', 'benchmarkSuites' ].forEach(function (name) {
 				var value = kwArgs[name];
 				if (value != null && !Array.isArray(value)) {
 					kwArgs[name] = value === '' ? [] : [ value ];


### PR DESCRIPTION
Hello!

When I tried to enable benchmarks for my project, I got an exeption
```
TypeError: moduleIds.reduce is not a function
  at Object.resolveModuleIds  <node_modules/intern/lib/util.js:790:21>
  at <node_modules/intern/lib/executors/PreExecutor.js:439:28>
  at new Promise  <node_modules/intern/browser_modules/dojo/Promise.ts:411:3>
  at resolveSuites  <node_modules/intern/lib/executors/PreExecutor.js:438:16>
  at <node_modules/intern/browser_modules/dojo/Promise.ts:393:15>
  at runCallbacks  <node_modules/intern/browser_modules/dojo/Promise.ts:11:11>
  at <node_modules/intern/browser_modules/dojo/Promise.ts:317:4>
  at run  <node_modules/intern/browser_modules/dojo/Promise.ts:237:7>
  at <node_modules/intern/browser_modules/dojo/nextTick.ts:44:3>
  at _combinedTickCallback  <internal/process/next_tick.js:67:7>
```

It happen because function intern/lib/util.resolveModuleIds should accept an array, but it got string instead.

Seems what you forget cast string to array?