### PR TITLE
Fix typo in benchmark example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1448,7 +1448,7 @@
 			// benchmark that returns a Promise or resolves the passed in deferred object
 		})
 	});
-}</code></pre>
+});</code></pre>
 
 						<p>Intern's benchmarking support is based on <a href="https://benchmarkjs.com">Benchmark.js</a>, which accepts configuration options beyond the standard ones provided through Intern. To pass additional options directly to Benchmark.js, attach them as an "options" property to the test function.</p>
 


### PR DESCRIPTION
You miss a `);` in the code example.