### PR TITLE
Add currentTest to suite

### DIFF
--- a/lib/Suite.js
+++ b/lib/Suite.js
@@ -15,6 +15,7 @@ define([
 	// BAIL_REASON needs to be a string so that Intern can tell when a remote has bailed during unit tests so that it
 	// can skip functional tests.
 	var BAIL_REASON = 'bailed';
+	var _currentTest = null;
 
 	Suite.prototype = {
 		constructor: Suite,
@@ -194,6 +195,12 @@ define([
 		set timeout(value) {
 			this._timeout = value;
 		},
+		/**
+		 * The currently running test in the suite
+		 */
+		get currentTest() {
+			return _currentTest;
+		},
 
 		/**
 		 * Runs test suite in order:
@@ -359,6 +366,8 @@ define([
 			function runTests() {
 				var i = 0;
 				var tests = self.tests;
+
+				_currentTest = tests[i];
 
 				return new Promise(function (resolve, reject, progress, setCanceler) {
 					var current;


### PR DESCRIPTION
It's good to know which test is currently running, so we can interact with it in `beforeEach/afterEach` 