### PR TITLE
Add currentTest to suite

### DIFF
--- a/lib/Suite.js
+++ b/lib/Suite.js
@@ -39,6 +39,8 @@ define([
 		 */
 		publishAfterSetup: false,
 
+		_currentTest: null,
+
 		/**
 		 * A flag used to indicate whether a test run shoudl stop after a failed test.
 		 */
@@ -194,6 +196,20 @@ define([
 		set timeout(value) {
 			this._timeout = value;
 		},
+		/**
+		 * The currently running test in the suite
+		 */
+		get currentTest() {
+			return this._currentTest;
+		},
+
+		set currentTest(value) {
+			var suite = this;
+			do {
+				suite._currentTest = value;
+			} while ((suite = suite.parent));
+		},
+
 
 		/**
 		 * Runs test suite in order:
@@ -415,6 +431,8 @@ define([
 						}
 						// test is a single test
 						else {
+							self.currentTest = test;
+
 							if (!self.grep.test(test.id)) {
 								test.skipped = 'grep';
 							}


### PR DESCRIPTION
It's good to know which test is currently running, so we can interact with it, for example, in beforeEach/afterEach
