### PR TITLE
Unpin dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,24 +10,24 @@
   },
   "license": "BSD-3-Clause",
   "dependencies": {
-    "benchmark": "2.1.1",
-    "chai": "3.5.0",
-    "charm": "0.2.0",
-    "diff": "1.1.0",
-    "digdug": "~1.6.0",
+    "benchmark": "^2.1.1",
+    "chai": "^3.5.0",
+    "charm": "^0.2.0",
+    "diff": "^1.1.0",
+    "digdug": "^1.6.0",
     "dojo": "2.0.0-alpha.7",
-    "glob": "7.0.3",
-    "istanbul": "0.4.1",
-    "leadfoot": "~1.7.0",
-    "lodash-amd": "4.16.4",
-    "mimetype": "0.0.8",
-    "platform": "1.3.1",
-    "source-map": "0.1.33",
-    "@types/chai": "3.4.34",
-    "@types/node": "6.0.48"
+    "glob": "^7.0.3",
+    "istanbul": "^0.4.1",
+    "leadfoot": "^1.7.0",
+    "lodash-amd": "^4.16.4",
+    "mimetype": "^0.0.8",
+    "platform": "^1.3.1",
+    "source-map": "^0.1.33",
+    "@types/chai": "^3.4.34",
+    "@types/node": "^6.0.48"
   },
   "devDependencies": {
-    "intern": "3.2.3"
+    "intern": "^3.2.3"
   },
   "scripts": {
     "install": "node support/fixdeps.js",


### PR DESCRIPTION
Intern has previously had a very inconsistent use of pinned and unpinned dependencies. This PR aims to normalize that and improve the user experience when upstream features are released that do not require code changes to Intern (e.g. new tunnels or env vars added to [DigDug](https://github.com/theintern/digdug)).

The basic premise here is that whatever gain is had from pinning the immediate dependencies is cancelled out by virtue of the nested dependencies using ranges themselves (extremely common, in part due to `npm` defaults).

So in effect, prior to this PR, Intern still experiences the dangers of version ranges, but without the benefits. I think Intern should either [shrinkwrap](https://docs.npmjs.com/cli/shrinkwrap) its dependencies or use this PR.

I left `dojo` alone since it is pinned to a pre-release version. Using `^2.0.0-alpha.7` is valid, but since it matches both pre-releases and releases, if a breaking change happens prior to a proper release, that would be problematic, which seems within the realm of possibility (and is allowed by [the spec](http://semver.org/#spec-item-9)).