### PR TITLE
Allow equals sign in arg string

### DIFF
--- a/src/lib/common/util.ts
+++ b/src/lib/common/util.ts
@@ -86,7 +86,7 @@ export function normalizePath(path: string) {
 export function parseArgs(rawArgs: string[]) {
 	const args: { [key: string]: any } = {};
 	rawArgs.forEach(arg => {
-		let [name, value] = arg.split('=', 2);
+		let [name, value] = arg.split(/=(.*)/, 2);
 
 		if (typeof value === 'undefined') {
 			args[name] = true;


### PR DESCRIPTION
Currently, there is no way to pass a string containing an equals sign into intern.args. This might be necessary sometimes, for example when running tests with a protected URL token. 

Behavior before change: Everything before the first equals sign in an arg is the name, the substring between the first and second equals sign is the value
Behavior after change: Everything before the first equals sign in an arg is the name, everything after the first equals sign is the value