### PR TITLE
improve check for absolute paths in Executor#_loadReporters to support Windows

### DIFF
--- a/lib/executors/Executor.js
+++ b/lib/executors/Executor.js
@@ -5,7 +5,8 @@ define([
 	'../../main',
 	'../ReporterManager',
 	'../util',
-	'require'
+	'require',
+	'dojo/has!host-node?dojo/node!path'
 ], function (
 	has,
 	lang,
@@ -13,7 +14,8 @@ define([
 	intern,
 	ReporterManager,
 	util,
-	require
+	require,
+	pathUtil
 ) {
 	function Executor(config, preExecutor) {
 		this.config = lang.deepDelegate(this.config, config);
@@ -192,7 +194,7 @@ define([
 					id = reporter.id;
 				}
 
-				if (id.indexOf('/') === -1) {
+				if (id.indexOf('/') === -1 && (has('host-node') && !pathUtil.isAbsolute(id))) {
 					id = '../reporters/' + id;
 				}
 


### PR DESCRIPTION
If an absolute path is provided for a custom reporter, it is not properly detected on Windows, when running with node. This PR adds an additional check for absolute paths using node's path module.