### PR TITLE
Include coverage sources with glob patterns in Intern 4

### DIFF
--- a/intern.json
+++ b/intern.json
@@ -96,8 +96,6 @@
 
 		"coverage": {
 			"description": "Generate full coverage",
-			// "benchmark": true,
-			// "extends": [ "allSuites" ]
 			"coverage": [
 				"_build/src/lib/**/*.js",
 				"_build/src/bin/**/*.js",

--- a/intern.json
+++ b/intern.json
@@ -95,13 +95,15 @@
 		},
 
 		"coverage": {
+			"benchmark": true,
 			"description": "Generate full coverage",
 			"coverage": [
 				"_build/src/lib/**/*.js",
 				"_build/src/bin/**/*.js",
 				"_build/src/loaders/**/*.js",
 				"_build/src/tasks/**/*.js"
-			]
+			],
+			"extends": [ "allSuites" ]
 		},
 
 		"wd": {

--- a/intern.json
+++ b/intern.json
@@ -47,7 +47,7 @@
 			"_tests/tests/unit/tasks/intern.js"
 		],
 		"plugins": "_tests/tests/support/nodeMocking.js",
-		"reporters": { "name": "runner", "options": { "hideSkipped": true, "hidePassed": false } }
+		"reporters": { "name": "runner", "options": { "hideSkipped": true, "hidePassed": true } }
 	},
 
 	"browser": {
@@ -75,7 +75,6 @@
 	},
 
 	"benchmark": false,
-	"excludeInstrumentation": "(?:node_modules|_tests)/",
 	"filterErrorStack": true,
 	"internPath": "_tests/src",
 
@@ -88,24 +87,23 @@
 			]
 		},
 
-		"fast": {
-			"description": "For running unit tests quickly",
-			"excludeInstrumentation": true,
+		"progress": {
+			"description": "For showing test progress",
 			"node": {
-				"reporters": { "name": "runner", "options": { "hideSkipped": true, "hidePassed": true } }
+				"reporters": { "name": "runner", "options": { "hideSkipped": true, "hidePassed": false } }
 			}
 		},
 
 		"coverage": {
 			"description": "Generate full coverage",
-			"benchmark": true,
-			"coverageSources": [
+			// "benchmark": true,
+			// "extends": [ "allSuites" ]
+			"coverage": [
 				"_build/src/lib/**/*.js",
 				"_build/src/bin/**/*.js",
 				"_build/src/loaders/**/*.js",
 				"_build/src/tasks/**/*.js"
-			],
-			"extends": [ "allSuites" ]
+			]
 		},
 
 		"wd": {

--- a/src/lib/executors/Node.ts
+++ b/src/lib/executors/Node.ts
@@ -493,7 +493,7 @@ export default class Node extends Executor<Events, Config, NodePlugins> {
 			case 'excludeInstrumentation':
 				this.emit('deprecated', {
 					original: 'excludeInstrumentation',
-					replacement: 'instrument'
+					replacement: 'coverage'
 				});
 				if (value === true) {
 					this._setOption(name, value);

--- a/src/lib/node/util.ts
+++ b/src/lib/node/util.ts
@@ -22,9 +22,23 @@ export function expandFiles(patterns?: string[] | string) {
 		patterns = [patterns];
 	}
 
-	const excludes = patterns.filter(pattern => pattern[0] === '!');
-	const includes = patterns.filter(pattern => pattern[0] !== '!' && hasMagic(pattern));
-	const paths = patterns.filter(pattern => pattern[0] !== '!' && !hasMagic(pattern));
+	const excludes: string[] = [];
+	const includes: string[] = [];
+	const paths: string[] = [];
+
+	for (let pattern of patterns) {
+		if (pattern[0] === '!') {
+			excludes.push(pattern.slice(1));
+		}
+		else {
+			if (hasMagic(pattern)) {
+				includes.push(pattern);
+			}
+			else {
+				paths.push(pattern);
+			}
+		}
+	}
 
 	return includes
 		.map(pattern => glob(pattern, { ignore: excludes }))

--- a/tests/support/unit/executor.ts
+++ b/tests/support/unit/executor.ts
@@ -9,13 +9,30 @@ export function testProperty<E extends Executor = Executor, C extends Config = C
 	badValue: any,
 	goodValue: any,
 	expectedValue: any,
-	error: RegExp, message?: string
+	error: RegExp,
+	allowDeprecated?: boolean | string,
+	message?: string
 ) {
+	if (typeof allowDeprecated === 'string') {
+		message = allowDeprecated;
+		allowDeprecated = undefined;
+	}
+	if (typeof allowDeprecated === 'undefined') {
+		allowDeprecated = false;
+	}
+
 	assert.throws(() => { executor.configure(<any>{ [name]: badValue }); }, error);
 	executor.configure(<any>{ [name]: goodValue });
-	for (let call of mockConsole.warn.getCalls()) {
-		assert.include(call.args[0], 'deprecated', 'no warning should have been emitted');
+
+	if (allowDeprecated) {
+		for (let call of mockConsole.warn.getCalls()) {
+			assert.include(call.args[0], 'deprecated', 'no warning should have been emitted');
+		}
 	}
+	else {
+		assert.equal(mockConsole.warn.callCount, 0, 'no warning should have been emitted');
+	}
+
 	name = <keyof Config>name.replace(/\+$/, '');
 	const config = <C>executor.config;
 	if (typeof expectedValue === 'object') {

--- a/tests/support/unit/executor.ts
+++ b/tests/support/unit/executor.ts
@@ -13,7 +13,9 @@ export function testProperty<E extends Executor = Executor, C extends Config = C
 ) {
 	assert.throws(() => { executor.configure(<any>{ [name]: badValue }); }, error);
 	executor.configure(<any>{ [name]: goodValue });
-	assert.equal(mockConsole.warn.callCount, 0, 'no warning should have been emitted');
+	for (let call of mockConsole.warn.getCalls()) {
+		assert.include(call.args[0], 'deprecated', 'no warning should have been emitted');
+	}
 	name = <keyof Config>name.replace(/\+$/, '');
 	const config = <C>executor.config;
 	if (typeof expectedValue === 'object') {

--- a/tests/unit/lib/executors/Executor.ts
+++ b/tests/unit/lib/executors/Executor.ts
@@ -144,7 +144,6 @@ registerSuite('lib/executors/Executor', function () {
 					coverageVariable: '__coverage__',
 					debug: false,
 					defaultTimeout: 30000,
-					excludeInstrumentation: /(?:node_modules|browser|tests)\//,
 					filterErrorStack: false,
 					grep: new RegExp(''),
 					loader: { script: 'default' },
@@ -253,12 +252,6 @@ registerSuite('lib/executors/Executor', function () {
 						defaultTimeout() {
 							test('defaultTimeout', 'foo', 5, 5, /Non-numeric value/);
 							test('defaultTimeout', 'foo', '5', 5, /Non-numeric value/);
-						},
-
-						excludeInstrumentation() {
-							test('excludeInstrumentation', 5, true, true, /Invalid value/);
-							test('excludeInstrumentation', 5, /foo/, /foo/, /Invalid value/);
-							test('excludeInstrumentation', 5, 'foo', /foo/, /Invalid value/);
 						},
 
 						grep() {

--- a/tests/unit/lib/executors/Executor.ts
+++ b/tests/unit/lib/executors/Executor.ts
@@ -442,7 +442,6 @@ registerSuite('lib/executors/Executor', function () {
 						'    "coverageVariable": "__coverage__",\n' +
 						'    "debug": false,\n' +
 						'    "defaultTimeout": 30000,\n' +
-						'    "excludeInstrumentation": {},\n' +
 						'    "filterErrorStack": false,\n' +
 						'    "grep": {},\n' +
 						'    "internPath": "",\n' +

--- a/tests/unit/lib/executors/Node.ts
+++ b/tests/unit/lib/executors/Node.ts
@@ -349,12 +349,18 @@ registerSuite('lib/executors/Node', function () {
 						test('tunnel', 5, 'null', 'null', /Non-string/);
 					},
 
+					excludeInstrumentation() {
+						test('excludeInstrumentation', 5, true, true, /Invalid value/);
+						test('excludeInstrumentation', 5, /foo/, /foo/, /Invalid value/);
+						test('excludeInstrumentation', 5, 'foo', /foo/, /Invalid value/);
+					},
+
 					functionalCoverage: booleanTest('functionalCoverage'),
 					leaveRemoteOpen: booleanTest('leaveRemoteOpen'),
 					serveOnly: booleanTest('serveOnly'),
 					runInSync: booleanTest('runInSync'),
 
-					coverageSources: stringArrayTest('coverageSources'),
+					coverage: stringArrayTest('coverage'),
 					functionalSuites: stringArrayTest('functionalSuites'),
 
 					connectTimeout: numberTest('connectTimeout'),

--- a/tests/unit/lib/executors/Node.ts
+++ b/tests/unit/lib/executors/Node.ts
@@ -436,7 +436,7 @@ registerSuite('lib/executors/Node', function () {
 					const dfd = this.async();
 					executor.configure({ basePath: 'bar' });
 					executor.on('beforeRun', dfd.callback(() => {
-						assert.isTrue(executor.shouldInstrumentFile('bar/foo.js'));
+						assert.isFalse(executor.shouldInstrumentFile('bar/foo.js'));
 					}));
 					executor.run();
 				},
@@ -532,7 +532,7 @@ registerSuite('lib/executors/Node', function () {
 						environments: 'chrome',
 						tunnel: 'null',
 						suites: 'foo.js',
-						coverageSources: ['foo.js']
+						coverage: ['foo.js']
 					});
 					return executor.run().then(() => {
 						assert.lengthOf(coverageMaps, 1);

--- a/tests/unit/lib/executors/Node.ts
+++ b/tests/unit/lib/executors/Node.ts
@@ -321,8 +321,8 @@ registerSuite('lib/executors/Node', function () {
 			},
 
 			'#configure': (() => {
-				function test(name: keyof Config, badValue: any, goodValue: any, expectedValue: any, error: RegExp, message?: string) {
-					testProperty<_Node, Config>(executor, mockConsole, name, badValue, goodValue, expectedValue, error, message);
+				function test(name: keyof Config, badValue: any, goodValue: any, expectedValue: any, error: RegExp, allowDeprecated?: boolean | string, message?: string) {
+					testProperty<_Node, Config>(executor, mockConsole, name, badValue, goodValue, expectedValue, error, allowDeprecated, message);
 				}
 
 				const booleanTest = (name: keyof Config) => () => { test(name, 5, 'true', true, /Non-boolean/); };
@@ -350,9 +350,9 @@ registerSuite('lib/executors/Node', function () {
 					},
 
 					excludeInstrumentation() {
-						test('excludeInstrumentation', 5, true, true, /Invalid value/);
-						test('excludeInstrumentation', 5, /foo/, /foo/, /Invalid value/);
-						test('excludeInstrumentation', 5, 'foo', /foo/, /Invalid value/);
+						test('excludeInstrumentation', 5, true, true, /Invalid value/, true);
+						test('excludeInstrumentation', 5, /foo/, /foo/, /Invalid value/, true);
+						test('excludeInstrumentation', 5, 'foo', /foo/, /Invalid value/, true);
 					},
 
 					functionalCoverage: booleanTest('functionalCoverage'),


### PR DESCRIPTION
This removes `coverageSources`, deprecates `excludeInstrumentation`, and adds `coverage` to the Intern config. It also adds the functionality to negate glob patterns in an array of patterns.