### PR TITLE
Fix coverage bugs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,7 +307,7 @@ Intern will automatically provide certain capabilities to provide better feedbac
 
 This property specifies an array of file paths or globs that should be instrumented for code coverage. This property should point to the actual JavaScript files that will be executed, not pre-transpiled sources (coverage results will still be mapped back to original sources). Coverage data will be collected for these files even if they’re not loaded by Intern for tests, allowing a test writer to see which files _haven’t_ been tested, as well as coverage on files that were tested.
 
-💡This property replaces the `excludeInstrumentation` property used in previous versions of Intern, which acted as a filter rather than an inclusive list. `excludeInstrumentation` will still work for now, but we encourage users to switch to `coverage`.
+💡This property replaces the `excludeInstrumentation` property used in previous versions of Intern, which acted as a filter rather than an inclusive list.
 
 ### debug
 

--- a/intern.json
+++ b/intern.json
@@ -99,10 +99,9 @@
 			"benchmark": true,
 			"description": "Generate full coverage",
 			"coverage": [
-				"_build/src/lib/**/*.js",
-				"_build/src/bin/**/*.js",
-				"_build/src/loaders/**/*.js",
-				"_build/src/tasks/**/*.js"
+				"_build/src/**/*.js",
+				"!_build/src/*.js",
+				"!_build/src/browser/**/*.js"
 			],
 			"extends": [ "allSuites" ]
 		},

--- a/src/lib/RemoteSuite.ts
+++ b/src/lib/RemoteSuite.ts
@@ -127,7 +127,7 @@ export default class RemoteSuite extends Suite {
 						case 'runEnd':
 							// Consume this event, and do some post-processing
 							let promise = remote.setHeartbeatInterval(0);
-							if (config.excludeInstrumentation !== true) {
+							if (this.executor.hasCoveredFiles) {
 								// get about:blank to always collect code coverage data from the page in case it is
 								// navigated away later by some other process; this happens during self-testing when the
 								// Leadfoot library takes over

--- a/src/lib/Server.ts
+++ b/src/lib/Server.ts
@@ -3,11 +3,12 @@ import { normalizePath } from './node/util';
 import { after } from '@dojo/core/aspect';
 import { createServer, IncomingMessage, Server as HttpServer, ServerResponse } from 'http';
 import { basename, join, resolve } from 'path';
+import { stat, readFile, createReadStream } from 'fs';
+import { Stream } from 'stream';
 import { lookup } from 'mime-types';
 import { Socket } from 'net';
 import { mixin } from '@dojo/core/lang';
 import { Handle } from '@dojo/interfaces/core';
-import Task from '@dojo/core/async/Task';
 import Node from './executors/Node';
 import { Message } from './channels/Base';
 import * as WebSocket from 'ws';
@@ -28,8 +29,8 @@ export default class Server implements ServerProperties {
 	/** Port to use for WebSocket connections */
 	socketPort: number;
 
+	protected _codeCache: { [key: string]: { data: string; mtime: number; size: number; } } | null;
 	protected _httpServer: HttpServer | null;
-	protected _readTasks: { [filename: string]: Task<any>; } | null;
 	protected _sessions: { [id: string]: { listeners: ServerListener[] } };
 	protected _wsServer: WebSocket.Server | null;
 
@@ -45,8 +46,8 @@ export default class Server implements ServerProperties {
 			const server = this._httpServer = createServer((request: IncomingMessage, response: ServerResponse) => {
 				return this._handleHttp(request, response);
 			});
-			this._readTasks = Object.create(null);
 			this._sessions = {};
+			this._codeCache = Object.create(null);
 
 			const sockets: Socket[] = [];
 
@@ -88,12 +89,6 @@ export default class Server implements ServerProperties {
 		this.executor.log('Stopping server...');
 		const promises: Promise<any>[] = [];
 
-		if (this._readTasks) {
-			Object.keys(this._readTasks).forEach(filename => {
-				this._readTasks![filename].cancel();
-			});
-		}
-
 		if (this._httpServer) {
 			promises.push(new Promise(resolve => {
 				this._httpServer!.close(resolve);
@@ -113,7 +108,7 @@ export default class Server implements ServerProperties {
 		}
 
 		return Promise.all(promises).then(() => {
-			this._readTasks = null;
+			this._codeCache = null;
 		});
 	}
 
@@ -211,43 +206,89 @@ export default class Server implements ServerProperties {
 			wholePath += 'index.html';
 		}
 
-		if (this._readTasks![wholePath]) {
-			return this._readTasks![wholePath];
-		}
+		stat(wholePath, (error, stats) => {
+			// The server was stopped before this file was served
+			if (!this._httpServer) {
+				return;
+			}
 
-		return this._readTasks![wholePath] = this.executor.readFile(wholePath, omitContent)
-			.then(({ size, data }) => {
-				this.executor.log('Serving', wholePath);
+			if (error || !stats.isFile()) {
+				this.executor.log(`Unable to serve ${wholePath} (unreadable)`);
+				this._send404(response);
+				return;
+			}
 
-				const contentType = lookup(basename(wholePath)) || 'application/octet-stream';
+			this.executor.log(`Serving ${wholePath}`);
 
+			const contentType = lookup(basename(wholePath)) || 'application/octet-stream';
+
+			const onEnd = (error?: Error) => {
+				if (error) {
+					this.executor.emit('error', new Error(`Error serving ${wholePath}: ${error.message}`));
+				}
+				else {
+					this.executor.log(`Served ${wholePath}`);
+				}
+			};
+			const send = (size: number, data: string | Stream | null) => {
 				response.writeHead(200, {
 					'Content-Type': contentType,
 					'Content-Length': size
 				});
 
-				if (data === null) {
+				if (!data) {
 					response.end();
+					return;
+				}
+
+				if (typeof data === 'string') {
+					response.end(data, onEnd);
 				}
 				else {
-					response.end(data, (error?: Error) => {
+					data.on('end', () => onEnd());
+					data.on('error', (error: Error) => {
+						onEnd(error);
+						// If the read stream errors, the write stream has to be manually closed
+						response.end();
+					});
+					data.pipe(response);
+				}
+			};
+
+			if (this.executor.shouldInstrumentFile(wholePath)) {
+				const mtime = stats.mtime.getTime();
+				const codeCache = this._codeCache!;
+				const entry = codeCache[wholePath];
+
+				if (entry && entry.mtime === mtime) {
+					send(entry.size, entry.data);
+				}
+				else {
+					readFile(wholePath, 'utf8', (error, data) => {
+						// The server was stopped in the middle of the file read
+						if (!this._httpServer) {
+							return;
+						}
+
 						if (error) {
-							this.executor.emit('error', new Error(`Error serving ${wholePath}: ${error.message}`));
+							this._send404(response);
+							return;
 						}
-						else {
-							this.executor.log('Served', wholePath);
-						}
+
+						// providing `wholePath` to the instrumenter instead of a partial filename is necessary because
+						// lcov.info requires full path names as per the lcov spec
+						data = this.executor.instrumentCode(data, wholePath);
+						const size = Buffer.byteLength(data);
+						codeCache[wholePath] = { data, mtime, size };
+
+						send(size, data);
 					});
 				}
-			})
-			.catch(error => {
-				this.executor.log('Error serving', wholePath, ':', error);
-				this._send404(response);
-			})
-			.finally(() => {
-				delete this._readTasks![wholePath];
-			})
-		;
+			}
+			else {
+				send(stats.size, omitContent ? null : createReadStream(wholePath));
+			}
+		});
 	}
 
 	private _handleMessage(message: Message): Promise<any> {

--- a/src/lib/reporters/Coverage.ts
+++ b/src/lib/reporters/Coverage.ts
@@ -35,14 +35,18 @@ export default abstract class Coverage extends Reporter implements CoveragePrope
 			map = createCoverageMap(data);
 		}
 
-		const transformed = this.executor.sourceMapStore.transformCoverage(map).map;
+		const transformed = this.executor.sourceMapStore.transformCoverage(map);
 
-		const context = createContext();
-		const tree = summarizers.pkg(transformed);
-		tree.visit(create(type, {
+		const context = createContext({
+			sourceFinder: transformed.sourceFinder,
+			watermarks: this.watermarks
+		});
+		const tree = summarizers.pkg(transformed.map);
+		const report = create(type, {
 			file: this.filename,
 			watermarks: this.watermarks
-		}), context);
+		});
+		tree.visit(report, context);
 	}
 
 	@eventHandler()

--- a/src/lib/reporters/Runner.ts
+++ b/src/lib/reporters/Runner.ts
@@ -115,7 +115,7 @@ export default class Runner extends Coverage implements RunnerProperties {
 
 	@eventHandler()
 	runEnd() {
-		let map = createCoverageMap();
+		const map = this.executor.coverageMap;
 		let numTests = 0;
 		let numFailedTests = 0;
 		let numSkippedTests = 0;
@@ -123,47 +123,42 @@ export default class Runner extends Coverage implements RunnerProperties {
 		const sessionIds = Object.keys(this.sessions);
 		const numEnvironments = sessionIds.length;
 
-		if (sessionIds.length > 1) {
-			sessionIds.forEach(sessionId => {
-				const session = this.sessions[sessionId];
-				if (session.coverage) {
-					map.merge(session.coverage);
-				}
-				numTests += session.suite.numTests;
-				numFailedTests += session.suite.numFailedTests;
-				numSkippedTests += session.suite.numSkippedTests;
-			});
+		sessionIds.forEach(sessionId => {
+			const session = this.sessions[sessionId];
+			numTests += session.suite.numTests;
+			numFailedTests += session.suite.numFailedTests;
+			numSkippedTests += session.suite.numSkippedTests;
+		});
 
-			const charm = this.charm;
+		const charm = this.charm;
 
-			if (map.files().length > 0) {
-				charm.write('\n');
-				charm.display('bright');
-				charm.write('Total coverage\n');
-				charm.display('reset');
-				this.createCoverageReport(this.reportType, map);
-			}
-
-			const numPassedTests = numTests - numFailedTests - numSkippedTests;
-			let message = `TOTAL: tested ${numEnvironments} platforms, ${numPassedTests} passed, ${numFailedTests} failed`;
-
-			if (numSkippedTests) {
-				message += `, ${numSkippedTests} skipped`;
-			}
-
-			if (this.hasRunErrors) {
-				message += '; fatal error occurred';
-			}
-			else if (this.hasSuiteErrors) {
-				message += '; suite error occurred';
-			}
-
-			charm.display('bright');
-			charm.foreground(numFailedTests > 0 || this.hasRunErrors || this.hasSuiteErrors ? 'red' : 'green');
-			charm.write(message);
-			charm.display('reset');
+		if (map.files().length > 0) {
 			charm.write('\n');
+			charm.display('bright');
+			charm.write('Total coverage\n');
+			charm.display('reset');
+			this.createCoverageReport(this.reportType, map);
 		}
+
+		const numPassedTests = numTests - numFailedTests - numSkippedTests;
+		let message = `TOTAL: tested ${numEnvironments} platforms, ${numPassedTests} passed, ${numFailedTests} failed`;
+
+		if (numSkippedTests) {
+			message += `, ${numSkippedTests} skipped`;
+		}
+
+		if (this.hasRunErrors) {
+			message += '; fatal error occurred';
+		}
+		else if (this.hasSuiteErrors) {
+			message += '; suite error occurred';
+		}
+
+		charm.display('bright');
+		charm.foreground(numFailedTests > 0 || this.hasRunErrors || this.hasSuiteErrors ? 'red' : 'green');
+		charm.write(message);
+		charm.display('reset');
+		charm.write('\n');
 	}
 
 	@eventHandler()
@@ -203,7 +198,7 @@ export default class Runner extends Coverage implements RunnerProperties {
 
 			session.hasSuiteErrors = true;
 		}
-		else if (!suite.hasParent) {
+		else if (!suite.hasParent && this.executor.suites.length > 1) {
 			if (session.coverage) {
 				this.charm.write('\n');
 				this.createCoverageReport(this.reportType, session.coverage);

--- a/tests/support/unit/mocks.ts
+++ b/tests/support/unit/mocks.ts
@@ -83,6 +83,10 @@ export function mockNodeExecutor(properties?: { [P in keyof Node]?: Node[P] }) {
 
 		shouldInstrumentFile(_filename: string) {
 			return false;
+		},
+
+		readFile(_filename: string, _omitCode = false) {
+			return Task.reject<any>(new Error());
 		}
 	}, properties || {}));
 	return <MockNode>executor;

--- a/tests/unit/lib/executors/Node.ts
+++ b/tests/unit/lib/executors/Node.ts
@@ -211,6 +211,13 @@ registerSuite('lib/executors/Node', function () {
 				'src/lib/reporters/Lcov': { default: MockReporter },
 				'src/lib/reporters/Benchmark': { default: MockReporter },
 				'istanbul-lib-coverage': {
+					classes: {
+						FileCoverage: {
+							prototype: {
+								merge() {}
+							}
+						}
+					},
 					createCoverageMap() {
 						return new MockCoverageMap();
 					}

--- a/tests/unit/lib/executors/Node.ts
+++ b/tests/unit/lib/executors/Node.ts
@@ -430,12 +430,6 @@ registerSuite('lib/executors/Node', function () {
 						test('tunnel', 5, 'null', 'null', /Non-string/);
 					},
 
-					excludeInstrumentation() {
-						test('excludeInstrumentation', 5, true, true, /Invalid value/, true);
-						test('excludeInstrumentation', 5, /foo/, /foo/, /Invalid value/, true);
-						test('excludeInstrumentation', 5, 'foo', /foo/, /Invalid value/, true);
-					},
-
 					functionalCoverage: booleanTest('functionalCoverage'),
 					leaveRemoteOpen: booleanTest('leaveRemoteOpen'),
 					serveOnly: booleanTest('serveOnly'),
@@ -619,41 +613,16 @@ registerSuite('lib/executors/Node', function () {
 						executor.run();
 					},
 
-					'excludeInstrumentation': {
-						'instrumentation disabled'() {
-							const dfd = this.async();
-							executor.configure({ excludeInstrumentation: true });
-							executor.on('beforeRun', dfd.callback(() => {
-								assert.isFalse(executor.shouldInstrumentFile('bar/foo.js'));
-							}));
-							executor.run();
-						},
-
-						'instrumentation disabled via regex'() {
-							const dfd = this.async();
-							executor.configure({ excludeInstrumentation: /blah/ });
-							executor.on('beforeRun', dfd.callback(() => {
-								assert.isFalse(executor.shouldInstrumentFile('bar/foo.js'));
-							}));
-							executor.run();
-						},
-
-						'default filter'() {
-							const dfd = this.async();
-							executor.on('beforeRun', dfd.callback(() => {
-								assert.isFalse(executor.shouldInstrumentFile('bar/foo.js'));
-							}));
-							executor.run();
-						},
-
-						'configured filter'() {
-							const dfd = this.async();
-							executor.configure({ excludeInstrumentation: /foo/ });
-							executor.on('beforeRun', dfd.callback(() => {
-								assert.isFalse(executor.shouldInstrumentFile('bar/foo.js'));
-							}));
-							executor.run();
-						}
+					'excludeInstrumentation'() {
+						const dfd = this.async();
+						executor.configure({ excludeInstrumentation: true });
+						executor.on('beforeRun', dfd.callback(() => {
+							for (let call of mockConsole.warn.getCalls()) {
+								assert.include(call.args[0], 'deprecated', 'warning should have been emitted');
+							}
+							assert.isUndefined(executor.config.excludeInstrumentation);
+						}));
+						executor.run();
 					},
 
 					'coverage': {

--- a/types/istanbul-lib-coverage/index.d.ts
+++ b/types/istanbul-lib-coverage/index.d.ts
@@ -9,15 +9,19 @@ declare module 'istanbul-lib-coverage' {
 	export class CoverageMap {
 		addFileCoverage(pathOrObject: string | object): void;
 		files(): string[];
-		fileCoverageFor(filename: string): FileCoverage;
+		fileCoverageFor(filename: string): classes.FileCoverage;
 		merge(data: object | CoverageMap): void;
 	}
 
-	export class FileCoverage {
-		toSummary(): CoverageSummary;
+	export namespace classes {
+		export class FileCoverage {
+			merge(other: object): void;
+			toSummary(): CoverageSummary;
+			toJSON(): object;
+		}
 	}
 
 	export function createCoverageMap(data?: any): CoverageMap;
 	export function createCoverageSummary(): CoverageSummary;
-	export function createFileCoverage(pathOrObject: string | object): FileCoverage;
+	export function createFileCoverage(pathOrObject: string | object): classes.FileCoverage;
 }

--- a/types/istanbul-lib-source-maps/index.d.ts
+++ b/types/istanbul-lib-source-maps/index.d.ts
@@ -12,7 +12,7 @@ declare module 'istanbul-lib-source-maps' {
 		data: any;
 
 		registerMap(filename: string, sourceMap: any): void;
-		transformCoverage(coverageMap: CoverageMap): { map: CoverageMap };
+		transformCoverage(coverageMap: CoverageMap): { map: CoverageMap; sourceFinder: (path: string) => string; };
 	}
 
 	export class SourceStore {


### PR DESCRIPTION
Currently, full coverage (including uncovered files) only displays for the final report if there are more than two sessions. This PR contains changes to output full coverage for all sessions.