### PR TITLE
Improve HTML reporter #724

### DIFF
--- a/lib/reporters/Html.js
+++ b/lib/reporters/Html.js
@@ -1,7 +1,40 @@
 define([
 	'require',
-	'../util',
-], function (require, util) {
+
+	'../util'
+], function (
+	require,
+
+	util
+) {
+	var location = window.location;
+
+	function getFullName(test) {
+		var name = test.name;
+		while (test.parent && test.parent.name) {
+			test = test.parent;
+			name = test.name + ' - ' + name;
+		}
+		return name;
+	}
+
+	function createLinkNode(test) {
+		var text = test.name;
+		var a = document.createElement('a');
+		var search = location.search;
+
+		if (search) {
+			search = search.slice(1).split("&").filter(function (el) {
+				return !el.startsWith("grep");
+			}).join("&");
+		}
+
+		search = "?" + search + "&grep=/" + getFullName(test) + "/";
+		a.href = location.origin + location.pathname + search;
+		a.appendChild(document.createTextNode(text));
+		return a;
+	}
+
 	function pad(value, size) {
 		var padded = String(value);
 
@@ -338,7 +371,7 @@ define([
 			suiteCount++;
 
 			cellNode.className = 'title';
-			cellNode.appendChild(document.createTextNode(suite.name));
+			cellNode.appendChild(createLinkNode(suite));
 			rowNode.className = 'suite';
 			rowNode.appendChild(cellNode);
 			reportNode.appendChild(rowNode);
@@ -393,7 +426,7 @@ define([
 			var numSkippedTests = suite.numSkippedTests;
 			var numPassedTests = numTests - numFailedTests - numSkippedTests;
 
-			// Mark a suite as failed if any of its child tests failed, and 
+			// Mark a suite as failed if any of its child tests failed, and
 			addClass(rowNode, numFailedTests > 0 ? 'failed' : 'passed');
 
 			// Only suites with failed tests will be initially expanded
@@ -471,7 +504,7 @@ define([
 				cellNode.className += ' indent' + indentLevel;
 			}
 
-			cellNode.appendChild(document.createTextNode(test.name));
+			cellNode.appendChild(createLinkNode(test));
 			rowNode.appendChild(cellNode);
 
 			cellNode = document.createElement('td');


### PR DESCRIPTION
Hello @dylans, hello @jason0x43!

I decide to help with https://github.com/theintern/intern/issues/724 issue.

There is an initial pull request.

Known problems:

1. Icon for skipped tests is not exist. 
There is a `$skippedIcon` variable with `\e807` value in `intern/lib/reporters/html/variables.styl`, but fonts don't contain that character.

2. I don't know how link should look like.  Any ideas / markup / CSS class? 

3. Need to write functional tests for that path.

Now it's looks like this:
![screenshot from 2017-09-25 20-13-23](https://user-images.githubusercontent.com/2428161/30821422-02ee0154-a22e-11e7-9b42-eaf2e210b4b9.png)


