### PR TITLE
improve HTML - init commit

### DIFF
--- a/src/lib/reporters/Html.ts
+++ b/src/lib/reporters/Html.ts
@@ -11,6 +11,8 @@ export default class Html extends Reporter implements HtmlProperties {
 
 	document: Document;
 
+	location: Location;
+
 	protected _reportContainer: Element;
 
 	// Div element to hold buttons above the summary table
@@ -57,6 +59,7 @@ export default class Html extends Reporter implements HtmlProperties {
 	constructor(executor: Browser, options: HtmlOptions = {}) {
 		super(executor, options);
 		this.document = options.document || window.document;
+		this.location = options.location || window.location;
 		this._fragment = this.document.createDocumentFragment();
 	}
 
@@ -323,7 +326,7 @@ export default class Html extends Reporter implements HtmlProperties {
 		this._suiteCount++;
 
 		cellNode.className = 'title';
-		cellNode.appendChild(document.createTextNode(suite.name));
+		cellNode.appendChild(this.createLinkNode(suite));
 		rowNode.className = 'suite';
 		rowNode.appendChild(cellNode);
 		this._reportNode.appendChild(rowNode);
@@ -466,7 +469,7 @@ export default class Html extends Reporter implements HtmlProperties {
 			cellNode.className += ' indent' + this._indentLevel;
 		}
 
-		cellNode.appendChild(document.createTextNode(test.name));
+		cellNode.appendChild(this.createLinkNode(test));
 		rowNode.appendChild(cellNode);
 
 		cellNode = document.createElement('td');
@@ -499,10 +502,28 @@ export default class Html extends Reporter implements HtmlProperties {
 
 		this._reportNode.appendChild(rowNode);
 	}
+
+	private createLinkNode(obj: Suite | Test) {
+		const document = this.document;
+		const location = this.location;
+		const a = document.createElement('a');
+		let search = location.search;
+
+		if (search) {
+			search = search.slice(1).split('&').filter(el => {
+				return !el.startsWith('grep');
+			}).join('&');
+		}
+
+		a.href = location.origin + location.pathname + `?${search}&grep=${encodeURIComponent(obj.id)}`;
+		a.appendChild(document.createTextNode(obj.name));
+		return a;
+	}
 }
 
 export interface HtmlProperties extends ReporterProperties {
 	document: Document;
+	location: Location;
 }
 
 export type HtmlOptions = Partial<HtmlProperties>;

--- a/tests/support/mocking.d.ts
+++ b/tests/support/mocking.d.ts
@@ -15,4 +15,8 @@ declare namespace mocking {
 	export interface DocCreator {
 		(): Document;
 	}
+
+	export interface LocCreator {
+		(): Location;
+	}
 }

--- a/tests/unit/lib/reporters/support/mocks.ts
+++ b/tests/unit/lib/reporters/support/mocks.ts
@@ -41,3 +41,26 @@ export function createMockDocument() {
 	};
 	return doc;
 }
+
+export function createLocation() {
+	return {
+		hash: '',
+		host: '',
+		hostname: '',
+		href: '',
+		origin: '',
+		pathname: '',
+		port: '',
+		protocol: '',
+		search: '',
+		assign: function() {
+		},
+		reload: function() {
+		},
+		replace: function() {
+		},
+		toString: function(): string {
+			return '';
+		}
+	};
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 		"declaration": true,
 		"lib": [
 			"es5",
+			"ES2015.Core",
 			"es2015.collection",
 			"es2015.promise",
 			"es2015.symbol",


### PR DESCRIPTION
Hello @dylans, hello @jason0x43!

This pull request can fix several issues:
https://github.com/theintern/intern/issues/636  https://github.com/theintern/intern/issues/724

Now it's looks like this:
![screenshot from 2017-09-25 20-13-23](https://user-images.githubusercontent.com/2428161/30821422-02ee0154-a22e-11e7-9b42-eaf2e210b4b9.png)

Feedback:
`npm test serveOnly` command say `Listening on localhost:9000 (ws 9001)` it's not comfortable - maybe it's should say `Listening on  http://127.0.0.1:9000/__intern/  (ws 9001)`? In that case you can copy-paste this URL to browser.

If you prefer arrow function for callback - maybe you should add linter rule for that?
https://eslint.org/docs/rules/prefer-arrow-callback