### PR TITLE
Update Grunt task

### DIFF
--- a/src/lib/node/util.ts
+++ b/src/lib/node/util.ts
@@ -48,15 +48,15 @@ export function expandFiles(patterns?: string[] | string) {
  * Get the user-supplied config data, which may include command line args and a
  * config file.
  */
-export function getConfig(file?: string) {
+export function getConfig(file?: string, argv: string[] = process.argv) {
 	let args: { [key: string]: any } = {};
 
 	if (process.env['INTERN_ARGS']) {
 		mixin(args, parseArgs(parse(process.env['INTERN_ARGS'])));
 	}
 
-	if (process.argv.length > 2) {
-		mixin(args, parseArgs(process.argv.slice(2)));
+	if (argv.length > 2) {
+		mixin(args, parseArgs(argv.slice(2)));
 	}
 
 	if (file) {

--- a/src/tasks/intern.ts
+++ b/src/tasks/intern.ts
@@ -1,26 +1,46 @@
 import global from '@dojo/shim/global';
+import { assign } from '@dojo/core/lang';
 
 import Node from '../lib/executors/Node';
 import { Config } from '../lib/executors/Executor';
+import { getConfig } from '../lib/node/util';
 
 interface TaskOptions extends grunt.task.ITaskOptions, Partial<Config> {
 	[key: string]: any;
 }
 
+function configure(options: TaskOptions): Promise<{
+	config: Partial<Config>;
+	options: TaskOptions;
+}> {
+	if (options.config) {
+		return getConfig(options.config, []).then(({ config }) => {
+			delete options.config;
+
+			return { config, options };
+		});
+	}
+
+	return Promise.resolve({ config: {}, options });
+}
+
 export = function(grunt: IGrunt) {
 	grunt.registerMultiTask('intern', function() {
 		const done = this.async();
-		const config = this.options<TaskOptions>({});
+		const options = assign({}, this.options<TaskOptions>({}));
 
 		// Force colored output for istanbul report
 		process.env.FORCE_COLOR = 'true';
 
-		const intern = (global.intern = new Node(config));
-		intern.run().then(finish, finish);
+		configure(options).then(({ config, options }) => {
+			const intern = (global.intern = new Node());
+			intern.configure(config);
+			intern.configure(options);
+
+			return intern.run();
+		}).then(finish, finish);
 
 		function finish(error?: any) {
-			// Remove the global intern object when we're done; this will allow
-			// Intern to be run again in the same process
 			global.intern = null;
 			done(error);
 		}


### PR DESCRIPTION
* Allow grunt options to specify 'config' to point to a config file and/or section
* Change node/util.getConfig to accept an optional second argument to allow passing in other command line arguments
* Updated task tests

Fixes #812