### PR TITLE
Fix nonexistent `config()` method. Add charset

### DIFF
--- a/docs/how_to.md
+++ b/docs/how_to.md
@@ -121,9 +121,12 @@ If you’d rather not install Intern, you can load the package from a CDN, like:
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="UTF-8">
+
         <script src="https://unpkg.com/intern@next/browser/intern.js"></script>
         <script>
             var registerSuite = intern.getInterface('object').registerSuite;
+
             registerSuite('app/module', {
                 test1: function () {
                     // ...
@@ -133,7 +136,8 @@ If you’d rather not install Intern, you can load the package from a CDN, like:
                 },
                 // ...
             });
-            intern.config({ reporters: 'html' });
+
+            intern.configure({ reporters: 'html' });
             intern.run();
         </script>
     </head>


### PR DESCRIPTION
I've made the following changes:
- `config()` does not exist, I replaced it with `configure()`.
- Firefox complains when no character encoding is specified, and it is anyways a good practice to specify it, so I added UTF-8.

In addition, I was getting an error in Firefox: `Error loading /node_modules/intern/loaders/default.js`, for which I had to manually load the default loader as a script. Simply using `browser/intern.js` was not enough. I ended up with:

```html
<script src="../../node_modules/intern/browser/intern.js"></script>
<script src="../../node_modules/intern/loaders/default.js"></script>
```

I've not changed the documentation to include this though, because I assume it is a bug that needs to be fixed in a different layer.