### PR TITLE
Initialize reporters after plugins have loaded to support third-party reporters

### DIFF
--- a/src/lib/executors/Executor.ts
+++ b/src/lib/executors/Executor.ts
@@ -566,9 +566,7 @@ export default abstract class Executor<
 			let runError: Error;
 
 			try {
-				this._runTask = this._resolveConfig().then(() =>
-					this._initReporters()
-				);
+				this._runTask = this._resolveConfig();
 
 				if (this.config.showConfig) {
 					this._runTask = this._runTask
@@ -605,6 +603,7 @@ export default abstract class Executor<
 						.then(() => this._loadPlugins())
 						.then(() => this._loadLoader())
 						.then(() => this._loadPluginsWithLoader())
+						.then(() => this._initReporters())
 						.then(() => this._loadSuites())
 						.then(() => this._beforeRun())
 						.then((skipTests: boolean) => {

--- a/tests/unit/lib/executors/Executor.ts
+++ b/tests/unit/lib/executors/Executor.ts
@@ -731,17 +731,6 @@ registerSuite('lib/executors/Executor', function() {
 							executor,
 							/has not been registered/
 						);
-					},
-
-					invalid() {
-						executor.registerPlugin('reporter.foo', () =>
-							Promise.resolve({})
-						);
-						executor.configure({ reporters: <any>'foo' });
-						return assertRunFails(
-							executor,
-							/A plugin .* not been registered/
-						);
 					}
 				},
 


### PR DESCRIPTION
Currently, reporters are initialized immediately after the configuration resolves and before plugins are loaded. This means a third-party reporter cannot be loaded as a plugin, register itself, and be used in the `reporters` configuration (`_initReporters()` will throw because it can't find a reporter with the right name since the plugin hasn't loaded yet). These changes move `_initReporters()` to after all plugins have loaded, but before any suites load. This also removes a test that is no longer valid that checked that `run()` threw when a reporter was registered and configured.