### PR TITLE
Fix plugin options

### DIFF
--- a/src/lib/executors/Executor.ts
+++ b/src/lib/executors/Executor.ts
@@ -932,8 +932,10 @@ export default abstract class BaseExecutor<
 				if (typeof script === 'string') {
 					return previous.then(() => loader(script));
 				} else {
-					this._loadingPluginOptions = script.options;
 					return previous
+						.then(() => {
+							this._loadingPluginOptions = script.options;
+						})
 						.then(() => loader(script.script))
 						.then(() => {
 							this._loadingPluginOptions = undefined;


### PR DESCRIPTION
This patch sets the loading plugin options at the appropriate time. Right now they're getting wiped out before the loader has a chance to run.