### PR TITLE
fix: lint-staged avoid flagging of Node.js v10+

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "concurrently": "~3.5.0",
     "css-loader": "~0.28.11",
     "jsdom": "~11.8.0",
-    "lint-staged": "~7.0.4",
+    "lint-staged": "^7.0.5",
     "pre-commit": "~1.2.2",
     "prettier": "~1.12.1",
     "sinon": "~2.3.6",


### PR DESCRIPTION
https://github.com/okonet/lint-staged/pull/434

Includes semantic version range checking that avoids incorrect flagging
of Node.js version 10+. typicode/please-upgrade-node#11

E.g.:

```
node --version
v10.3.0
```

incorrectly causes:

```
git commit -m "fix(html reporter): toggle visibility in IE11" src/lib/reporters/Html.ts
lint-staged requires at least version 6 of Node, please upgrade
pre-commit:
pre-commit: We've failed to pass the specified git pre-commit hooks as
the `precommit`
pre-commit: hook returned an exit code (1). If you're feeling
adventurous you can
pre-commit: skip the git pre-commit hooks by adding the following flags
to your commit:
pre-commit:
pre-commit:   git commit -n (or --no-verify)
pre-commit:
pre-commit: This is ill-advised since the commit is broken.
pre-commit:
```