### PR TITLE
Pass non-normalized path to shouldInstrumentFile() to ensure Windows paths will match

### DIFF
--- a/src/lib/browser/util.ts
+++ b/src/lib/browser/util.ts
@@ -76,6 +76,7 @@ export function getDefaultBasePath() {
 	}
 }
 
+// TODO: Remove in the next version
 /**
  * Normalize a path (e.g., resolve '..')
  */

--- a/src/lib/middleware/instrument.ts
+++ b/src/lib/middleware/instrument.ts
@@ -5,7 +5,6 @@ import { join, resolve } from 'path';
 import { RequestHandler } from 'express';
 
 import { Context } from '../Server';
-import { normalizePath } from '../node/util';
 
 export default function instrument(context: Context): RequestHandler {
 	const codeCache: {
@@ -14,16 +13,14 @@ export default function instrument(context: Context): RequestHandler {
 
 	return (request, response, next) => {
 		const { basePath, executor } = context;
-		const filePath = resolve(join(basePath, request.url));
+		const wholePath = resolve(join(basePath, request.url));
 
 		if (
 			!(request.method === 'HEAD' || request.method === 'GET') ||
-			!executor.shouldInstrumentFile(filePath)
+			!executor.shouldInstrumentFile(wholePath)
 		) {
 			return next();
 		}
-
-		const wholePath = normalizePath(filePath);
 
 		stat(wholePath, (error, stats) => {
 			// The server was stopped before this file was served

--- a/src/lib/middleware/instrument.ts
+++ b/src/lib/middleware/instrument.ts
@@ -14,14 +14,16 @@ export default function instrument(context: Context): RequestHandler {
 
 	return (request, response, next) => {
 		const { basePath, executor } = context;
-		const wholePath = normalizePath(resolve(join(basePath, request.url)));
+		const filePath = resolve(join(basePath, request.url));
 
 		if (
 			!(request.method === 'HEAD' || request.method === 'GET') ||
-			!executor.shouldInstrumentFile(wholePath)
+			!executor.shouldInstrumentFile(filePath)
 		) {
 			return next();
 		}
+
+		const wholePath = normalizePath(filePath);
 
 		stat(wholePath, (error, stats) => {
 			// The server was stopped before this file was served

--- a/src/lib/node/util.ts
+++ b/src/lib/node/util.ts
@@ -141,6 +141,7 @@ export function loadText(path: string) {
 	});
 }
 
+// TODO: Remove in the next version
 /**
  * Normalize a path (e.g., resolve '..')
  */

--- a/tests/unit/lib/middleware/instrument.ts
+++ b/tests/unit/lib/middleware/instrument.ts
@@ -10,7 +10,6 @@ import {
 	createMockServerContext
 } from '../../../support/unit/mocks';
 import { mockFs, mockPath, MockStats } from '../../../support/unit/nodeMocks';
-import { win32 } from 'path';
 
 const mockRequire = <mocking.MockRequire>intern.getPlugin('mockRequire');
 
@@ -88,29 +87,6 @@ registerSuite('lib/middleware/instrument', function() {
 							200,
 							'expected success status for good file'
 						);
-					},
-
-					'handles windows paths'() {
-						const { join } = path;
-
-						path.join = (...args: any[]) => win32.join(...args);
-
-						handler(request, response, next);
-
-						assert.isFalse(next.called);
-						assert.isTrue(
-							shouldInstrumentFile.alwaysCalledWith(
-								'\\base\\foo\\thing.js'
-							)
-						);
-						assert.equal(response.data, 'what a fun time');
-						assert.strictEqual(
-							response.statusCode,
-							200,
-							'expected success status for good file'
-						);
-
-						path.join = join;
 					},
 
 					'caches code'() {

--- a/tests/unit/lib/middleware/instrument.ts
+++ b/tests/unit/lib/middleware/instrument.ts
@@ -10,6 +10,7 @@ import {
 	createMockServerContext
 } from '../../../support/unit/mocks';
 import { mockFs, mockPath, MockStats } from '../../../support/unit/nodeMocks';
+import { win32 } from 'path';
 
 const mockRequire = <mocking.MockRequire>intern.getPlugin('mockRequire');
 
@@ -87,6 +88,29 @@ registerSuite('lib/middleware/instrument', function() {
 							200,
 							'expected success status for good file'
 						);
+					},
+
+					'handles windows paths'() {
+						const { join } = path;
+
+						path.join = (...args: any[]) => win32.join(...args);
+
+						handler(request, response, next);
+
+						assert.isFalse(next.called);
+						assert.isTrue(
+							shouldInstrumentFile.alwaysCalledWith(
+								'\\base\\foo\\thing.js'
+							)
+						);
+						assert.equal(response.data, 'what a fun time');
+						assert.strictEqual(
+							response.statusCode,
+							200,
+							'expected success status for good file'
+						);
+
+						path.join = join;
 					},
 
 					'caches code'() {


### PR DESCRIPTION
On Windows, coverage file paths are stored non-normalized. Because of this, the path passed to `shouldInstrumentFile()` needs to be non-normalized.