### PR TITLE
Report suite errors in JUnit reporter

### DIFF
--- a/src/lib/reporters/JUnit.ts
+++ b/src/lib/reporters/JUnit.ts
@@ -136,7 +136,9 @@ class XmlNode {
 function createSuiteNode(suite: Suite, reporter: JUnit): XmlNode {
   const suiteError = suite.error;
 
-  let childNodes = suite.tests.map(test => createTestNode(test, reporter));
+  const childNodesProvider = () =>
+    suite.tests.map(test => createTestNode(test, reporter));
+  let childNodes: XmlNode[] | undefined;
 
   if (suiteError) {
     const lifecycleMethod = suiteError.lifecycleMethod;
@@ -164,7 +166,7 @@ function createSuiteNode(suite: Suite, reporter: JUnit): XmlNode {
         break;
       case 'after':
       case 'afterEach':
-        childNodes.push(createLifecycleTestCase());
+        childNodes = [...childNodesProvider(), createLifecycleTestCase()];
         break;
     }
   }
@@ -175,7 +177,7 @@ function createSuiteNode(suite: Suite, reporter: JUnit): XmlNode {
     skipped: suite.numSkippedTests,
     tests: suite.numTests,
     time: suite.timeElapsed! / 1000,
-    childNodes
+    childNodes: childNodes || childNodesProvider()
   });
 }
 


### PR DESCRIPTION
Currently the JUnit reporter does not report any suite level errors in the output, resulting in the report suggesting tests have passed when suite level errors occur. The JUnit schemas I have found also suggest there is no concept of a suite level errors, see:
https://github.com/junit-team/junit5/blob/master/platform-tests/src/test/resources/jenkins-junit.xsd
https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd

This PR will update the test report to fail any tests which have not been skipped with the suite error. It is worth noting that should errors occur in the after/afterEach of tests these tests will also be marked as failed even if they have passed themselves. I feel this is a lesser of two evils as never finding out about suite errors is more misleading, there is most likely an issue which needs to be resolved.

I also set up jenkins builds with the JUnit reporter plugin to test the script below, along with the before + after report output:

```const bdd = intern.getPlugin("interface.bdd");
const { assert } = intern.getPlugin('chai');

bdd.describe("Top level", () => {
  const testCases: { context: string; setup: (cb:() => void) => void }[] = [
    { context: "a failing before", setup: bdd.before },
    { context: "a failing after", setup: bdd.after },
    { context: "a failing beforeEach", setup: bdd.beforeEach },
    { context: "a failing afterEach", setup: bdd.afterEach },
    { context: "a skipped suite", setup: _cb => bdd.before(suite => {suite.skip(`Skipped suite`)})  },
    { context: "no issues", setup: () => {} }
  ];

  testCases.forEach((testCase, i) => {
    const context = testCase.context;
    bdd.describe(`${i} Suite with ${context}`, () => {
      testCase.setup(() => {
        throw new Error(`Problem in ${context}`);
      });

      bdd.it(`${i}.1 test within a suite with ${context}`, () => {});
      bdd.it(
        `${i}.2 another test within a suite with ${context}`,
        () => {}
      );

      bdd.it(
        `${i}.3 failing test within a suite with ${context}`,
        () => {
          assert.equal(true, false, "True should be false")
        }
      );

      bdd.it(
        `${i}.4 a skipped test within a suite with ${context}`,
        test => {
          test.skip(`Skipped test: '${test.name}'`)
        }
      );
    });
  });
});
```

**Jenkins JUnit report output - BEFORE**

Only reports individual test failures

![image](https://user-images.githubusercontent.com/15254526/47425695-105cb980-d783-11e8-962c-749bafe7c32c.png)


**Jenkins JUnit report output - AFTER**

![image](https://user-images.githubusercontent.com/15254526/47425712-194d8b00-d783-11e8-9b10-d183355b19a9.png)


