### PR TITLE
Add option to Runner to hide tunnel download progress

### DIFF
--- a/src/lib/reporters/Runner.ts
+++ b/src/lib/reporters/Runner.ts
@@ -28,6 +28,7 @@ export default class Runner extends TextCoverage implements RunnerProperties {
   hasSuiteErrors: boolean;
   hidePassed: boolean;
   hideSkipped: boolean;
+  hideTunnelDownloadProgress: boolean;
   serveOnly: boolean;
 
   private _deprecationMessages: { [message: string]: boolean };
@@ -39,6 +40,8 @@ export default class Runner extends TextCoverage implements RunnerProperties {
 
     this.hidePassed = options.hidePassed || false;
     this.hideSkipped = options.hideSkipped || false;
+    this.hideTunnelDownloadProgress =
+      options.hideTunnelDownloadProgress || false;
 
     this.sessions = {};
     this.hasRunErrors = false;
@@ -319,6 +322,10 @@ export default class Runner extends TextCoverage implements RunnerProperties {
 
   @eventHandler()
   tunnelDownloadProgress(message: TunnelMessage) {
+    if (this.hideTunnelDownloadProgress) {
+      return;
+    }
+
     const progress = message.progress!;
     this.charm.write(
       'Tunnel download: ' +
@@ -341,4 +348,5 @@ export default class Runner extends TextCoverage implements RunnerProperties {
 export interface RunnerProperties extends TextCoverageProperties {
   hidePassed: boolean;
   hideSkipped: boolean;
+  hideTunnelDownloadProgress: boolean;
 }

--- a/tests/unit/lib/reporters/Runner.ts
+++ b/tests/unit/lib/reporters/Runner.ts
@@ -57,6 +57,7 @@ registerSuite('lib/reporters/Runner', function() {
         assert.isDefined(reporter);
         assert.isFalse(reporter.serveOnly);
         assert.isTrue(reporter.hidePassed);
+        assert.isFalse(reporter.hideTunnelDownloadProgress);
       },
 
       coverage() {
@@ -419,6 +420,14 @@ registerSuite('lib/reporters/Runner', function() {
             ).toFixed(3)}%\r`
           ]
         ]);
+      },
+
+      hideTunnelDownloadProgress() {
+        reporter.hideTunnelDownloadProgress = true;
+        const progress = { received: 10, total: 50 };
+        reporter.tunnelDownloadProgress(<any>{ progress });
+
+        assert.equal(mockCharm.write.callCount, 0);
       },
 
       tunnelStart() {


### PR DESCRIPTION
When using the Runner our consoles on the build machines get heavily polluted with tunnel download progress (see below), this PR provides an option to the Runner to hide the download progress (defaulting to off).

```
…
Tunnel download: 24.477%
Tunnel download: 24.514%
Tunnel download: 24.551%
Tunnel download: 24.589%
Tunnel download: 24.626%
Tunnel download: 24.663%
Tunnel download: 24.701%
Tunnel download: 24.738%
Tunnel download: 24.776%
Tunnel download: 24.813%
Tunnel download: 24.850%
Tunnel download: 24.888%
Tunnel download: 24.925%
Tunnel download: 24.962%
Tunnel download: 25.000%
Tunnel download: 25.037%
Tunnel download: 25.075%
Tunnel download: 25.112%
…
```
