### PR TITLE
Add the ability to hide skipped tests in Html report

### DIFF
--- a/src/lib/reporters/html/html.styl
+++ b/src/lib/reporters/html/html.styl
@@ -135,9 +135,10 @@ body {
 	}
 }
 
-.failedFilter {
+.toggleFilter {
 	color: $reportTextColor;
 	input {
+		margin-left: 0.5em;
 		margin-right: 0.5em;
 	}
 }
@@ -233,6 +234,16 @@ body {
 				}
 			}
 		}
+
+		&.skipped {
+			testStatusIcon(lighten($skippedColor, 80%), $skippedColor, $skippedIcon)
+			color: $skippedColor;
+			background-color: #fff;
+
+			td {
+				border: 1px solid $cellBorderColor;
+			}
+		}
 	}
 
 	.testResult {
@@ -298,12 +309,21 @@ body {
 	}
 }
 
+.hideSkipped .report {
+	.skipped {
+		display: none;
+	}
+}
+
 .reportControls {
 	margin-bottom: 0.75em;
 	color: $summaryTextColor;
 
 	> * {
 		width: 50%;
+	}
+	
+	* {
 		display: inline-block;
 	}
 


### PR DESCRIPTION
This PR is to add a feature to hide all skipped tests / suites, we have found this functionality particularly useful with our 7k of tests and 3k or suites when using grep. Updates were also made to the styling to render suites as skipped if all the tests inside are skipped. The credit for this goes to one of my colleagues. Screenshots can be seen below:

I apologise that I have not added any unit tests as I don't really have the time to write them at the moment. Also it didn't appear that there were existing tests for the _Show only failed tests_ filter. I suspect the coverage may drop slightly but I have refactored out the common code for the filters.

## Hide skipped enabled

<img width="877" alt="screenshot 2018-10-25 at 18 39 35" src="https://user-images.githubusercontent.com/15254526/47521231-6c5e3580-d88a-11e8-81a9-b4d5d3512f8b.png">

## Suites being rendered as skipped

![image](https://user-images.githubusercontent.com/15254526/47522292-150d9480-d88d-11e8-819c-885c25f075c7.png)
