### PR TITLE
Remove console reporter from defaults within the browser Html report

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,7 @@
 				}
 
 				// Add the HTML and console reporters to the default
-				intern.configure({ 'reporters+': ['html', 'console'] });
+				intern.configure({ 'reporters+': ['html'] });
 				intern.configure(config);
 			})
 			.then(


### PR DESCRIPTION
This PR is to disable the console reporter default in the browser/Html reporter, in our dev environments we see a significant performance decrease with it enabled with the dev tools open (more details below).

The console reporter can still be enabled via the config if desired, e.g.

```
...
  "browser": {
    "suites": [...],
    "reporters": ["console"]
},
...
```

## Performance figures

These average were generated using our unit tests and in chrome

|         | Dev tools open       | Dev tools closed  |
| ------------- |:-------------:| -----:|
| Console On     | 132s | 54s |
| Console Off      |    83s   |   53s |