### PR TITLE
Do not run suite lifecycle methods when all descendant tests are skipped

### DIFF
--- a/src/lib/Suite.ts
+++ b/src/lib/Suite.ts
@@ -355,6 +355,8 @@ export default class Suite implements SuiteProperties {
       return this.executor.emit('suiteEnd', this);
     };
 
+    const allTestsSkipped = this.numTests === this.numSkippedTests;
+
     // Run the before and after suite lifecycle methods
     const runLifecycleMethod = (
       suite: Suite,
@@ -363,7 +365,7 @@ export default class Suite implements SuiteProperties {
     ): CancellablePromise<void> => {
       let result: PromiseLike<void> | undefined;
 
-      if (this.numTests === this.numSkippedTests) {
+      if (allTestsSkipped) {
         // If all descendant tests are skipped then do not run the suite lifecycles
         return Task.resolve();
       }

--- a/src/lib/Suite.ts
+++ b/src/lib/Suite.ts
@@ -373,6 +373,7 @@ export default class Suite implements SuiteProperties {
       return this.executor.emit('suiteEnd', this);
     };
 
+    // Important to check this outside of the lifecycle as skip may have been called within a child
     const allTestsSkipped = this.numTests === this.numSkippedTests;
 
     // Run the before and after suite lifecycle methods
@@ -383,7 +384,9 @@ export default class Suite implements SuiteProperties {
     ): CancellablePromise<void> => {
       let result: PromiseLike<void> | undefined;
 
-      if (allTestsSkipped) {
+      // If we are the root suite with our own executor then we want to run life cycle functions regardless of
+      // whether all tests are skipped
+      if (!this._executor && allTestsSkipped) {
         // If all descendant tests are skipped then do not run the suite lifecycles
         return Task.resolve();
       }

--- a/tests/unit/lib/Suite.ts
+++ b/tests/unit/lib/Suite.ts
@@ -1300,7 +1300,43 @@ registerSuite('lib/Suite', {
           }
         );
       },
-      ...createGrepLifecycleTests()
+      ...createGrepLifecycleTests(),
+
+      'executes the after and afterEach if the only test is skipped'() {
+        const dfd = this.async(5000);
+        const testsRun: any[] = [];
+        let afterExecuted = false;
+        let afterEachExecuted = false;
+        const test = new Test({
+          name: 'foo',
+          test() {
+            testsRun.push(this);
+            this.skip('skipped test');
+          }
+        });
+
+        const suite = createSuite({
+          name: 'my suite',
+          bail: true,
+          tests: [test],
+          after() {
+            afterExecuted = true;
+          },
+          afterEach() {
+            afterEachExecuted = true;
+          }
+        });
+
+        suite.run().then(
+          dfd.callback(function() {
+            assert.isTrue(afterExecuted, 'after should have run');
+            assert.isTrue(afterEachExecuted, 'afterEach should have run');
+          }),
+          function() {
+            dfd.reject(new Error('Suite should not fail'));
+          }
+        );
+      }
     },
 
     bail() {


### PR DESCRIPTION
- Add tests to ensure suite lifecycle functions do not run if all tests are skipped
- Evaluate grep up front rather than when the tests are executed

In our functional end-to-end tests we have had to write our own grep due to this, some of our `before` functions have substantial setup by navigating the app. Also mentioned in comment https://github.com/theintern/intern/issues/950#issuecomment-423613018.

I have gone round the houses a bit with regards to this PR and think the dust has now settled, I was getting caught out by the fact `grep` is set on the rootSuite after instantiation, in that case it needs to process all the children recursively.

With regards to https://github.com/theintern/intern/issues/950#issuecomment-423339655, I believe the tests should be added and skipped rather than just excluded.

p.s. This PR will have a merge conflict with my other PR (https://github.com/theintern/intern/pull/955) relating to the type information for `LifecycleMethod`.