### PR TITLE
Fix query parsing when clicking on Suites/Tests in the Html reporter

### DIFF
--- a/src/lib/browser/util.ts
+++ b/src/lib/browser/util.ts
@@ -108,22 +108,15 @@ export function normalizePath(path: string) {
  * Parse a query string and return a set of decoded name=value pairs
  */
 export function parseQuery(query?: string) {
-  query = query || global.location.search.slice(1);
-  return query!
-    .split('&')
-    .filter(arg => {
-      return arg !== '' && arg[0] !== '=';
-    })
-    .map(arg => {
-      const parts = arg.split('=');
-      const name = decodeURIComponent(parts[0]);
-      if (parts[1]) {
-        return `${name}=${decodeURIComponent(parts[1].replace(/\+/g, '%20'))}`;
-      } else if (parts.length > 1) {
-        return `${name}=`;
-      }
-      return name;
-    });
+  query = query || global.location.search;
+
+  const parsed: string[] = [];
+  const params = new URLSearchParams(query);
+  params.forEach((value, key) => {
+    parsed.push(value ? `${key}=${value}` : key);
+  });
+
+  return parsed;
 }
 
 /**

--- a/src/lib/browser/util.ts
+++ b/src/lib/browser/util.ts
@@ -118,7 +118,7 @@ export function parseQuery(query?: string) {
       const parts = arg.split('=');
       const name = decodeURIComponent(parts[0]);
       if (parts[1]) {
-        return `${name}=${decodeURIComponent(parts[1])}`;
+        return `${name}=${decodeURIComponent(parts[1].replace(/\+/g, '%20'))}`;
       } else if (parts.length > 1) {
         return `${name}=`;
       }

--- a/tests/unit/lib/browser/util.ts
+++ b/tests/unit/lib/browser/util.ts
@@ -227,8 +227,8 @@ registerSuite('lib/browser/util', function() {
       },
 
       parseQuery() {
-        const rawArgs = util.parseQuery('foo&bar=5&baz=6&baz=7&baz=8');
-        const expected = ['foo', 'bar=5', 'baz=6', 'baz=7', 'baz=8'];
+        const rawArgs = util.parseQuery('foo&bar=5&baz=6&baz=7&baz=foo+bar');
+        const expected = ['foo', 'bar=5', 'baz=6', 'baz=7', 'baz=foo bar'];
         assert.deepEqual(rawArgs, expected);
       },
 

--- a/tests/unit/lib/browser/util.ts
+++ b/tests/unit/lib/browser/util.ts
@@ -227,7 +227,7 @@ registerSuite('lib/browser/util', function() {
       },
 
       parseQuery() {
-        const rawArgs = util.parseQuery('foo&bar=5&baz=6&baz=7&baz=foo+bar');
+        const rawArgs = util.parseQuery('?foo&bar=5&baz=6&baz=7&baz=foo+bar');
         const expected = ['foo', 'bar=5', 'baz=6', 'baz=7', 'baz=foo bar'];
         assert.deepEqual(rawArgs, expected);
       },


### PR DESCRIPTION
Edit: I didn't really add much context to this, in summary clicking on a link to apply a grep, results in skipping all the tests because nothing ever matches (tested in chrome 70)

The Html reporter was updated to use `URLSearchParams` at which point it started using "+" rather than "%20" to replace spaces. The knock on effect was that `parseQuery` does not understand what to do with "+" as it uses `decodeURIComponent`.

https://github.com/theintern/intern/blob/6a93567201e0e6cb8f9e813b5f6eaab8b4886962/src/lib/browser/util.ts#L121

I did not parse using `URLSearchParams` as I presume tests are expected to [run in IE](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#Browser_compatibility). I am not sure if this was intentional for the Html reporter but tests using `Runner` should continue to work in IE.