### PR TITLE
Fix expand bug in html reporter that causes a row to disappear.

### DIFF
--- a/src/lib/reporters/Html.ts
+++ b/src/lib/reporters/Html.ts
@@ -195,7 +195,7 @@ export default class Html extends Reporter implements HtmlProperties {
 
       // Stop looping when we encounter a row that's not indented more
       // than the suite being updated
-      if (indentDelta === 0) {
+      if (indentDelta <= 0) {
         break;
       }
 


### PR DESCRIPTION
Fixes #966.

When a row is expanded in the HTML reporter, only direct descendants are made visible all grandchildren are hidden.  The code processing the rows was written to stop processing rows if a row at the same indent level was found.  If a row with a smaller indent value was encountered, that row was hidden as if it were a descendant.