### PR TITLE
Expose requested environment on Remote

### DIFF
--- a/src/lib/executors/Node.ts
+++ b/src/lib/executors/Node.ts
@@ -452,6 +452,7 @@ export default class Node extends Executor<NodeEvents, Config, NodePlugins> {
 
                 let remote: Remote = <Remote>new Command(session);
                 remote.environmentType = new Environment(session.capabilities);
+                remote.requestedEnvironment = environmentType;
                 this.remote = remote;
                 this.sessionId = remote.session.sessionId;
 
@@ -820,6 +821,7 @@ export interface NodePlugins extends Plugins {
 
 export interface Remote extends Command<any> {
   environmentType?: Environment;
+  requestedEnvironment?: Environment;
   setHeartbeatInterval(delay: number): Command<any>;
 }
 


### PR DESCRIPTION
Different drivers are inconsistent in how they report the browser and platform name and version, and IE for example doesn't report the OS version at all. This makes it hard to check the current platform from within tests. This PR adds a `requestedEnvironment` property to the `remote` object so that you can see the environment that you requested.