### PR TITLE
Marshal lifecycleMethod on Suite error

### DIFF
--- a/docs/api.json
+++ b/docs/api.json
@@ -2115,7 +2115,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 807,
+									"line": 808,
 									"character": 7
 								}
 							],
@@ -2150,7 +2150,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 808,
+									"line": 809,
 									"character": 11
 								}
 							],
@@ -2215,7 +2215,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 809,
+									"line": 810,
 									"character": 6
 								}
 							],
@@ -2249,7 +2249,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 810,
+									"line": 811,
 									"character": 8
 								}
 							],
@@ -2284,7 +2284,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 811,
+									"line": 812,
 									"character": 12
 								}
 							],
@@ -2349,7 +2349,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 812,
+									"line": 813,
 									"character": 6
 								}
 							],
@@ -2374,7 +2374,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 813,
+									"line": 814,
 									"character": 6
 								}
 							],
@@ -2408,7 +2408,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 814,
+									"line": 815,
 									"character": 19
 								}
 							],
@@ -2433,7 +2433,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 815,
+									"line": 816,
 									"character": 9
 								}
 							],
@@ -28104,7 +28104,7 @@
 					"sources": [
 						{
 							"fileName": "lib/Suite.ts",
-							"line": 792,
+							"line": 793,
 							"character": 39
 						}
 					]
@@ -28133,7 +28133,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 807,
+									"line": 808,
 									"character": 7
 								}
 							],
@@ -28163,7 +28163,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 808,
+									"line": 809,
 									"character": 11
 								}
 							],
@@ -28193,7 +28193,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 809,
+									"line": 810,
 									"character": 6
 								}
 							],
@@ -28222,7 +28222,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 810,
+									"line": 811,
 									"character": 8
 								}
 							],
@@ -28252,7 +28252,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 811,
+									"line": 812,
 									"character": 12
 								}
 							],
@@ -28282,7 +28282,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 812,
+									"line": 813,
 									"character": 6
 								}
 							],
@@ -28302,7 +28302,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 813,
+									"line": 814,
 									"character": 6
 								}
 							],
@@ -28331,7 +28331,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 814,
+									"line": 815,
 									"character": 19
 								}
 							],
@@ -28351,7 +28351,7 @@
 							"sources": [
 								{
 									"fileName": "lib/Suite.ts",
-									"line": 815,
+									"line": 816,
 									"character": 9
 								}
 							],
@@ -28381,7 +28381,7 @@
 					"sources": [
 						{
 							"fileName": "lib/Suite.ts",
-							"line": 806,
+							"line": 807,
 							"character": 32
 						}
 					],
@@ -28487,7 +28487,7 @@
 					"sources": [
 						{
 							"fileName": "lib/Suite.ts",
-							"line": 796,
+							"line": 797,
 							"character": 38
 						}
 					]
@@ -28506,7 +28506,7 @@
 					"sources": [
 						{
 							"fileName": "lib/Suite.ts",
-							"line": 843,
+							"line": 844,
 							"character": 27
 						}
 					],
@@ -28560,7 +28560,7 @@
 					"sources": [
 						{
 							"fileName": "lib/Suite.ts",
-							"line": 831,
+							"line": 832,
 							"character": 28
 						}
 					],
@@ -28596,7 +28596,7 @@
 											"sources": [
 												{
 													"fileName": "lib/Suite.ts",
-													"line": 832,
+													"line": 833,
 													"character": 10
 												}
 											],
@@ -28617,7 +28617,7 @@
 											"sources": [
 												{
 													"fileName": "lib/Suite.ts",
-													"line": 833,
+													"line": 834,
 													"character": 7
 												}
 											],
@@ -28654,7 +28654,7 @@
 									"sources": [
 										{
 											"fileName": "lib/Suite.ts",
-											"line": 831,
+											"line": 832,
 											"character": 57
 										}
 									]
@@ -28677,7 +28677,7 @@
 					"sources": [
 						{
 							"fileName": "lib/Suite.ts",
-							"line": 821,
+							"line": 822,
 							"character": 24
 						}
 					],
@@ -28713,7 +28713,7 @@
 											"sources": [
 												{
 													"fileName": "lib/Suite.ts",
-													"line": 822,
+													"line": 823,
 													"character": 6
 												}
 											],
@@ -28731,7 +28731,7 @@
 											"sources": [
 												{
 													"fileName": "lib/Suite.ts",
-													"line": 823,
+													"line": 824,
 													"character": 8
 												}
 											],
@@ -28752,7 +28752,7 @@
 											"sources": [
 												{
 													"fileName": "lib/Suite.ts",
-													"line": 824,
+													"line": 825,
 													"character": 7
 												}
 											],
@@ -28790,7 +28790,7 @@
 									"sources": [
 										{
 											"fileName": "lib/Suite.ts",
-											"line": 821,
+											"line": 822,
 											"character": 53
 										}
 									]
@@ -28810,7 +28810,7 @@
 					"sources": [
 						{
 							"fileName": "lib/Suite.ts",
-							"line": 838,
+							"line": 839,
 							"character": 17
 						}
 					],
@@ -28857,7 +28857,7 @@
 					"sources": [
 						{
 							"fileName": "lib/Suite.ts",
-							"line": 788,
+							"line": 789,
 							"character": 23
 						}
 					]

--- a/src/lib/Suite.ts
+++ b/src/lib/Suite.ts
@@ -768,7 +768,8 @@ export default class Suite implements SuiteProperties {
       json.error = {
         name: this.error.name,
         message: this.error.message,
-        stack: this.error.stack
+        stack: this.error.stack,
+        lifecycleMethod: this.error.lifecycleMethod
       };
 
       if (this.error.relatedTest && this.error.relatedTest !== <any>this) {

--- a/tests/unit/lib/Suite.ts
+++ b/tests/unit/lib/Suite.ts
@@ -1628,6 +1628,7 @@ registerSuite('lib/Suite', {
       name: 'bad',
       message: 'failed',
       stack: '',
+      lifecycleMethod: 'afterEach',
       relatedTest: <Test>suite.tests[0]
     };
 
@@ -1637,6 +1638,7 @@ registerSuite('lib/Suite', {
         name: 'bad',
         message: 'failed',
         stack: '',
+        lifecycleMethod: 'afterEach',
         relatedTest: {
           id: 'foo - bar',
           parentId: 'foo',


### PR DESCRIPTION
Found this when testing the updated JUnit reporter. The lifecycleMethod was not being marshalled on Suite error, therefore the JUnit reporter was unable to generate reports for remote suites with the correct errors. See screenshot below (before and after):

![image](https://user-images.githubusercontent.com/15254526/70754984-8b3eb600-1d30-11ea-863c-78405bcbd1a2.png)
