### PR TITLE
Option to disable the 'dom' reporter in the remote browser.

### DIFF
--- a/src/lib/RemoteSuite.ts
+++ b/src/lib/RemoteSuite.ts
@@ -221,11 +221,14 @@ export default class RemoteSuite extends Suite {
         // These are options that will be POSTed to the remote page and
         // used to configure intern. Stringify and parse them to ensure
         // that the config can be properly transmitted.
+        const disableDomUpdates =
+          config.remoteOptions && config.remoteOptions.disableDomUpdates;
+        const remoteReporters = disableDomUpdates ? [] : [{ name: 'dom' }];
         const remoteConfig: Partial<RemoteConfig> = {
           debug: config.debug,
           internPath: `${serverUrl.pathname}${internPath}`,
           name: this.id,
-          reporters: [{ name: 'dom' }]
+          reporters: remoteReporters
         };
 
         // Don't overwrite any config data we've already set

--- a/src/lib/common/config.ts
+++ b/src/lib/common/config.ts
@@ -269,6 +269,11 @@ export interface Config extends ResourceConfig {
   proxy?: string;
 
   /**
+   * Options to pass to the remote runner.
+   */
+  remoteOptions: RemoteOptions;
+
+  /**
    * If true, a remote will wait for reponses from Intern for any executor
    * events.
    */
@@ -500,4 +505,8 @@ export interface LoaderDescriptor {
 export interface EnvironmentSpec {
   browserName: string;
   [key: string]: any;
+}
+
+export interface RemoteOptions {
+  disableDomUpdates: boolean;
 }

--- a/src/lib/common/util.ts
+++ b/src/lib/common/util.ts
@@ -569,6 +569,10 @@ export function processOption<C extends Config>(
       );
       break;
     }
+    case 'remoteOptions': {
+      setOption(config, name, parseValue(name, value, 'object'));
+      break;
+    }
     case 'excludeInstrumentation': {
       emit('deprecated', {
         original: 'excludeInstrumentation',

--- a/src/schemas/config.json
+++ b/src/schemas/config.json
@@ -328,6 +328,8 @@
           ]
         },
 
+        "remoteOptions": { "$ref": "#/definitions/remoteOptions" },
+
         "reporters": { "$ref": "#/definitions/reportersProperty" },
         "reporters+": { "$ref": "#/definitions/reportersProperty+" },
 
@@ -574,6 +576,14 @@
     "positiveNumber": {
       "type": "number",
       "minimum": 0
+    },
+
+    "remoteOptions": {
+      "description": "Options to pass to the remote runner",
+      "type": "object",
+      "properties": {
+        "disableDomUpdates": { "type": "boolean" }
+      }
     },
 
     "reporterName": {

--- a/tests/unit/lib/executors/Executor.ts
+++ b/tests/unit/lib/executors/Executor.ts
@@ -382,6 +382,17 @@ registerSuite('lib/executors/Executor', function() {
                 },
                 /Non-object/
               );
+            },
+
+            remoteOptions() {
+              test('remoteOptions', 5, {}, {}, /Non-object/);
+              test(
+                'remoteOptions',
+                5,
+                { disableDomUpdates: true },
+                { disableDomUpdates: true },
+                /Non-object/
+              );
             }
           };
         })()


### PR DESCRIPTION
As discussed on Gitter, this creates an option
`{
    remoteOptions: {
        disableDomUpdates: true
    }
}`
that avoids the `dom` reporter from being automatically selected for a remotely opened browser run.

This fixes #909.