### PR TITLE
Added directory/filename support to JUnit

### DIFF
--- a/docs/api.json
+++ b/docs/api.json
@@ -5,7 +5,7 @@
 	"flags": {},
 	"children": [
 		{
-			"id": 4346,
+			"id": 4350,
 			"name": "\"bin/intern\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -15,21 +15,21 @@
 			"originalName": "src/bin/intern.ts",
 			"children": [
 				{
-					"id": 4347,
+					"id": 4351,
 					"name": "printHelp",
 					"kind": 64,
 					"kindString": "Function",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 4348,
+							"id": 4352,
 							"name": "printHelp",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 4349,
+									"id": 4353,
 									"name": "config",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -40,7 +40,7 @@
 									}
 								},
 								{
-									"id": 4350,
+									"id": 4354,
 									"name": "file",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -82,7 +82,7 @@
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						4347
+						4351
 					]
 				}
 			],
@@ -95,7 +95,7 @@
 			]
 		},
 		{
-			"id": 4342,
+			"id": 4346,
 			"name": "\"index\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -109,7 +109,7 @@
 			},
 			"children": [
 				{
-					"id": 4344,
+					"id": 4348,
 					"name": "__global",
 					"kind": 2,
 					"kindString": "Module",
@@ -118,7 +118,7 @@
 					},
 					"children": [
 						{
-							"id": 4345,
+							"id": 4349,
 							"name": "intern",
 							"kind": 32,
 							"kindString": "Variable",
@@ -148,7 +148,7 @@
 							"title": "Variables",
 							"kind": 32,
 							"children": [
-								4345
+								4349
 							]
 						}
 					],
@@ -161,7 +161,7 @@
 					]
 				},
 				{
-					"id": 4343,
+					"id": 4347,
 					"name": "intern",
 					"kind": 32,
 					"kindString": "Variable",
@@ -180,7 +180,7 @@
 					"type": {
 						"type": "reference",
 						"name": "Node",
-						"id": 2600
+						"id": 2607
 					},
 					"defaultValue": " (global.intern = new NodeExecutor())"
 				}
@@ -190,14 +190,14 @@
 					"title": "Modules",
 					"kind": 2,
 					"children": [
-						4344
+						4348
 					]
 				},
 				{
 					"title": "Variables",
 					"kind": 32,
 					"children": [
-						4343
+						4347
 					]
 				}
 			],
@@ -210,7 +210,7 @@
 			]
 		},
 		{
-			"id": 3652,
+			"id": 3659,
 			"name": "\"lib/BenchmarkSuite\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -220,7 +220,7 @@
 			"originalName": "src/lib/BenchmarkSuite.ts",
 			"children": [
 				{
-					"id": 3653,
+					"id": 3660,
 					"name": "BenchmarkSuite",
 					"kind": 128,
 					"kindString": "Class",
@@ -232,7 +232,7 @@
 					},
 					"children": [
 						{
-							"id": 3657,
+							"id": 3664,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -241,14 +241,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3658,
+									"id": 3665,
 									"name": "new BenchmarkSuite",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3659,
+											"id": 3666,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -256,19 +256,19 @@
 											"type": {
 												"type": "reference",
 												"name": "BenchmarkSuiteOptions",
-												"id": 3737
+												"id": 3744
 											}
 										}
 									],
 									"type": {
 										"type": "reference",
 										"name": "BenchmarkSuite",
-										"id": 3653
+										"id": 3660
 									},
 									"overwrites": {
 										"type": "reference",
 										"name": "Suite.__constructor",
-										"id": 3415
+										"id": 3422
 									}
 								}
 							],
@@ -282,11 +282,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Suite.__constructor",
-								"id": 3415
+								"id": 3422
 							}
 						},
 						{
-							"id": 3660,
+							"id": 3667,
 							"name": "after",
 							"kind": 1024,
 							"kindString": "Property",
@@ -309,7 +309,7 @@
 									{
 										"type": "reference",
 										"name": "SuiteLifecycleFunction",
-										"id": 3470
+										"id": 3477
 									},
 									{
 										"type": "intrinsic",
@@ -320,16 +320,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.after",
-								"id": 3401
+								"id": 3408
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkSuiteProperties.after",
-								"id": 3728
+								"id": 3735
 							}
 						},
 						{
-							"id": 3661,
+							"id": 3668,
 							"name": "afterEach",
 							"kind": 1024,
 							"kindString": "Property",
@@ -352,7 +352,7 @@
 									{
 										"type": "reference",
 										"name": "TestLifecycleFunction",
-										"id": 3474
+										"id": 3481
 									},
 									{
 										"type": "intrinsic",
@@ -363,16 +363,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.afterEach",
-								"id": 3402
+								"id": 3409
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkSuiteProperties.afterEach",
-								"id": 3729
+								"id": 3736
 							}
 						},
 						{
-							"id": 3654,
+							"id": 3661,
 							"name": "afterEachLoop",
 							"kind": 1024,
 							"kindString": "Property",
@@ -395,7 +395,7 @@
 									{
 										"type": "reference",
 										"name": "TestLifecycleFunction",
-										"id": 3474
+										"id": 3481
 									},
 									{
 										"type": "intrinsic",
@@ -406,11 +406,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkSuiteProperties.afterEachLoop",
-								"id": 3727
+								"id": 3734
 							}
 						},
 						{
-							"id": 3662,
+							"id": 3669,
 							"name": "async",
 							"kind": 1024,
 							"kindString": "Property",
@@ -433,21 +433,21 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 3663,
+											"id": 3670,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 3664,
+													"id": 3671,
 													"name": "__call",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 3665,
+															"id": 3672,
 															"name": "timeout",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -500,11 +500,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.async",
-								"id": 3403
+								"id": 3410
 							}
 						},
 						{
-							"id": 3666,
+							"id": 3673,
 							"name": "before",
 							"kind": 1024,
 							"kindString": "Property",
@@ -527,7 +527,7 @@
 									{
 										"type": "reference",
 										"name": "SuiteLifecycleFunction",
-										"id": 3470
+										"id": 3477
 									},
 									{
 										"type": "intrinsic",
@@ -538,16 +538,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.before",
-								"id": 3407
+								"id": 3414
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkSuiteProperties.before",
-								"id": 3731
+								"id": 3738
 							}
 						},
 						{
-							"id": 3667,
+							"id": 3674,
 							"name": "beforeEach",
 							"kind": 1024,
 							"kindString": "Property",
@@ -570,7 +570,7 @@
 									{
 										"type": "reference",
 										"name": "TestLifecycleFunction",
-										"id": 3474
+										"id": 3481
 									},
 									{
 										"type": "intrinsic",
@@ -581,16 +581,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.beforeEach",
-								"id": 3408
+								"id": 3415
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkSuiteProperties.beforeEach",
-								"id": 3732
+								"id": 3739
 							}
 						},
 						{
-							"id": 3655,
+							"id": 3662,
 							"name": "beforeEachLoop",
 							"kind": 1024,
 							"kindString": "Property",
@@ -613,7 +613,7 @@
 									{
 										"type": "reference",
 										"name": "TestLifecycleFunction",
-										"id": 3474
+										"id": 3481
 									},
 									{
 										"type": "intrinsic",
@@ -624,11 +624,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkSuiteProperties.beforeEachLoop",
-								"id": 3726
+								"id": 3733
 							}
 						},
 						{
-							"id": 3668,
+							"id": 3675,
 							"name": "error",
 							"kind": 1024,
 							"kindString": "Property",
@@ -662,11 +662,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.error",
-								"id": 3409
+								"id": 3416
 							}
 						},
 						{
-							"id": 3669,
+							"id": 3676,
 							"name": "parent",
 							"kind": 1024,
 							"kindString": "Property",
@@ -689,7 +689,7 @@
 									{
 										"type": "reference",
 										"name": "Suite",
-										"id": 3400
+										"id": 3407
 									},
 									{
 										"type": "intrinsic",
@@ -700,11 +700,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.parent",
-								"id": 3410
+								"id": 3417
 							}
 						},
 						{
-							"id": 3670,
+							"id": 3677,
 							"name": "publishAfterSetup",
 							"kind": 1024,
 							"kindString": "Property",
@@ -729,16 +729,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.publishAfterSetup",
-								"id": 3411
+								"id": 3418
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkSuiteProperties.publishAfterSetup",
-								"id": 3735
+								"id": 3742
 							}
 						},
 						{
-							"id": 3671,
+							"id": 3678,
 							"name": "skipped",
 							"kind": 1024,
 							"kindString": "Property",
@@ -771,11 +771,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.skipped",
-								"id": 3412
+								"id": 3419
 							}
 						},
 						{
-							"id": 3656,
+							"id": 3663,
 							"name": "tests",
 							"kind": 1024,
 							"kindString": "Property",
@@ -797,12 +797,12 @@
 										{
 											"type": "reference",
 											"name": "BenchmarkTest",
-											"id": 1984
+											"id": 1991
 										},
 										{
 											"type": "reference",
 											"name": "BenchmarkSuite",
-											"id": 3653
+											"id": 3660
 										}
 									]
 								}
@@ -810,11 +810,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Suite.tests",
-								"id": 3413
+								"id": 3420
 							}
 						},
 						{
-							"id": 3672,
+							"id": 3679,
 							"name": "timeElapsed",
 							"kind": 1024,
 							"kindString": "Property",
@@ -847,11 +847,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.timeElapsed",
-								"id": 3414
+								"id": 3421
 							}
 						},
 						{
-							"id": 3673,
+							"id": 3680,
 							"name": "bail",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -863,7 +863,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3674,
+									"id": 3681,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -878,13 +878,13 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.bail",
-										"id": 3418
+										"id": 3425
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 3675,
+									"id": 3682,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -894,7 +894,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3676,
+											"id": 3683,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -912,7 +912,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.bail",
-										"id": 3418
+										"id": 3425
 									}
 								}
 							],
@@ -931,16 +931,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.bail",
-								"id": 3418
+								"id": 3425
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkSuiteProperties.bail",
-								"id": 3730
+								"id": 3737
 							}
 						},
 						{
-							"id": 3677,
+							"id": 3684,
 							"name": "executor",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -952,7 +952,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3678,
+									"id": 3685,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -963,18 +963,18 @@
 									"type": {
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.executor",
-										"id": 3422
+										"id": 3429
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 3679,
+									"id": 3686,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -984,7 +984,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3680,
+											"id": 3687,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -992,7 +992,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Executor",
-												"id": 3780
+												"id": 3787
 											}
 										}
 									],
@@ -1003,7 +1003,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.executor",
-										"id": 3422
+										"id": 3429
 									}
 								}
 							],
@@ -1022,11 +1022,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.executor",
-								"id": 3422
+								"id": 3429
 							}
 						},
 						{
-							"id": 3681,
+							"id": 3688,
 							"name": "grep",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -1038,7 +1038,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3682,
+									"id": 3689,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -1053,13 +1053,13 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.grep",
-										"id": 3426
+										"id": 3433
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 3683,
+									"id": 3690,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -1069,7 +1069,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3684,
+											"id": 3691,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1087,7 +1087,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.grep",
-										"id": 3426
+										"id": 3433
 									}
 								}
 							],
@@ -1106,16 +1106,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.grep",
-								"id": 3426
+								"id": 3433
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkSuiteProperties.grep",
-								"id": 3733
+								"id": 3740
 							}
 						},
 						{
-							"id": 3709,
+							"id": 3716,
 							"name": "hasParent",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -1127,7 +1127,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3710,
+									"id": 3717,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -1142,7 +1142,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.hasParent",
-										"id": 3454
+										"id": 3461
 									}
 								}
 							],
@@ -1156,11 +1156,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.hasParent",
-								"id": 3454
+								"id": 3461
 							}
 						},
 						{
-							"id": 3689,
+							"id": 3696,
 							"name": "id",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -1172,7 +1172,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3690,
+									"id": 3697,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -1187,7 +1187,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.id",
-										"id": 3434
+										"id": 3441
 									}
 								}
 							],
@@ -1201,11 +1201,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.id",
-								"id": 3434
+								"id": 3441
 							}
 						},
 						{
-							"id": 3685,
+							"id": 3692,
 							"name": "name",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -1217,7 +1217,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3686,
+									"id": 3693,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -1241,13 +1241,13 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.name",
-										"id": 3430
+										"id": 3437
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 3687,
+									"id": 3694,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -1257,7 +1257,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3688,
+											"id": 3695,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1284,7 +1284,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.name",
-										"id": 3430
+										"id": 3437
 									}
 								}
 							],
@@ -1303,16 +1303,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.name",
-								"id": 3430
+								"id": 3437
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkSuiteProperties.name",
-								"id": 3734
+								"id": 3741
 							}
 						},
 						{
-							"id": 3705,
+							"id": 3712,
 							"name": "numFailedTests",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -1324,7 +1324,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3706,
+									"id": 3713,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -1339,7 +1339,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.numFailedTests",
-										"id": 3450
+										"id": 3457
 									}
 								}
 							],
@@ -1353,11 +1353,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.numFailedTests",
-								"id": 3450
+								"id": 3457
 							}
 						},
 						{
-							"id": 3703,
+							"id": 3710,
 							"name": "numPassedTests",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -1369,7 +1369,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3704,
+									"id": 3711,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -1384,7 +1384,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.numPassedTests",
-										"id": 3448
+										"id": 3455
 									}
 								}
 							],
@@ -1398,11 +1398,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.numPassedTests",
-								"id": 3448
+								"id": 3455
 							}
 						},
 						{
-							"id": 3707,
+							"id": 3714,
 							"name": "numSkippedTests",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -1414,7 +1414,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3708,
+									"id": 3715,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -1429,7 +1429,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.numSkippedTests",
-										"id": 3452
+										"id": 3459
 									}
 								}
 							],
@@ -1443,11 +1443,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.numSkippedTests",
-								"id": 3452
+								"id": 3459
 							}
 						},
 						{
-							"id": 3701,
+							"id": 3708,
 							"name": "numTests",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -1459,7 +1459,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3702,
+									"id": 3709,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -1474,7 +1474,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.numTests",
-										"id": 3446
+										"id": 3453
 									}
 								}
 							],
@@ -1488,11 +1488,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.numTests",
-								"id": 3446
+								"id": 3453
 							}
 						},
 						{
-							"id": 3691,
+							"id": 3698,
 							"name": "parentId",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -1504,7 +1504,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3692,
+									"id": 3699,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -1528,7 +1528,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.parentId",
-										"id": 3436
+										"id": 3443
 									}
 								}
 							],
@@ -1542,11 +1542,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.parentId",
-								"id": 3436
+								"id": 3443
 							}
 						},
 						{
-							"id": 3693,
+							"id": 3700,
 							"name": "remote",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -1558,7 +1558,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3694,
+									"id": 3701,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -1569,18 +1569,18 @@
 									"type": {
 										"type": "reference",
 										"name": "Remote",
-										"id": 2813
+										"id": 2820
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.remote",
-										"id": 3438
+										"id": 3445
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 3695,
+									"id": 3702,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -1590,7 +1590,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3696,
+											"id": 3703,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1598,7 +1598,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Remote",
-												"id": 2813
+												"id": 2820
 											}
 										}
 									],
@@ -1609,7 +1609,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.remote",
-										"id": 3438
+										"id": 3445
 									}
 								}
 							],
@@ -1628,11 +1628,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.remote",
-								"id": 3438
+								"id": 3445
 							}
 						},
 						{
-							"id": 3697,
+							"id": 3704,
 							"name": "sessionId",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -1644,7 +1644,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3698,
+									"id": 3705,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -1659,13 +1659,13 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.sessionId",
-										"id": 3442
+										"id": 3449
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 3699,
+									"id": 3706,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -1675,7 +1675,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3700,
+											"id": 3707,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1693,7 +1693,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.sessionId",
-										"id": 3442
+										"id": 3449
 									}
 								}
 							],
@@ -1712,11 +1712,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.sessionId",
-								"id": 3442
+								"id": 3449
 							}
 						},
 						{
-							"id": 3711,
+							"id": 3718,
 							"name": "timeout",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -1725,7 +1725,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3712,
+									"id": 3719,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -1737,20 +1737,20 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.timeout",
-										"id": 3456
+										"id": 3463
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 3713,
+									"id": 3720,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3714,
+											"id": 3721,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1768,7 +1768,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.timeout",
-										"id": 3456
+										"id": 3463
 									}
 								}
 							],
@@ -1787,16 +1787,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.timeout",
-								"id": 3456
+								"id": 3463
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkSuiteProperties.timeout",
-								"id": 3736
+								"id": 3743
 							}
 						},
 						{
-							"id": 3715,
+							"id": 3722,
 							"name": "add",
 							"kind": 2048,
 							"kindString": "Method",
@@ -1805,7 +1805,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3716,
+									"id": 3723,
 									"name": "add",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -1815,7 +1815,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3717,
+											"id": 3724,
 											"name": "suiteOrTest",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1826,12 +1826,12 @@
 													{
 														"type": "reference",
 														"name": "Suite",
-														"id": 3400
+														"id": 3407
 													},
 													{
 														"type": "reference",
 														"name": "Test",
-														"id": 3317
+														"id": 3324
 													}
 												]
 											}
@@ -1844,7 +1844,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.add",
-										"id": 3460
+										"id": 3467
 									}
 								}
 							],
@@ -1858,11 +1858,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.add",
-								"id": 3460
+								"id": 3467
 							}
 						},
 						{
-							"id": 3718,
+							"id": 3725,
 							"name": "run",
 							"kind": 2048,
 							"kindString": "Method",
@@ -1871,7 +1871,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3719,
+									"id": 3726,
 									"name": "run",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -1893,7 +1893,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.run",
-										"id": 3463
+										"id": 3470
 									}
 								}
 							],
@@ -1907,11 +1907,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.run",
-								"id": 3463
+								"id": 3470
 							}
 						},
 						{
-							"id": 3720,
+							"id": 3727,
 							"name": "skip",
 							"kind": 2048,
 							"kindString": "Method",
@@ -1920,7 +1920,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3721,
+									"id": 3728,
 									"name": "skip",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -1931,7 +1931,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3722,
+											"id": 3729,
 											"name": "message",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1953,7 +1953,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.skip",
-										"id": 3465
+										"id": 3472
 									}
 								}
 							],
@@ -1967,11 +1967,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.skip",
-								"id": 3465
+								"id": 3472
 							}
 						},
 						{
-							"id": 3723,
+							"id": 3730,
 							"name": "toJSON",
 							"kind": 2048,
 							"kindString": "Method",
@@ -1980,7 +1980,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3724,
+									"id": 3731,
 									"name": "toJSON",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -1992,7 +1992,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.toJSON",
-										"id": 3468
+										"id": 3475
 									}
 								}
 							],
@@ -2006,7 +2006,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.toJSON",
-								"id": 3468
+								"id": 3475
 							}
 						}
 					],
@@ -2015,56 +2015,56 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								3657
+								3664
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3660,
-								3661,
-								3654,
-								3662,
-								3666,
 								3667,
-								3655,
 								3668,
+								3661,
 								3669,
-								3670,
-								3671,
-								3656,
-								3672
+								3673,
+								3674,
+								3662,
+								3675,
+								3676,
+								3677,
+								3678,
+								3663,
+								3679
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								3673,
-								3677,
-								3681,
-								3709,
-								3689,
-								3685,
-								3705,
-								3703,
-								3707,
-								3701,
-								3691,
-								3693,
-								3697,
-								3711
+								3680,
+								3684,
+								3688,
+								3716,
+								3696,
+								3692,
+								3712,
+								3710,
+								3714,
+								3708,
+								3698,
+								3700,
+								3704,
+								3718
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								3715,
-								3718,
-								3720,
-								3723
+								3722,
+								3725,
+								3727,
+								3730
 							]
 						}
 					],
@@ -2079,24 +2079,24 @@
 						{
 							"type": "reference",
 							"name": "Suite",
-							"id": 3400
+							"id": 3407
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "SuiteProperties",
-							"id": 3479
+							"id": 3486
 						},
 						{
 							"type": "reference",
 							"name": "BenchmarkSuiteProperties",
-							"id": 3725
+							"id": 3732
 						}
 					]
 				},
 				{
-					"id": 3725,
+					"id": 3732,
 					"name": "BenchmarkSuiteProperties",
 					"kind": 256,
 					"kindString": "Interface",
@@ -2105,7 +2105,7 @@
 					},
 					"children": [
 						{
-							"id": 3728,
+							"id": 3735,
 							"name": "after",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2125,7 +2125,7 @@
 									{
 										"type": "reference",
 										"name": "SuiteLifecycleFunction",
-										"id": 3470
+										"id": 3477
 									},
 									{
 										"type": "intrinsic",
@@ -2136,11 +2136,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "SuiteProperties.after",
-								"id": 3480
+								"id": 3487
 							}
 						},
 						{
-							"id": 3729,
+							"id": 3736,
 							"name": "afterEach",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2160,7 +2160,7 @@
 									{
 										"type": "reference",
 										"name": "TestLifecycleFunction",
-										"id": 3474
+										"id": 3481
 									},
 									{
 										"type": "intrinsic",
@@ -2171,11 +2171,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "SuiteProperties.afterEach",
-								"id": 3481
+								"id": 3488
 							}
 						},
 						{
-							"id": 3727,
+							"id": 3734,
 							"name": "afterEachLoop",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2195,7 +2195,7 @@
 									{
 										"type": "reference",
 										"name": "TestLifecycleFunction",
-										"id": 3474
+										"id": 3481
 									},
 									{
 										"type": "intrinsic",
@@ -2205,7 +2205,7 @@
 							}
 						},
 						{
-							"id": 3730,
+							"id": 3737,
 							"name": "bail",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2235,11 +2235,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "SuiteProperties.bail",
-								"id": 3482
+								"id": 3489
 							}
 						},
 						{
-							"id": 3731,
+							"id": 3738,
 							"name": "before",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2259,7 +2259,7 @@
 									{
 										"type": "reference",
 										"name": "SuiteLifecycleFunction",
-										"id": 3470
+										"id": 3477
 									},
 									{
 										"type": "intrinsic",
@@ -2270,11 +2270,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "SuiteProperties.before",
-								"id": 3483
+								"id": 3490
 							}
 						},
 						{
-							"id": 3732,
+							"id": 3739,
 							"name": "beforeEach",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2294,7 +2294,7 @@
 									{
 										"type": "reference",
 										"name": "TestLifecycleFunction",
-										"id": 3474
+										"id": 3481
 									},
 									{
 										"type": "intrinsic",
@@ -2305,11 +2305,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "SuiteProperties.beforeEach",
-								"id": 3484
+								"id": 3491
 							}
 						},
 						{
-							"id": 3726,
+							"id": 3733,
 							"name": "beforeEachLoop",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2329,7 +2329,7 @@
 									{
 										"type": "reference",
 										"name": "TestLifecycleFunction",
-										"id": 3474
+										"id": 3481
 									},
 									{
 										"type": "intrinsic",
@@ -2339,7 +2339,7 @@
 							}
 						},
 						{
-							"id": 3733,
+							"id": 3740,
 							"name": "grep",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2360,11 +2360,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "SuiteProperties.grep",
-								"id": 3485
+								"id": 3492
 							}
 						},
 						{
-							"id": 3734,
+							"id": 3741,
 							"name": "name",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2394,11 +2394,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "SuiteProperties.name",
-								"id": 3486
+								"id": 3493
 							}
 						},
 						{
-							"id": 3735,
+							"id": 3742,
 							"name": "publishAfterSetup",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2419,11 +2419,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "SuiteProperties.publishAfterSetup",
-								"id": 3487
+								"id": 3494
 							}
 						},
 						{
-							"id": 3736,
+							"id": 3743,
 							"name": "timeout",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2444,7 +2444,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "SuiteProperties.timeout",
-								"id": 3488
+								"id": 3495
 							}
 						}
 					],
@@ -2453,17 +2453,17 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3728,
-								3729,
-								3727,
-								3730,
-								3731,
-								3732,
-								3726,
-								3733,
-								3734,
 								3735,
-								3736
+								3736,
+								3734,
+								3737,
+								3738,
+								3739,
+								3733,
+								3740,
+								3741,
+								3742,
+								3743
 							]
 						}
 					],
@@ -2478,19 +2478,19 @@
 						{
 							"type": "reference",
 							"name": "SuiteProperties",
-							"id": 3479
+							"id": 3486
 						}
 					],
 					"implementedBy": [
 						{
 							"type": "reference",
 							"name": "BenchmarkSuite",
-							"id": 3653
+							"id": 3660
 						}
 					]
 				},
 				{
-					"id": 3737,
+					"id": 3744,
 					"name": "BenchmarkSuiteOptions",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -2514,21 +2514,21 @@
 									{
 										"type": "reference",
 										"name": "BenchmarkSuiteProperties",
-										"id": 3725
+										"id": 3732
 									}
 								]
 							},
 							{
 								"type": "reflection",
 								"declaration": {
-									"id": 3738,
+									"id": 3745,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 3739,
+											"id": 3746,
 											"name": "name",
 											"kind": 32,
 											"kindString": "Variable",
@@ -2546,7 +2546,7 @@
 											}
 										},
 										{
-											"id": 3740,
+											"id": 3747,
 											"name": "parent",
 											"kind": 32,
 											"kindString": "Variable",
@@ -2561,11 +2561,11 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										},
 										{
-											"id": 3741,
+											"id": 3748,
 											"name": "tests",
 											"kind": 32,
 											"kindString": "Variable",
@@ -2587,12 +2587,12 @@
 														{
 															"type": "reference",
 															"name": "BenchmarkTest",
-															"id": 1984
+															"id": 1991
 														},
 														{
 															"type": "reference",
 															"name": "BenchmarkSuite",
-															"id": 3653
+															"id": 3660
 														}
 													]
 												}
@@ -2604,9 +2604,9 @@
 											"title": "Variables",
 											"kind": 32,
 											"children": [
-												3739,
-												3740,
-												3741
+												3746,
+												3747,
+												3748
 											]
 										}
 									],
@@ -2628,21 +2628,21 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						3653
+						3660
 					]
 				},
 				{
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						3725
+						3732
 					]
 				},
 				{
 					"title": "Type aliases",
 					"kind": 4194304,
 					"children": [
-						3737
+						3744
 					]
 				}
 			],
@@ -2655,7 +2655,7 @@
 			]
 		},
 		{
-			"id": 1983,
+			"id": 1990,
 			"name": "\"lib/BenchmarkTest\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -2665,7 +2665,7 @@
 			"originalName": "src/lib/BenchmarkTest.ts",
 			"children": [
 				{
-					"id": 1984,
+					"id": 1991,
 					"name": "BenchmarkTest",
 					"kind": 128,
 					"kindString": "Class",
@@ -2677,7 +2677,7 @@
 					},
 					"children": [
 						{
-							"id": 1987,
+							"id": 1994,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -2686,14 +2686,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1988,
+									"id": 1995,
 									"name": "new BenchmarkTest",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1989,
+											"id": 1996,
 											"name": "descriptor",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -2701,19 +2701,19 @@
 											"type": {
 												"type": "reference",
 												"name": "BenchmarkTestOptions",
-												"id": 2427
+												"id": 2434
 											}
 										}
 									],
 									"type": {
 										"type": "reference",
 										"name": "BenchmarkTest",
-										"id": 1984
+										"id": 1991
 									},
 									"overwrites": {
 										"type": "reference",
 										"name": "Test.__constructor",
-										"id": 3331
+										"id": 3338
 									}
 								}
 							],
@@ -2727,11 +2727,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Test.__constructor",
-								"id": 3331
+								"id": 3338
 							}
 						},
 						{
-							"id": 2014,
+							"id": 2021,
 							"name": "_hasPassed",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2754,11 +2754,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test._hasPassed",
-								"id": 3324
+								"id": 3331
 							}
 						},
 						{
-							"id": 2015,
+							"id": 2022,
 							"name": "_isAsync",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2781,11 +2781,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test._isAsync",
-								"id": 3325
+								"id": 3332
 							}
 						},
 						{
-							"id": 2017,
+							"id": 2024,
 							"name": "_runTask",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2822,11 +2822,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test._runTask",
-								"id": 3327
+								"id": 3334
 							}
 						},
 						{
-							"id": 2018,
+							"id": 2025,
 							"name": "_timeElapsed",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2857,11 +2857,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test._timeElapsed",
-								"id": 3328
+								"id": 3335
 							}
 						},
 						{
-							"id": 2016,
+							"id": 2023,
 							"name": "_timeout",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2892,11 +2892,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test._timeout",
-								"id": 3326
+								"id": 3333
 							}
 						},
 						{
-							"id": 2019,
+							"id": 2026,
 							"name": "_timer",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2927,11 +2927,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test._timer",
-								"id": 3329
+								"id": 3336
 							}
 						},
 						{
-							"id": 2020,
+							"id": 2027,
 							"name": "_usesRemote",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2954,11 +2954,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test._usesRemote",
-								"id": 3330
+								"id": 3337
 							}
 						},
 						{
-							"id": 1986,
+							"id": 1993,
 							"name": "benchmark",
 							"kind": 1024,
 							"kindString": "Property",
@@ -2978,11 +2978,11 @@
 							"type": {
 								"type": "reference",
 								"name": "InternBenchmark",
-								"id": 2093
+								"id": 2100
 							}
 						},
 						{
-							"id": 2012,
+							"id": 2019,
 							"name": "error",
 							"kind": 1024,
 							"kindString": "Property",
@@ -3016,11 +3016,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.error",
-								"id": 3322
+								"id": 3329
 							}
 						},
 						{
-							"id": 2009,
+							"id": 2016,
 							"name": "name",
 							"kind": 1024,
 							"kindString": "Property",
@@ -3044,16 +3044,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.name",
-								"id": 3318
+								"id": 3325
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "TestProperties.name",
-								"id": 3380
+								"id": 3387
 							}
 						},
 						{
-							"id": 2010,
+							"id": 2017,
 							"name": "parent",
 							"kind": 1024,
 							"kindString": "Property",
@@ -3073,21 +3073,21 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.parent",
-								"id": 3319
+								"id": 3326
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "TestProperties.parent",
-								"id": 3381
+								"id": 3388
 							}
 						},
 						{
-							"id": 2011,
+							"id": 2018,
 							"name": "skipped",
 							"kind": 1024,
 							"kindString": "Property",
@@ -3120,16 +3120,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.skipped",
-								"id": 3320
+								"id": 3327
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "TestProperties.skipped",
-								"id": 3382
+								"id": 3389
 							}
 						},
 						{
-							"id": 2013,
+							"id": 2020,
 							"name": "suiteError",
 							"kind": 1024,
 							"kindString": "Property",
@@ -3163,11 +3163,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.suiteError",
-								"id": 3323
+								"id": 3330
 							}
 						},
 						{
-							"id": 1985,
+							"id": 1992,
 							"name": "test",
 							"kind": 1024,
 							"kindString": "Property",
@@ -3187,21 +3187,21 @@
 							"type": {
 								"type": "reference",
 								"name": "BenchmarkTestFunction",
-								"id": 2045
+								"id": 2052
 							},
 							"overwrites": {
 								"type": "reference",
 								"name": "Test.test",
-								"id": 3321
+								"id": 3328
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "TestProperties.test",
-								"id": 3383
+								"id": 3390
 							}
 						},
 						{
-							"id": 2021,
+							"id": 2028,
 							"name": "executor",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -3213,7 +3213,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2022,
+									"id": 2029,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -3224,12 +3224,12 @@
 									"type": {
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Test.executor",
-										"id": 3337
+										"id": 3344
 									}
 								}
 							],
@@ -3243,11 +3243,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.executor",
-								"id": 3337
+								"id": 3344
 							}
 						},
 						{
-							"id": 2023,
+							"id": 2030,
 							"name": "hasPassed",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -3259,7 +3259,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2024,
+									"id": 2031,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -3274,7 +3274,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Test.hasPassed",
-										"id": 3339
+										"id": 3346
 									}
 								}
 							],
@@ -3288,16 +3288,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.hasPassed",
-								"id": 3339
+								"id": 3346
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "TestProperties.hasPassed",
-								"id": 3379
+								"id": 3386
 							}
 						},
 						{
-							"id": 2025,
+							"id": 2032,
 							"name": "id",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -3309,7 +3309,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2026,
+									"id": 2033,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -3324,7 +3324,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Test.id",
-										"id": 3341
+										"id": 3348
 									}
 								}
 							],
@@ -3338,11 +3338,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.id",
-								"id": 3341
+								"id": 3348
 							}
 						},
 						{
-							"id": 2027,
+							"id": 2034,
 							"name": "isAsync",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -3354,7 +3354,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2028,
+									"id": 2035,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -3369,7 +3369,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Test.isAsync",
-										"id": 3343
+										"id": 3350
 									}
 								}
 							],
@@ -3383,11 +3383,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.isAsync",
-								"id": 3343
+								"id": 3350
 							}
 						},
 						{
-							"id": 2029,
+							"id": 2036,
 							"name": "parentId",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -3399,7 +3399,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2030,
+									"id": 2037,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -3414,7 +3414,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Test.parentId",
-										"id": 3345
+										"id": 3352
 									}
 								}
 							],
@@ -3428,11 +3428,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.parentId",
-								"id": 3345
+								"id": 3352
 							}
 						},
 						{
-							"id": 2031,
+							"id": 2038,
 							"name": "remote",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -3450,7 +3450,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2032,
+									"id": 2039,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -3467,12 +3467,12 @@
 									"type": {
 										"type": "reference",
 										"name": "Remote",
-										"id": 2813
+										"id": 2820
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Test.remote",
-										"id": 3347
+										"id": 3354
 									}
 								}
 							],
@@ -3486,11 +3486,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.remote",
-								"id": 3347
+								"id": 3354
 							}
 						},
 						{
-							"id": 2033,
+							"id": 2040,
 							"name": "sessionId",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -3502,7 +3502,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2034,
+									"id": 2041,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -3517,7 +3517,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Test.sessionId",
-										"id": 3349
+										"id": 3356
 									}
 								}
 							],
@@ -3531,11 +3531,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.sessionId",
-								"id": 3349
+								"id": 3356
 							}
 						},
 						{
-							"id": 1990,
+							"id": 1997,
 							"name": "timeElapsed",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -3547,7 +3547,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 1991,
+									"id": 1998,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -3562,13 +3562,13 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Test.timeElapsed",
-										"id": 3351
+										"id": 3358
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 1992,
+									"id": 1999,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -3578,7 +3578,7 @@
 									},
 									"parameters": [
 										{
-											"id": 1993,
+											"id": 2000,
 											"name": "_value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3596,7 +3596,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Test.timeElapsed",
-										"id": 3351
+										"id": 3358
 									}
 								}
 							],
@@ -3615,11 +3615,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Test.timeElapsed",
-								"id": 3351
+								"id": 3358
 							}
 						},
 						{
-							"id": 2035,
+							"id": 2042,
 							"name": "timeout",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -3631,7 +3631,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2036,
+									"id": 2043,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -3646,13 +3646,13 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Test.timeout",
-										"id": 3353
+										"id": 3360
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 2037,
+									"id": 2044,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -3662,7 +3662,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2038,
+											"id": 2045,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3680,7 +3680,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Test.timeout",
-										"id": 3353
+										"id": 3360
 									}
 								}
 							],
@@ -3699,16 +3699,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.timeout",
-								"id": 3353
+								"id": 3360
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "TestProperties.timeout",
-								"id": 3384
+								"id": 3391
 							}
 						},
 						{
-							"id": 1994,
+							"id": 2001,
 							"name": "async",
 							"kind": 2048,
 							"kindString": "Method",
@@ -3717,14 +3717,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1995,
+									"id": 2002,
 									"name": "async",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1996,
+											"id": 2003,
 											"name": "_timeout",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3746,7 +3746,7 @@
 											}
 										},
 										{
-											"id": 1997,
+											"id": 2004,
 											"name": "_numCallsUntilResolution",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3782,7 +3782,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Test.async",
-										"id": 3357
+										"id": 3364
 									}
 								}
 							],
@@ -3796,11 +3796,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Test.async",
-								"id": 3357
+								"id": 3364
 							}
 						},
 						{
-							"id": 2039,
+							"id": 2046,
 							"name": "restartTimeout",
 							"kind": 2048,
 							"kindString": "Method",
@@ -3809,7 +3809,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2040,
+									"id": 2047,
 									"name": "restartTimeout",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -3819,7 +3819,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2041,
+											"id": 2048,
 											"name": "timeout",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3848,7 +3848,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Test.restartTimeout",
-										"id": 3361
+										"id": 3368
 									}
 								}
 							],
@@ -3862,11 +3862,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.restartTimeout",
-								"id": 3361
+								"id": 3368
 							}
 						},
 						{
-							"id": 1998,
+							"id": 2005,
 							"name": "run",
 							"kind": 2048,
 							"kindString": "Method",
@@ -3875,7 +3875,7 @@
 							},
 							"signatures": [
 								{
-									"id": 1999,
+									"id": 2006,
 									"name": "run",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -3893,7 +3893,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Test.run",
-										"id": 3364
+										"id": 3371
 									}
 								}
 							],
@@ -3907,11 +3907,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Test.run",
-								"id": 3364
+								"id": 3371
 							}
 						},
 						{
-							"id": 2042,
+							"id": 2049,
 							"name": "skip",
 							"kind": 2048,
 							"kindString": "Method",
@@ -3920,7 +3920,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2043,
+									"id": 2050,
 									"name": "skip",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -3931,7 +3931,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2044,
+											"id": 2051,
 											"name": "message",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3953,7 +3953,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Test.skip",
-										"id": 3366
+										"id": 3373
 									}
 								}
 							],
@@ -3967,11 +3967,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Test.skip",
-								"id": 3366
+								"id": 3373
 							}
 						},
 						{
-							"id": 2000,
+							"id": 2007,
 							"name": "toJSON",
 							"kind": 2048,
 							"kindString": "Method",
@@ -3980,7 +3980,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2001,
+									"id": 2008,
 									"name": "toJSON",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -3988,21 +3988,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2002,
+											"id": 2009,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 2003,
+													"id": 2010,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 2004,
+															"id": 2011,
 															"name": "key",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -4024,7 +4024,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Test.toJSON",
-										"id": 3369
+										"id": 3376
 									}
 								}
 							],
@@ -4038,11 +4038,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Test.toJSON",
-								"id": 3369
+								"id": 3376
 							}
 						},
 						{
-							"id": 2005,
+							"id": 2012,
 							"name": "async",
 							"kind": 2048,
 							"kindString": "Method",
@@ -4052,14 +4052,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2006,
+									"id": 2013,
 									"name": "async",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2007,
+											"id": 2014,
 											"name": "testFunction",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -4067,11 +4067,11 @@
 											"type": {
 												"type": "reference",
 												"name": "BenchmarkDeferredTestFunction",
-												"id": 2052
+												"id": 2059
 											}
 										},
 										{
-											"id": 2008,
+											"id": 2015,
 											"name": "numCallsUntilResolution",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -4096,7 +4096,7 @@
 									"type": {
 										"type": "reference",
 										"name": "BenchmarkTestFunction",
-										"id": 2045
+										"id": 2052
 									}
 								}
 							],
@@ -4114,54 +4114,54 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								1987
+								1994
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2014,
-								2015,
+								2021,
+								2022,
+								2024,
+								2025,
+								2023,
+								2026,
+								2027,
+								1993,
+								2019,
+								2016,
 								2017,
 								2018,
-								2016,
-								2019,
 								2020,
-								1986,
-								2012,
-								2009,
-								2010,
-								2011,
-								2013,
-								1985
+								1992
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								2021,
-								2023,
-								2025,
-								2027,
-								2029,
-								2031,
-								2033,
-								1990,
-								2035
+								2028,
+								2030,
+								2032,
+								2034,
+								2036,
+								2038,
+								2040,
+								1997,
+								2042
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								1994,
-								2039,
-								1998,
-								2042,
-								2000,
-								2005
+								2001,
+								2046,
+								2005,
+								2049,
+								2007,
+								2012
 							]
 						}
 					],
@@ -4176,19 +4176,19 @@
 						{
 							"type": "reference",
 							"name": "Test",
-							"id": 3317
+							"id": 3324
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "TestProperties",
-							"id": 3378
+							"id": 3385
 						}
 					]
 				},
 				{
-					"id": 2052,
+					"id": 2059,
 					"name": "BenchmarkDeferredTestFunction",
 					"kind": 256,
 					"kindString": "Interface",
@@ -4197,14 +4197,14 @@
 					},
 					"signatures": [
 						{
-							"id": 2053,
+							"id": 2060,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 2054,
+									"id": 2061,
 									"name": "this",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -4212,11 +4212,11 @@
 									"type": {
 										"type": "reference",
 										"name": "BenchmarkTest",
-										"id": 1984
+										"id": 1991
 									}
 								},
 								{
-									"id": 2055,
+									"id": 2062,
 									"name": "deferred",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -4255,14 +4255,14 @@
 							}
 						},
 						{
-							"id": 2057,
+							"id": 2064,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 2058,
+									"id": 2065,
 									"name": "this",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -4270,7 +4270,7 @@
 									"type": {
 										"type": "reference",
 										"name": "BenchmarkTest",
-										"id": 1984
+										"id": 1991
 									}
 								}
 							],
@@ -4295,14 +4295,14 @@
 							}
 						},
 						{
-							"id": 2059,
+							"id": 2066,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 2060,
+									"id": 2067,
 									"name": "this",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -4310,11 +4310,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Test",
-										"id": 3317
+										"id": 3324
 									}
 								},
 								{
-									"id": 2061,
+									"id": 2068,
 									"name": "test",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -4322,7 +4322,7 @@
 									"type": {
 										"type": "reference",
 										"name": "Test",
-										"id": 3317
+										"id": 3324
 									}
 								}
 							],
@@ -4349,7 +4349,7 @@
 					],
 					"children": [
 						{
-							"id": 2056,
+							"id": 2063,
 							"name": "options",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4367,12 +4367,12 @@
 							"type": {
 								"type": "reference",
 								"name": "BenchmarkOptions",
-								"id": 2071
+								"id": 2078
 							},
 							"overwrites": {
 								"type": "reference",
 								"name": "BenchmarkTestFunction.options",
-								"id": 2048
+								"id": 2055
 							}
 						}
 					],
@@ -4381,7 +4381,7 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2056
+								2063
 							]
 						}
 					],
@@ -4396,12 +4396,12 @@
 						{
 							"type": "reference",
 							"name": "BenchmarkTestFunction",
-							"id": 2045
+							"id": 2052
 						}
 					]
 				},
 				{
-					"id": 2071,
+					"id": 2078,
 					"name": "BenchmarkOptions",
 					"kind": 256,
 					"kindString": "Interface",
@@ -4410,7 +4410,7 @@
 					},
 					"children": [
 						{
-							"id": 2074,
+							"id": 2081,
 							"name": "async",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4448,7 +4448,7 @@
 							}
 						},
 						{
-							"id": 2075,
+							"id": 2082,
 							"name": "defer",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4486,7 +4486,7 @@
 							}
 						},
 						{
-							"id": 2076,
+							"id": 2083,
 							"name": "delay",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4520,7 +4520,7 @@
 							}
 						},
 						{
-							"id": 2091,
+							"id": 2098,
 							"name": "fn",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4554,7 +4554,7 @@
 							}
 						},
 						{
-							"id": 2077,
+							"id": 2084,
 							"name": "id",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4588,7 +4588,7 @@
 							}
 						},
 						{
-							"id": 2078,
+							"id": 2085,
 							"name": "initCount",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4622,7 +4622,7 @@
 							}
 						},
 						{
-							"id": 2079,
+							"id": 2086,
 							"name": "maxTime",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4656,7 +4656,7 @@
 							}
 						},
 						{
-							"id": 2080,
+							"id": 2087,
 							"name": "minSamples",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4690,7 +4690,7 @@
 							}
 						},
 						{
-							"id": 2081,
+							"id": 2088,
 							"name": "minTime",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4724,7 +4724,7 @@
 							}
 						},
 						{
-							"id": 2082,
+							"id": 2089,
 							"name": "name",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4758,7 +4758,7 @@
 							}
 						},
 						{
-							"id": 2073,
+							"id": 2080,
 							"name": "numCallsUntilResolution",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4788,7 +4788,7 @@
 							}
 						},
 						{
-							"id": 2083,
+							"id": 2090,
 							"name": "onAbort",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4813,7 +4813,7 @@
 							}
 						},
 						{
-							"id": 2084,
+							"id": 2091,
 							"name": "onComplete",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4838,7 +4838,7 @@
 							}
 						},
 						{
-							"id": 2085,
+							"id": 2092,
 							"name": "onCycle",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4863,7 +4863,7 @@
 							}
 						},
 						{
-							"id": 2086,
+							"id": 2093,
 							"name": "onError",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4888,7 +4888,7 @@
 							}
 						},
 						{
-							"id": 2087,
+							"id": 2094,
 							"name": "onReset",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4913,7 +4913,7 @@
 							}
 						},
 						{
-							"id": 2088,
+							"id": 2095,
 							"name": "onStart",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4938,7 +4938,7 @@
 							}
 						},
 						{
-							"id": 2092,
+							"id": 2099,
 							"name": "queued",
 							"kind": 1024,
 							"kindString": "Property",
@@ -4976,7 +4976,7 @@
 							}
 						},
 						{
-							"id": 2089,
+							"id": 2096,
 							"name": "setup",
 							"kind": 1024,
 							"kindString": "Property",
@@ -5010,7 +5010,7 @@
 							}
 						},
 						{
-							"id": 2072,
+							"id": 2079,
 							"name": "skip",
 							"kind": 1024,
 							"kindString": "Property",
@@ -5040,7 +5040,7 @@
 							}
 						},
 						{
-							"id": 2090,
+							"id": 2097,
 							"name": "teardown",
 							"kind": 1024,
 							"kindString": "Property",
@@ -5079,27 +5079,27 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2074,
-								2075,
-								2076,
-								2091,
-								2077,
-								2078,
-								2079,
-								2080,
 								2081,
 								2082,
-								2073,
 								2083,
+								2098,
 								2084,
 								2085,
 								2086,
 								2087,
 								2088,
-								2092,
 								2089,
-								2072,
-								2090
+								2080,
+								2090,
+								2091,
+								2092,
+								2093,
+								2094,
+								2095,
+								2099,
+								2096,
+								2079,
+								2097
 							]
 						}
 					],
@@ -5118,7 +5118,7 @@
 					]
 				},
 				{
-					"id": 2045,
+					"id": 2052,
 					"name": "BenchmarkTestFunction",
 					"kind": 256,
 					"kindString": "Interface",
@@ -5127,14 +5127,14 @@
 					},
 					"signatures": [
 						{
-							"id": 2046,
+							"id": 2053,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 2047,
+									"id": 2054,
 									"name": "this",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -5142,7 +5142,7 @@
 									"type": {
 										"type": "reference",
 										"name": "BenchmarkTest",
-										"id": 1984
+										"id": 1991
 									}
 								}
 							],
@@ -5167,14 +5167,14 @@
 							}
 						},
 						{
-							"id": 2049,
+							"id": 2056,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 2050,
+									"id": 2057,
 									"name": "this",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -5182,11 +5182,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Test",
-										"id": 3317
+										"id": 3324
 									}
 								},
 								{
-									"id": 2051,
+									"id": 2058,
 									"name": "test",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -5194,7 +5194,7 @@
 									"type": {
 										"type": "reference",
 										"name": "Test",
-										"id": 3317
+										"id": 3324
 									}
 								}
 							],
@@ -5221,7 +5221,7 @@
 					],
 					"children": [
 						{
-							"id": 2048,
+							"id": 2055,
 							"name": "options",
 							"kind": 1024,
 							"kindString": "Property",
@@ -5239,7 +5239,7 @@
 							"type": {
 								"type": "reference",
 								"name": "BenchmarkOptions",
-								"id": 2071
+								"id": 2078
 							}
 						}
 					],
@@ -5248,7 +5248,7 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2048
+								2055
 							]
 						}
 					],
@@ -5263,19 +5263,19 @@
 						{
 							"type": "reference",
 							"name": "TestFunction",
-							"id": 3374
+							"id": 3381
 						}
 					],
 					"extendedBy": [
 						{
 							"type": "reference",
 							"name": "BenchmarkDeferredTestFunction",
-							"id": 2052
+							"id": 2059
 						}
 					]
 				},
 				{
-					"id": 2062,
+					"id": 2069,
 					"name": "BenchmarkTestProperties",
 					"kind": 256,
 					"kindString": "Interface",
@@ -5284,7 +5284,7 @@
 					},
 					"children": [
 						{
-							"id": 2066,
+							"id": 2073,
 							"name": "hasPassed",
 							"kind": 1024,
 							"kindString": "Property",
@@ -5305,11 +5305,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "TestProperties.hasPassed",
-								"id": 3379
+								"id": 3386
 							}
 						},
 						{
-							"id": 2067,
+							"id": 2074,
 							"name": "name",
 							"kind": 1024,
 							"kindString": "Property",
@@ -5330,11 +5330,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "TestProperties.name",
-								"id": 3380
+								"id": 3387
 							}
 						},
 						{
-							"id": 2065,
+							"id": 2072,
 							"name": "numCallsUntilResolution",
 							"kind": 1024,
 							"kindString": "Property",
@@ -5354,7 +5354,7 @@
 							}
 						},
 						{
-							"id": 2068,
+							"id": 2075,
 							"name": "parent",
 							"kind": 1024,
 							"kindString": "Property",
@@ -5371,16 +5371,16 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "TestProperties.parent",
-								"id": 3381
+								"id": 3388
 							}
 						},
 						{
-							"id": 2064,
+							"id": 2071,
 							"name": "skip",
 							"kind": 1024,
 							"kindString": "Property",
@@ -5400,7 +5400,7 @@
 							}
 						},
 						{
-							"id": 2069,
+							"id": 2076,
 							"name": "skipped",
 							"kind": 1024,
 							"kindString": "Property",
@@ -5430,11 +5430,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "TestProperties.skipped",
-								"id": 3382
+								"id": 3389
 							}
 						},
 						{
-							"id": 2063,
+							"id": 2070,
 							"name": "test",
 							"kind": 1024,
 							"kindString": "Property",
@@ -5451,16 +5451,16 @@
 							"type": {
 								"type": "reference",
 								"name": "BenchmarkTestFunction",
-								"id": 2045
+								"id": 2052
 							},
 							"overwrites": {
 								"type": "reference",
 								"name": "TestProperties.test",
-								"id": 3383
+								"id": 3390
 							}
 						},
 						{
-							"id": 2070,
+							"id": 2077,
 							"name": "timeout",
 							"kind": 1024,
 							"kindString": "Property",
@@ -5481,7 +5481,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "TestProperties.timeout",
-								"id": 3384
+								"id": 3391
 							}
 						}
 					],
@@ -5490,14 +5490,14 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2066,
-								2067,
-								2065,
-								2068,
-								2064,
-								2069,
-								2063,
-								2070
+								2073,
+								2074,
+								2072,
+								2075,
+								2071,
+								2076,
+								2070,
+								2077
 							]
 						}
 					],
@@ -5512,12 +5512,12 @@
 						{
 							"type": "reference",
 							"name": "TestProperties",
-							"id": 3378
+							"id": 3385
 						}
 					]
 				},
 				{
-					"id": 2093,
+					"id": 2100,
 					"name": "InternBenchmark",
 					"kind": 256,
 					"kindString": "Interface",
@@ -5526,7 +5526,7 @@
 					},
 					"children": [
 						{
-							"id": 2309,
+							"id": 2316,
 							"name": "Deferred",
 							"kind": 128,
 							"kindString": "Class",
@@ -5535,7 +5535,7 @@
 							},
 							"children": [
 								{
-									"id": 2310,
+									"id": 2317,
 									"name": "constructor",
 									"kind": 512,
 									"kindString": "Constructor",
@@ -5544,14 +5544,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2311,
+											"id": 2318,
 											"name": "new Deferred",
 											"kind": 16384,
 											"kindString": "Constructor signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2312,
+													"id": 2319,
 													"name": "clone",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -5565,7 +5565,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Deferred",
-												"id": 2309
+												"id": 2316
 											}
 										}
 									],
@@ -5578,7 +5578,7 @@
 									]
 								},
 								{
-									"id": 2313,
+									"id": 2320,
 									"name": "benchmark",
 									"kind": 1024,
 									"kindString": "Property",
@@ -5598,7 +5598,7 @@
 									}
 								},
 								{
-									"id": 2314,
+									"id": 2321,
 									"name": "cycles",
 									"kind": 1024,
 									"kindString": "Property",
@@ -5618,7 +5618,7 @@
 									}
 								},
 								{
-									"id": 2315,
+									"id": 2322,
 									"name": "elapsed",
 									"kind": 1024,
 									"kindString": "Property",
@@ -5638,7 +5638,7 @@
 									}
 								},
 								{
-									"id": 2316,
+									"id": 2323,
 									"name": "timeStamp",
 									"kind": 1024,
 									"kindString": "Property",
@@ -5663,17 +5663,17 @@
 									"title": "Constructors",
 									"kind": 512,
 									"children": [
-										2310
+										2317
 									]
 								},
 								{
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2313,
-										2314,
-										2315,
-										2316
+										2320,
+										2321,
+										2322,
+										2323
 									]
 								}
 							],
@@ -5686,7 +5686,7 @@
 							]
 						},
 						{
-							"id": 2317,
+							"id": 2324,
 							"name": "Event",
 							"kind": 128,
 							"kindString": "Class",
@@ -5695,7 +5695,7 @@
 							},
 							"children": [
 								{
-									"id": 2318,
+									"id": 2325,
 									"name": "constructor",
 									"kind": 512,
 									"kindString": "Constructor",
@@ -5704,14 +5704,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2319,
+											"id": 2326,
 											"name": "new Event",
 											"kind": 16384,
 											"kindString": "Constructor signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2320,
+													"id": 2327,
 													"name": "type",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -5734,7 +5734,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Event",
-												"id": 2317
+												"id": 2324
 											}
 										}
 									],
@@ -5747,7 +5747,7 @@
 									]
 								},
 								{
-									"id": 2321,
+									"id": 2328,
 									"name": "aborted",
 									"kind": 1024,
 									"kindString": "Property",
@@ -5767,7 +5767,7 @@
 									}
 								},
 								{
-									"id": 2322,
+									"id": 2329,
 									"name": "cancelled",
 									"kind": 1024,
 									"kindString": "Property",
@@ -5787,7 +5787,7 @@
 									}
 								},
 								{
-									"id": 2323,
+									"id": 2330,
 									"name": "currentTarget",
 									"kind": 1024,
 									"kindString": "Property",
@@ -5807,7 +5807,7 @@
 									}
 								},
 								{
-									"id": 2324,
+									"id": 2331,
 									"name": "result",
 									"kind": 1024,
 									"kindString": "Property",
@@ -5827,7 +5827,7 @@
 									}
 								},
 								{
-									"id": 2325,
+									"id": 2332,
 									"name": "target",
 									"kind": 1024,
 									"kindString": "Property",
@@ -5847,7 +5847,7 @@
 									}
 								},
 								{
-									"id": 2326,
+									"id": 2333,
 									"name": "timeStamp",
 									"kind": 1024,
 									"kindString": "Property",
@@ -5867,7 +5867,7 @@
 									}
 								},
 								{
-									"id": 2327,
+									"id": 2334,
 									"name": "type",
 									"kind": 1024,
 									"kindString": "Property",
@@ -5892,20 +5892,20 @@
 									"title": "Constructors",
 									"kind": 512,
 									"children": [
-										2318
+										2325
 									]
 								},
 								{
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2321,
-										2322,
-										2323,
-										2324,
-										2325,
-										2326,
-										2327
+										2328,
+										2329,
+										2330,
+										2331,
+										2332,
+										2333,
+										2334
 									]
 								}
 							],
@@ -5918,7 +5918,7 @@
 							]
 						},
 						{
-							"id": 2328,
+							"id": 2335,
 							"name": "Suite",
 							"kind": 128,
 							"kindString": "Class",
@@ -5927,7 +5927,7 @@
 							},
 							"children": [
 								{
-									"id": 2332,
+									"id": 2339,
 									"name": "constructor",
 									"kind": 512,
 									"kindString": "Constructor",
@@ -5936,14 +5936,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2333,
+											"id": 2340,
 											"name": "new Suite",
 											"kind": 16384,
 											"kindString": "Constructor signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2334,
+													"id": 2341,
 													"name": "name",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -5965,7 +5965,7 @@
 													}
 												},
 												{
-													"id": 2335,
+													"id": 2342,
 													"name": "options",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -5975,14 +5975,14 @@
 													"type": {
 														"type": "reference",
 														"name": "Options",
-														"id": 2252
+														"id": 2259
 													}
 												}
 											],
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 2328
+												"id": 2335
 											}
 										}
 									],
@@ -5995,7 +5995,7 @@
 									]
 								},
 								{
-									"id": 2336,
+									"id": 2343,
 									"name": "aborted",
 									"kind": 1024,
 									"kindString": "Property",
@@ -6015,7 +6015,7 @@
 									}
 								},
 								{
-									"id": 2337,
+									"id": 2344,
 									"name": "length",
 									"kind": 1024,
 									"kindString": "Property",
@@ -6035,7 +6035,7 @@
 									}
 								},
 								{
-									"id": 2338,
+									"id": 2345,
 									"name": "running",
 									"kind": 1024,
 									"kindString": "Property",
@@ -6055,7 +6055,7 @@
 									}
 								},
 								{
-									"id": 2329,
+									"id": 2336,
 									"name": "options",
 									"kind": 1024,
 									"kindString": "Property",
@@ -6073,14 +6073,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2330,
+											"id": 2337,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 2331,
+													"id": 2338,
 													"name": "name",
 													"kind": 32,
 													"kindString": "Variable",
@@ -6103,7 +6103,7 @@
 													"title": "Variables",
 													"kind": 32,
 													"children": [
-														2331
+														2338
 													]
 												}
 											],
@@ -6118,7 +6118,7 @@
 									}
 								},
 								{
-									"id": 2339,
+									"id": 2346,
 									"name": "abort",
 									"kind": 2048,
 									"kindString": "Method",
@@ -6127,7 +6127,7 @@
 									},
 									"signatures": [
 										{
-											"id": 2340,
+											"id": 2347,
 											"name": "abort",
 											"kind": 4096,
 											"kindString": "Call signature",
@@ -6147,7 +6147,7 @@
 									]
 								},
 								{
-									"id": 2341,
+									"id": 2348,
 									"name": "add",
 									"kind": 2048,
 									"kindString": "Method",
@@ -6155,111 +6155,6 @@
 										"isExported": true
 									},
 									"signatures": [
-										{
-											"id": 2342,
-											"name": "add",
-											"kind": 4096,
-											"kindString": "Call signature",
-											"flags": {},
-											"parameters": [
-												{
-													"id": 2343,
-													"name": "name",
-													"kind": 32768,
-													"kindString": "Parameter",
-													"flags": {},
-													"type": {
-														"type": "intrinsic",
-														"name": "string"
-													}
-												},
-												{
-													"id": 2344,
-													"name": "fn",
-													"kind": 32768,
-													"kindString": "Parameter",
-													"flags": {},
-													"type": {
-														"type": "union",
-														"types": [
-															{
-																"type": "reference",
-																"name": "Function"
-															},
-															{
-																"type": "intrinsic",
-																"name": "string"
-															}
-														]
-													}
-												},
-												{
-													"id": 2345,
-													"name": "options",
-													"kind": 32768,
-													"kindString": "Parameter",
-													"flags": {
-														"isOptional": true
-													},
-													"type": {
-														"type": "reference",
-														"name": "Options",
-														"id": 2252
-													}
-												}
-											],
-											"type": {
-												"type": "reference",
-												"name": "Suite"
-											}
-										},
-										{
-											"id": 2346,
-											"name": "add",
-											"kind": 4096,
-											"kindString": "Call signature",
-											"flags": {},
-											"parameters": [
-												{
-													"id": 2347,
-													"name": "fn",
-													"kind": 32768,
-													"kindString": "Parameter",
-													"flags": {},
-													"type": {
-														"type": "union",
-														"types": [
-															{
-																"type": "reference",
-																"name": "Function"
-															},
-															{
-																"type": "intrinsic",
-																"name": "string"
-															}
-														]
-													}
-												},
-												{
-													"id": 2348,
-													"name": "options",
-													"kind": 32768,
-													"kindString": "Parameter",
-													"flags": {
-														"isOptional": true
-													},
-													"type": {
-														"type": "reference",
-														"name": "Options",
-														"id": 2252
-													}
-												}
-											],
-											"type": {
-												"type": "reference",
-												"name": "Suite"
-											}
-										},
 										{
 											"id": 2349,
 											"name": "add",
@@ -6280,6 +6175,26 @@
 												},
 												{
 													"id": 2351,
+													"name": "fn",
+													"kind": 32768,
+													"kindString": "Parameter",
+													"flags": {},
+													"type": {
+														"type": "union",
+														"types": [
+															{
+																"type": "reference",
+																"name": "Function"
+															},
+															{
+																"type": "intrinsic",
+																"name": "string"
+															}
+														]
+													}
+												},
+												{
+													"id": 2352,
 													"name": "options",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6289,7 +6204,7 @@
 													"type": {
 														"type": "reference",
 														"name": "Options",
-														"id": 2252
+														"id": 2259
 													}
 												}
 											],
@@ -6299,14 +6214,99 @@
 											}
 										},
 										{
-											"id": 2352,
+											"id": 2353,
 											"name": "add",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2353,
+													"id": 2354,
+													"name": "fn",
+													"kind": 32768,
+													"kindString": "Parameter",
+													"flags": {},
+													"type": {
+														"type": "union",
+														"types": [
+															{
+																"type": "reference",
+																"name": "Function"
+															},
+															{
+																"type": "intrinsic",
+																"name": "string"
+															}
+														]
+													}
+												},
+												{
+													"id": 2355,
+													"name": "options",
+													"kind": 32768,
+													"kindString": "Parameter",
+													"flags": {
+														"isOptional": true
+													},
+													"type": {
+														"type": "reference",
+														"name": "Options",
+														"id": 2259
+													}
+												}
+											],
+											"type": {
+												"type": "reference",
+												"name": "Suite"
+											}
+										},
+										{
+											"id": 2356,
+											"name": "add",
+											"kind": 4096,
+											"kindString": "Call signature",
+											"flags": {},
+											"parameters": [
+												{
+													"id": 2357,
+													"name": "name",
+													"kind": 32768,
+													"kindString": "Parameter",
+													"flags": {},
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 2358,
+													"name": "options",
+													"kind": 32768,
+													"kindString": "Parameter",
+													"flags": {
+														"isOptional": true
+													},
+													"type": {
+														"type": "reference",
+														"name": "Options",
+														"id": 2259
+													}
+												}
+											],
+											"type": {
+												"type": "reference",
+												"name": "Suite"
+											}
+										},
+										{
+											"id": 2359,
+											"name": "add",
+											"kind": 4096,
+											"kindString": "Call signature",
+											"flags": {},
+											"parameters": [
+												{
+													"id": 2360,
 													"name": "options",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6347,7 +6347,7 @@
 									]
 								},
 								{
-									"id": 2354,
+									"id": 2361,
 									"name": "clone",
 									"kind": 2048,
 									"kindString": "Method",
@@ -6356,14 +6356,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2355,
+											"id": 2362,
 											"name": "clone",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2356,
+													"id": 2363,
 													"name": "options",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6389,7 +6389,7 @@
 									]
 								},
 								{
-									"id": 2357,
+									"id": 2364,
 									"name": "emit",
 									"kind": 2048,
 									"kindString": "Method",
@@ -6398,14 +6398,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2358,
+											"id": 2365,
 											"name": "emit",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2359,
+													"id": 2366,
 													"name": "type",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6440,7 +6440,7 @@
 									]
 								},
 								{
-									"id": 2360,
+									"id": 2367,
 									"name": "filter",
 									"kind": 2048,
 									"kindString": "Method",
@@ -6449,14 +6449,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2361,
+											"id": 2368,
 											"name": "filter",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2362,
+													"id": 2369,
 													"name": "callback",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6491,7 +6491,7 @@
 									]
 								},
 								{
-									"id": 2363,
+									"id": 2370,
 									"name": "forEach",
 									"kind": 2048,
 									"kindString": "Method",
@@ -6500,14 +6500,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2364,
+											"id": 2371,
 											"name": "forEach",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2365,
+													"id": 2372,
 													"name": "callback",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6533,7 +6533,7 @@
 									]
 								},
 								{
-									"id": 2366,
+									"id": 2373,
 									"name": "indexOf",
 									"kind": 2048,
 									"kindString": "Method",
@@ -6542,14 +6542,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2367,
+											"id": 2374,
 											"name": "indexOf",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2368,
+													"id": 2375,
 													"name": "value",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6575,7 +6575,7 @@
 									]
 								},
 								{
-									"id": 2369,
+									"id": 2376,
 									"name": "invoke",
 									"kind": 2048,
 									"kindString": "Method",
@@ -6584,14 +6584,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2370,
+											"id": 2377,
 											"name": "invoke",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2371,
+													"id": 2378,
 													"name": "name",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6602,7 +6602,7 @@
 													}
 												},
 												{
-													"id": 2372,
+													"id": 2379,
 													"name": "args",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6636,7 +6636,7 @@
 									]
 								},
 								{
-									"id": 2373,
+									"id": 2380,
 									"name": "join",
 									"kind": 2048,
 									"kindString": "Method",
@@ -6645,14 +6645,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2374,
+											"id": 2381,
 											"name": "join",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2375,
+													"id": 2382,
 													"name": "separator",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6689,7 +6689,7 @@
 									]
 								},
 								{
-									"id": 2376,
+									"id": 2383,
 									"name": "listeners",
 									"kind": 2048,
 									"kindString": "Method",
@@ -6698,14 +6698,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2377,
+											"id": 2384,
 											"name": "listeners",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2378,
+													"id": 2385,
 													"name": "type",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6734,7 +6734,7 @@
 									]
 								},
 								{
-									"id": 2379,
+									"id": 2386,
 									"name": "map",
 									"kind": 2048,
 									"kindString": "Method",
@@ -6743,14 +6743,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2380,
+											"id": 2387,
 											"name": "map",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2381,
+													"id": 2388,
 													"name": "callback",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6779,7 +6779,7 @@
 									]
 								},
 								{
-									"id": 2382,
+									"id": 2389,
 									"name": "off",
 									"kind": 2048,
 									"kindString": "Method",
@@ -6788,14 +6788,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2383,
+											"id": 2390,
 											"name": "off",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2384,
+													"id": 2391,
 													"name": "type",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6817,7 +6817,7 @@
 													}
 												},
 												{
-													"id": 2385,
+													"id": 2392,
 													"name": "callback",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6836,14 +6836,14 @@
 											}
 										},
 										{
-											"id": 2386,
+											"id": 2393,
 											"name": "off",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2387,
+													"id": 2394,
 													"name": "types",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6877,7 +6877,7 @@
 									]
 								},
 								{
-									"id": 2388,
+									"id": 2395,
 									"name": "on",
 									"kind": 2048,
 									"kindString": "Method",
@@ -6886,14 +6886,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2389,
+											"id": 2396,
 											"name": "on",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2390,
+													"id": 2397,
 													"name": "type",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6915,7 +6915,7 @@
 													}
 												},
 												{
-													"id": 2391,
+													"id": 2398,
 													"name": "callback",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6934,14 +6934,14 @@
 											}
 										},
 										{
-											"id": 2392,
+											"id": 2399,
 											"name": "on",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2393,
+													"id": 2400,
 													"name": "types",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -6975,7 +6975,7 @@
 									]
 								},
 								{
-									"id": 2394,
+									"id": 2401,
 									"name": "pluck",
 									"kind": 2048,
 									"kindString": "Method",
@@ -6984,14 +6984,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2395,
+											"id": 2402,
 											"name": "pluck",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2396,
+													"id": 2403,
 													"name": "property",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -7020,7 +7020,7 @@
 									]
 								},
 								{
-									"id": 2397,
+									"id": 2404,
 									"name": "pop",
 									"kind": 2048,
 									"kindString": "Method",
@@ -7029,7 +7029,7 @@
 									},
 									"signatures": [
 										{
-											"id": 2398,
+											"id": 2405,
 											"name": "pop",
 											"kind": 4096,
 											"kindString": "Call signature",
@@ -7049,7 +7049,7 @@
 									]
 								},
 								{
-									"id": 2399,
+									"id": 2406,
 									"name": "push",
 									"kind": 2048,
 									"kindString": "Method",
@@ -7058,14 +7058,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2400,
+											"id": 2407,
 											"name": "push",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2401,
+													"id": 2408,
 													"name": "benchmark",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -7091,7 +7091,7 @@
 									]
 								},
 								{
-									"id": 2402,
+									"id": 2409,
 									"name": "reduce",
 									"kind": 2048,
 									"kindString": "Method",
@@ -7100,14 +7100,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2403,
+											"id": 2410,
 											"name": "reduce",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"typeParameter": [
 												{
-													"id": 2404,
+													"id": 2411,
 													"name": "T",
 													"kind": 131072,
 													"kindString": "Type parameter",
@@ -7116,7 +7116,7 @@
 											],
 											"parameters": [
 												{
-													"id": 2405,
+													"id": 2412,
 													"name": "callback",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -7127,7 +7127,7 @@
 													}
 												},
 												{
-													"id": 2406,
+													"id": 2413,
 													"name": "accumulator",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -7153,7 +7153,7 @@
 									]
 								},
 								{
-									"id": 2407,
+									"id": 2414,
 									"name": "reset",
 									"kind": 2048,
 									"kindString": "Method",
@@ -7162,7 +7162,7 @@
 									},
 									"signatures": [
 										{
-											"id": 2408,
+											"id": 2415,
 											"name": "reset",
 											"kind": 4096,
 											"kindString": "Call signature",
@@ -7182,7 +7182,7 @@
 									]
 								},
 								{
-									"id": 2409,
+									"id": 2416,
 									"name": "reverse",
 									"kind": 2048,
 									"kindString": "Method",
@@ -7191,7 +7191,7 @@
 									},
 									"signatures": [
 										{
-											"id": 2410,
+											"id": 2417,
 											"name": "reverse",
 											"kind": 4096,
 											"kindString": "Call signature",
@@ -7214,7 +7214,7 @@
 									]
 								},
 								{
-									"id": 2411,
+									"id": 2418,
 									"name": "run",
 									"kind": 2048,
 									"kindString": "Method",
@@ -7223,14 +7223,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2412,
+											"id": 2419,
 											"name": "run",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2413,
+													"id": 2420,
 													"name": "options",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -7240,7 +7240,7 @@
 													"type": {
 														"type": "reference",
 														"name": "Options",
-														"id": 2252
+														"id": 2259
 													}
 												}
 											],
@@ -7259,7 +7259,7 @@
 									]
 								},
 								{
-									"id": 2414,
+									"id": 2421,
 									"name": "shift",
 									"kind": 2048,
 									"kindString": "Method",
@@ -7268,7 +7268,7 @@
 									},
 									"signatures": [
 										{
-											"id": 2415,
+											"id": 2422,
 											"name": "shift",
 											"kind": 4096,
 											"kindString": "Call signature",
@@ -7288,7 +7288,7 @@
 									]
 								},
 								{
-									"id": 2416,
+									"id": 2423,
 									"name": "slice",
 									"kind": 2048,
 									"kindString": "Method",
@@ -7297,14 +7297,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2417,
+											"id": 2424,
 											"name": "slice",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2418,
+													"id": 2425,
 													"name": "start",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -7315,7 +7315,7 @@
 													}
 												},
 												{
-													"id": 2419,
+													"id": 2426,
 													"name": "end",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -7335,14 +7335,14 @@
 											}
 										},
 										{
-											"id": 2420,
+											"id": 2427,
 											"name": "slice",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2421,
+													"id": 2428,
 													"name": "start",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -7353,7 +7353,7 @@
 													}
 												},
 												{
-													"id": 2422,
+													"id": 2429,
 													"name": "deleteCount",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -7364,7 +7364,7 @@
 													}
 												},
 												{
-													"id": 2423,
+													"id": 2430,
 													"name": "values",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -7403,7 +7403,7 @@
 									]
 								},
 								{
-									"id": 2424,
+									"id": 2431,
 									"name": "unshift",
 									"kind": 2048,
 									"kindString": "Method",
@@ -7412,14 +7412,14 @@
 									},
 									"signatures": [
 										{
-											"id": 2425,
+											"id": 2432,
 											"name": "unshift",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2426,
+													"id": 2433,
 													"name": "benchmark",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -7450,46 +7450,46 @@
 									"title": "Constructors",
 									"kind": 512,
 									"children": [
-										2332
+										2339
 									]
 								},
 								{
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2336,
-										2337,
-										2338,
-										2329
+										2343,
+										2344,
+										2345,
+										2336
 									]
 								},
 								{
 									"title": "Methods",
 									"kind": 2048,
 									"children": [
-										2339,
-										2341,
-										2354,
-										2357,
-										2360,
-										2363,
-										2366,
-										2369,
+										2346,
+										2348,
+										2361,
+										2364,
+										2367,
+										2370,
 										2373,
 										2376,
-										2379,
-										2382,
-										2388,
-										2394,
-										2397,
-										2399,
-										2402,
-										2407,
+										2380,
+										2383,
+										2386,
+										2389,
+										2395,
+										2401,
+										2404,
+										2406,
 										2409,
-										2411,
 										2414,
 										2416,
-										2424
+										2418,
+										2421,
+										2423,
+										2431
 									]
 								}
 							],
@@ -7502,7 +7502,7 @@
 							]
 						},
 						{
-							"id": 2252,
+							"id": 2259,
 							"name": "Options",
 							"kind": 256,
 							"kindString": "Interface",
@@ -7511,7 +7511,7 @@
 							},
 							"children": [
 								{
-									"id": 2253,
+									"id": 2260,
 									"name": "async",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7545,7 +7545,7 @@
 									}
 								},
 								{
-									"id": 2254,
+									"id": 2261,
 									"name": "defer",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7579,7 +7579,7 @@
 									}
 								},
 								{
-									"id": 2255,
+									"id": 2262,
 									"name": "delay",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7609,7 +7609,7 @@
 									}
 								},
 								{
-									"id": 2270,
+									"id": 2277,
 									"name": "fn",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7639,7 +7639,7 @@
 									}
 								},
 								{
-									"id": 2256,
+									"id": 2263,
 									"name": "id",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7669,7 +7669,7 @@
 									}
 								},
 								{
-									"id": 2257,
+									"id": 2264,
 									"name": "initCount",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7699,7 +7699,7 @@
 									}
 								},
 								{
-									"id": 2258,
+									"id": 2265,
 									"name": "maxTime",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7729,7 +7729,7 @@
 									}
 								},
 								{
-									"id": 2259,
+									"id": 2266,
 									"name": "minSamples",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7759,7 +7759,7 @@
 									}
 								},
 								{
-									"id": 2260,
+									"id": 2267,
 									"name": "minTime",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7789,7 +7789,7 @@
 									}
 								},
 								{
-									"id": 2261,
+									"id": 2268,
 									"name": "name",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7819,7 +7819,7 @@
 									}
 								},
 								{
-									"id": 2262,
+									"id": 2269,
 									"name": "onAbort",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7840,7 +7840,7 @@
 									}
 								},
 								{
-									"id": 2263,
+									"id": 2270,
 									"name": "onComplete",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7861,7 +7861,7 @@
 									}
 								},
 								{
-									"id": 2264,
+									"id": 2271,
 									"name": "onCycle",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7882,7 +7882,7 @@
 									}
 								},
 								{
-									"id": 2265,
+									"id": 2272,
 									"name": "onError",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7903,7 +7903,7 @@
 									}
 								},
 								{
-									"id": 2266,
+									"id": 2273,
 									"name": "onReset",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7924,7 +7924,7 @@
 									}
 								},
 								{
-									"id": 2267,
+									"id": 2274,
 									"name": "onStart",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7945,7 +7945,7 @@
 									}
 								},
 								{
-									"id": 2271,
+									"id": 2278,
 									"name": "queued",
 									"kind": 1024,
 									"kindString": "Property",
@@ -7979,7 +7979,7 @@
 									}
 								},
 								{
-									"id": 2268,
+									"id": 2275,
 									"name": "setup",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8009,7 +8009,7 @@
 									}
 								},
 								{
-									"id": 2269,
+									"id": 2276,
 									"name": "teardown",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8044,25 +8044,25 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2253,
-										2254,
-										2255,
-										2270,
-										2256,
-										2257,
-										2258,
-										2259,
 										2260,
 										2261,
 										2262,
+										2277,
 										2263,
 										2264,
 										2265,
 										2266,
 										2267,
-										2271,
 										2268,
-										2269
+										2269,
+										2270,
+										2271,
+										2272,
+										2273,
+										2274,
+										2278,
+										2275,
+										2276
 									]
 								}
 							],
@@ -8075,7 +8075,7 @@
 							]
 						},
 						{
-							"id": 2272,
+							"id": 2279,
 							"name": "Platform",
 							"kind": 256,
 							"kindString": "Interface",
@@ -8084,7 +8084,7 @@
 							},
 							"children": [
 								{
-									"id": 2273,
+									"id": 2280,
 									"name": "description",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8104,7 +8104,7 @@
 									}
 								},
 								{
-									"id": 2274,
+									"id": 2281,
 									"name": "layout",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8124,7 +8124,7 @@
 									}
 								},
 								{
-									"id": 2275,
+									"id": 2282,
 									"name": "manufacturer",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8144,7 +8144,7 @@
 									}
 								},
 								{
-									"id": 2276,
+									"id": 2283,
 									"name": "name",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8164,7 +8164,7 @@
 									}
 								},
 								{
-									"id": 2277,
+									"id": 2284,
 									"name": "os",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8184,7 +8184,7 @@
 									}
 								},
 								{
-									"id": 2278,
+									"id": 2285,
 									"name": "prerelease",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8204,7 +8204,7 @@
 									}
 								},
 								{
-									"id": 2279,
+									"id": 2286,
 									"name": "product",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8224,7 +8224,7 @@
 									}
 								},
 								{
-									"id": 2280,
+									"id": 2287,
 									"name": "version",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8244,7 +8244,7 @@
 									}
 								},
 								{
-									"id": 2281,
+									"id": 2288,
 									"name": "toString",
 									"kind": 2048,
 									"kindString": "Method",
@@ -8253,7 +8253,7 @@
 									},
 									"signatures": [
 										{
-											"id": 2282,
+											"id": 2289,
 											"name": "toString",
 											"kind": 4096,
 											"kindString": "Call signature",
@@ -8278,21 +8278,21 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2273,
-										2274,
-										2275,
-										2276,
-										2277,
-										2278,
-										2279,
-										2280
+										2280,
+										2281,
+										2282,
+										2283,
+										2284,
+										2285,
+										2286,
+										2287
 									]
 								},
 								{
 									"title": "Methods",
 									"kind": 2048,
 									"children": [
-										2281
+										2288
 									]
 								}
 							],
@@ -8305,7 +8305,7 @@
 							]
 						},
 						{
-							"id": 2296,
+							"id": 2303,
 							"name": "Stats",
 							"kind": 256,
 							"kindString": "Interface",
@@ -8314,7 +8314,7 @@
 							},
 							"children": [
 								{
-									"id": 2297,
+									"id": 2304,
 									"name": "deviation",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8334,7 +8334,7 @@
 									}
 								},
 								{
-									"id": 2298,
+									"id": 2305,
 									"name": "mean",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8354,7 +8354,7 @@
 									}
 								},
 								{
-									"id": 2299,
+									"id": 2306,
 									"name": "moe",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8374,7 +8374,7 @@
 									}
 								},
 								{
-									"id": 2300,
+									"id": 2307,
 									"name": "rme",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8394,7 +8394,7 @@
 									}
 								},
 								{
-									"id": 2301,
+									"id": 2308,
 									"name": "sample",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8417,7 +8417,7 @@
 									}
 								},
 								{
-									"id": 2302,
+									"id": 2309,
 									"name": "sem",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8437,7 +8437,7 @@
 									}
 								},
 								{
-									"id": 2303,
+									"id": 2310,
 									"name": "variance",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8462,13 +8462,13 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2297,
-										2298,
-										2299,
-										2300,
-										2301,
-										2302,
-										2303
+										2304,
+										2305,
+										2306,
+										2307,
+										2308,
+										2309,
+										2310
 									]
 								}
 							],
@@ -8481,7 +8481,7 @@
 							]
 						},
 						{
-							"id": 2283,
+							"id": 2290,
 							"name": "Support",
 							"kind": 256,
 							"kindString": "Interface",
@@ -8490,7 +8490,7 @@
 							},
 							"children": [
 								{
-									"id": 2284,
+									"id": 2291,
 									"name": "air",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8510,7 +8510,7 @@
 									}
 								},
 								{
-									"id": 2285,
+									"id": 2292,
 									"name": "argumentsClass",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8530,7 +8530,7 @@
 									}
 								},
 								{
-									"id": 2286,
+									"id": 2293,
 									"name": "browser",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8550,7 +8550,7 @@
 									}
 								},
 								{
-									"id": 2287,
+									"id": 2294,
 									"name": "charByIndex",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8570,7 +8570,7 @@
 									}
 								},
 								{
-									"id": 2288,
+									"id": 2295,
 									"name": "charByOwnIndex",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8590,7 +8590,7 @@
 									}
 								},
 								{
-									"id": 2289,
+									"id": 2296,
 									"name": "decompilation",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8610,7 +8610,7 @@
 									}
 								},
 								{
-									"id": 2290,
+									"id": 2297,
 									"name": "descriptors",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8630,7 +8630,7 @@
 									}
 								},
 								{
-									"id": 2291,
+									"id": 2298,
 									"name": "getAllKeys",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8650,7 +8650,7 @@
 									}
 								},
 								{
-									"id": 2292,
+									"id": 2299,
 									"name": "iteratesOwnFirst",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8670,7 +8670,7 @@
 									}
 								},
 								{
-									"id": 2293,
+									"id": 2300,
 									"name": "java",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8690,7 +8690,7 @@
 									}
 								},
 								{
-									"id": 2294,
+									"id": 2301,
 									"name": "nodeClass",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8710,7 +8710,7 @@
 									}
 								},
 								{
-									"id": 2295,
+									"id": 2302,
 									"name": "timeout",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8735,18 +8735,18 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2284,
-										2285,
-										2286,
-										2287,
-										2288,
-										2289,
-										2290,
 										2291,
 										2292,
 										2293,
 										2294,
-										2295
+										2295,
+										2296,
+										2297,
+										2298,
+										2299,
+										2300,
+										2301,
+										2302
 									]
 								}
 							],
@@ -8759,7 +8759,7 @@
 							]
 						},
 						{
-							"id": 2304,
+							"id": 2311,
 							"name": "Times",
 							"kind": 256,
 							"kindString": "Interface",
@@ -8768,7 +8768,7 @@
 							},
 							"children": [
 								{
-									"id": 2305,
+									"id": 2312,
 									"name": "cycle",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8788,7 +8788,7 @@
 									}
 								},
 								{
-									"id": 2306,
+									"id": 2313,
 									"name": "elapsed",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8808,7 +8808,7 @@
 									}
 								},
 								{
-									"id": 2307,
+									"id": 2314,
 									"name": "period",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8828,7 +8828,7 @@
 									}
 								},
 								{
-									"id": 2308,
+									"id": 2315,
 									"name": "timeStamp",
 									"kind": 1024,
 									"kindString": "Property",
@@ -8853,10 +8853,10 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2305,
-										2306,
-										2307,
-										2308
+										2312,
+										2313,
+										2314,
+										2315
 									]
 								}
 							],
@@ -8869,7 +8869,7 @@
 							]
 						},
 						{
-							"id": 2194,
+							"id": 2201,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -8877,119 +8877,6 @@
 								"isExported": true
 							},
 							"signatures": [
-								{
-									"id": 2195,
-									"name": "new InternBenchmark",
-									"kind": 16384,
-									"kindString": "Constructor signature",
-									"flags": {},
-									"parameters": [
-										{
-											"id": 2196,
-											"name": "fn",
-											"kind": 32768,
-											"kindString": "Parameter",
-											"flags": {},
-											"type": {
-												"type": "union",
-												"types": [
-													{
-														"type": "reference",
-														"name": "Function"
-													},
-													{
-														"type": "intrinsic",
-														"name": "string"
-													}
-												]
-											}
-										},
-										{
-											"id": 2197,
-											"name": "options",
-											"kind": 32768,
-											"kindString": "Parameter",
-											"flags": {
-												"isOptional": true
-											},
-											"type": {
-												"type": "reference",
-												"name": "Benchmark.Options"
-											}
-										}
-									],
-									"type": {
-										"type": "reference",
-										"name": "InternBenchmark",
-										"id": 2093
-									},
-									"inheritedFrom": {
-										"type": "reference",
-										"name": "Benchmark.__constructor"
-									}
-								},
-								{
-									"id": 2198,
-									"name": "new InternBenchmark",
-									"kind": 16384,
-									"kindString": "Constructor signature",
-									"flags": {},
-									"parameters": [
-										{
-											"id": 2199,
-											"name": "name",
-											"kind": 32768,
-											"kindString": "Parameter",
-											"flags": {},
-											"type": {
-												"type": "intrinsic",
-												"name": "string"
-											}
-										},
-										{
-											"id": 2200,
-											"name": "fn",
-											"kind": 32768,
-											"kindString": "Parameter",
-											"flags": {},
-											"type": {
-												"type": "union",
-												"types": [
-													{
-														"type": "reference",
-														"name": "Function"
-													},
-													{
-														"type": "intrinsic",
-														"name": "string"
-													}
-												]
-											}
-										},
-										{
-											"id": 2201,
-											"name": "options",
-											"kind": 32768,
-											"kindString": "Parameter",
-											"flags": {
-												"isOptional": true
-											},
-											"type": {
-												"type": "reference",
-												"name": "Benchmark.Options"
-											}
-										}
-									],
-									"type": {
-										"type": "reference",
-										"name": "InternBenchmark",
-										"id": 2093
-									},
-									"inheritedFrom": {
-										"type": "reference",
-										"name": "Benchmark.__constructor"
-									}
-								},
 								{
 									"id": 2202,
 									"name": "new InternBenchmark",
@@ -8999,13 +8886,22 @@
 									"parameters": [
 										{
 											"id": 2203,
-											"name": "name",
+											"name": "fn",
 											"kind": 32768,
 											"kindString": "Parameter",
 											"flags": {},
 											"type": {
-												"type": "intrinsic",
-												"name": "string"
+												"type": "union",
+												"types": [
+													{
+														"type": "reference",
+														"name": "Function"
+													},
+													{
+														"type": "intrinsic",
+														"name": "string"
+													}
+												]
 											}
 										},
 										{
@@ -9025,7 +8921,7 @@
 									"type": {
 										"type": "reference",
 										"name": "InternBenchmark",
-										"id": 2093
+										"id": 2100
 									},
 									"inheritedFrom": {
 										"type": "reference",
@@ -9041,6 +8937,110 @@
 									"parameters": [
 										{
 											"id": 2206,
+											"name": "name",
+											"kind": 32768,
+											"kindString": "Parameter",
+											"flags": {},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										},
+										{
+											"id": 2207,
+											"name": "fn",
+											"kind": 32768,
+											"kindString": "Parameter",
+											"flags": {},
+											"type": {
+												"type": "union",
+												"types": [
+													{
+														"type": "reference",
+														"name": "Function"
+													},
+													{
+														"type": "intrinsic",
+														"name": "string"
+													}
+												]
+											}
+										},
+										{
+											"id": 2208,
+											"name": "options",
+											"kind": 32768,
+											"kindString": "Parameter",
+											"flags": {
+												"isOptional": true
+											},
+											"type": {
+												"type": "reference",
+												"name": "Benchmark.Options"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"name": "InternBenchmark",
+										"id": 2100
+									},
+									"inheritedFrom": {
+										"type": "reference",
+										"name": "Benchmark.__constructor"
+									}
+								},
+								{
+									"id": 2209,
+									"name": "new InternBenchmark",
+									"kind": 16384,
+									"kindString": "Constructor signature",
+									"flags": {},
+									"parameters": [
+										{
+											"id": 2210,
+											"name": "name",
+											"kind": 32768,
+											"kindString": "Parameter",
+											"flags": {},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										},
+										{
+											"id": 2211,
+											"name": "options",
+											"kind": 32768,
+											"kindString": "Parameter",
+											"flags": {
+												"isOptional": true
+											},
+											"type": {
+												"type": "reference",
+												"name": "Benchmark.Options"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"name": "InternBenchmark",
+										"id": 2100
+									},
+									"inheritedFrom": {
+										"type": "reference",
+										"name": "Benchmark.__constructor"
+									}
+								},
+								{
+									"id": 2212,
+									"name": "new InternBenchmark",
+									"kind": 16384,
+									"kindString": "Constructor signature",
+									"flags": {},
+									"parameters": [
+										{
+											"id": 2213,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -9054,7 +9054,7 @@
 									"type": {
 										"type": "reference",
 										"name": "InternBenchmark",
-										"id": 2093
+										"id": 2100
 									},
 									"inheritedFrom": {
 										"type": "reference",
@@ -9090,7 +9090,7 @@
 							}
 						},
 						{
-							"id": 2207,
+							"id": 2214,
 							"name": "aborted",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9114,7 +9114,7 @@
 							}
 						},
 						{
-							"id": 2208,
+							"id": 2215,
 							"name": "compiled",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9147,7 +9147,7 @@
 							}
 						},
 						{
-							"id": 2209,
+							"id": 2216,
 							"name": "count",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9171,7 +9171,7 @@
 							}
 						},
 						{
-							"id": 2210,
+							"id": 2217,
 							"name": "cycles",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9195,7 +9195,7 @@
 							}
 						},
 						{
-							"id": 2211,
+							"id": 2218,
 							"name": "error",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9219,7 +9219,7 @@
 							}
 						},
 						{
-							"id": 2212,
+							"id": 2219,
 							"name": "fn",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9252,7 +9252,7 @@
 							}
 						},
 						{
-							"id": 2213,
+							"id": 2220,
 							"name": "hz",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9276,7 +9276,7 @@
 							}
 						},
 						{
-							"id": 2094,
+							"id": 2101,
 							"name": "internTest",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9294,11 +9294,11 @@
 							"type": {
 								"type": "reference",
 								"name": "BenchmarkTest",
-								"id": 1984
+								"id": 1991
 							}
 						},
 						{
-							"id": 2214,
+							"id": 2221,
 							"name": "running",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9322,7 +9322,7 @@
 							}
 						},
 						{
-							"id": 2215,
+							"id": 2222,
 							"name": "setup",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9355,7 +9355,7 @@
 							}
 						},
 						{
-							"id": 2217,
+							"id": 2224,
 							"name": "stats",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9379,7 +9379,7 @@
 							}
 						},
 						{
-							"id": 2216,
+							"id": 2223,
 							"name": "teardown",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9412,7 +9412,7 @@
 							}
 						},
 						{
-							"id": 2218,
+							"id": 2225,
 							"name": "times",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9436,7 +9436,7 @@
 							}
 						},
 						{
-							"id": 2190,
+							"id": 2197,
 							"name": "options",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9461,7 +9461,7 @@
 							}
 						},
 						{
-							"id": 2191,
+							"id": 2198,
 							"name": "platform",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9486,7 +9486,7 @@
 							}
 						},
 						{
-							"id": 2192,
+							"id": 2199,
 							"name": "support",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9511,7 +9511,7 @@
 							}
 						},
 						{
-							"id": 2193,
+							"id": 2200,
 							"name": "version",
 							"kind": 1024,
 							"kindString": "Property",
@@ -9536,7 +9536,7 @@
 							}
 						},
 						{
-							"id": 2219,
+							"id": 2226,
 							"name": "abort",
 							"kind": 2048,
 							"kindString": "Method",
@@ -9545,7 +9545,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2220,
+									"id": 2227,
 									"name": "abort",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -9573,7 +9573,7 @@
 							}
 						},
 						{
-							"id": 2221,
+							"id": 2228,
 							"name": "clone",
 							"kind": 2048,
 							"kindString": "Method",
@@ -9582,14 +9582,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2222,
+									"id": 2229,
 									"name": "clone",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2223,
+											"id": 2230,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -9623,7 +9623,7 @@
 							}
 						},
 						{
-							"id": 2224,
+							"id": 2231,
 							"name": "compare",
 							"kind": 2048,
 							"kindString": "Method",
@@ -9632,14 +9632,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2225,
+									"id": 2232,
 									"name": "compare",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2226,
+											"id": 2233,
 											"name": "benchmark",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -9673,7 +9673,7 @@
 							}
 						},
 						{
-							"id": 2227,
+							"id": 2234,
 							"name": "emit",
 							"kind": 2048,
 							"kindString": "Method",
@@ -9682,14 +9682,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2228,
+									"id": 2235,
 									"name": "emit",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2229,
+											"id": 2236,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -9732,7 +9732,7 @@
 							}
 						},
 						{
-							"id": 2230,
+							"id": 2237,
 							"name": "listeners",
 							"kind": 2048,
 							"kindString": "Method",
@@ -9741,14 +9741,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2231,
+									"id": 2238,
 									"name": "listeners",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2232,
+											"id": 2239,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -9785,7 +9785,7 @@
 							}
 						},
 						{
-							"id": 2233,
+							"id": 2240,
 							"name": "off",
 							"kind": 2048,
 							"kindString": "Method",
@@ -9794,14 +9794,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2234,
+									"id": 2241,
 									"name": "off",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2235,
+											"id": 2242,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -9823,7 +9823,7 @@
 											}
 										},
 										{
-											"id": 2236,
+											"id": 2243,
 											"name": "listener",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -9846,14 +9846,14 @@
 									}
 								},
 								{
-									"id": 2237,
+									"id": 2244,
 									"name": "off",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2238,
+											"id": 2245,
 											"name": "types",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -9895,7 +9895,7 @@
 							}
 						},
 						{
-							"id": 2239,
+							"id": 2246,
 							"name": "on",
 							"kind": 2048,
 							"kindString": "Method",
@@ -9904,14 +9904,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2240,
+									"id": 2247,
 									"name": "on",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2241,
+											"id": 2248,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -9933,7 +9933,7 @@
 											}
 										},
 										{
-											"id": 2242,
+											"id": 2249,
 											"name": "listener",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -9956,14 +9956,14 @@
 									}
 								},
 								{
-									"id": 2243,
+									"id": 2250,
 									"name": "on",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2244,
+											"id": 2251,
 											"name": "types",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10005,7 +10005,7 @@
 							}
 						},
 						{
-							"id": 2245,
+							"id": 2252,
 							"name": "reset",
 							"kind": 2048,
 							"kindString": "Method",
@@ -10014,7 +10014,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2246,
+									"id": 2253,
 									"name": "reset",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -10042,7 +10042,7 @@
 							}
 						},
 						{
-							"id": 2247,
+							"id": 2254,
 							"name": "run",
 							"kind": 2048,
 							"kindString": "Method",
@@ -10051,14 +10051,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2248,
+									"id": 2255,
 									"name": "run",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2249,
+											"id": 2256,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10094,7 +10094,7 @@
 							}
 						},
 						{
-							"id": 2250,
+							"id": 2257,
 							"name": "toString",
 							"kind": 2048,
 							"kindString": "Method",
@@ -10103,7 +10103,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2251,
+									"id": 2258,
 									"name": "toString",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -10131,7 +10131,7 @@
 							}
 						},
 						{
-							"id": 2095,
+							"id": 2102,
 							"name": "deepClone",
 							"kind": 2048,
 							"kindString": "Method",
@@ -10141,14 +10141,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2096,
+									"id": 2103,
 									"name": "deepClone",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2097,
+											"id": 2104,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -10157,7 +10157,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2098,
+											"id": 2105,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10191,7 +10191,7 @@
 							}
 						},
 						{
-							"id": 2099,
+							"id": 2106,
 							"name": "each",
 							"kind": 2048,
 							"kindString": "Method",
@@ -10201,14 +10201,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2100,
+									"id": 2107,
 									"name": "each",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2101,
+											"id": 2108,
 											"name": "obj",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10231,7 +10231,7 @@
 											}
 										},
 										{
-											"id": 2102,
+											"id": 2109,
 											"name": "callback",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10242,7 +10242,7 @@
 											}
 										},
 										{
-											"id": 2103,
+											"id": 2110,
 											"name": "thisArg",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10278,7 +10278,7 @@
 							}
 						},
 						{
-							"id": 2104,
+							"id": 2111,
 							"name": "extend",
 							"kind": 2048,
 							"kindString": "Method",
@@ -10288,14 +10288,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2105,
+									"id": 2112,
 									"name": "extend",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2106,
+											"id": 2113,
 											"name": "destination",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10306,7 +10306,7 @@
 											}
 										},
 										{
-											"id": 2107,
+											"id": 2114,
 											"name": "sources",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10345,7 +10345,7 @@
 							}
 						},
 						{
-							"id": 2108,
+							"id": 2115,
 							"name": "filter",
 							"kind": 2048,
 							"kindString": "Method",
@@ -10355,14 +10355,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2109,
+									"id": 2116,
 									"name": "filter",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2110,
+											"id": 2117,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -10371,7 +10371,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2111,
+											"id": 2118,
 											"name": "arr",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10385,7 +10385,7 @@
 											}
 										},
 										{
-											"id": 2112,
+											"id": 2119,
 											"name": "callback",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10393,21 +10393,21 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 2113,
+													"id": 2120,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"signatures": [
 														{
-															"id": 2114,
+															"id": 2121,
 															"name": "__call",
 															"kind": 4096,
 															"kindString": "Call signature",
 															"flags": {},
 															"parameters": [
 																{
-																	"id": 2115,
+																	"id": 2122,
 																	"name": "value",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -10435,7 +10435,7 @@
 											}
 										},
 										{
-											"id": 2116,
+											"id": 2123,
 											"name": "thisArg",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10461,14 +10461,14 @@
 									}
 								},
 								{
-									"id": 2117,
+									"id": 2124,
 									"name": "filter",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2118,
+											"id": 2125,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -10477,7 +10477,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2119,
+											"id": 2126,
 											"name": "arr",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10491,7 +10491,7 @@
 											}
 										},
 										{
-											"id": 2120,
+											"id": 2127,
 											"name": "filter",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10502,7 +10502,7 @@
 											}
 										},
 										{
-											"id": 2121,
+											"id": 2128,
 											"name": "thisArg",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10546,7 +10546,7 @@
 							}
 						},
 						{
-							"id": 2122,
+							"id": 2129,
 							"name": "forEach",
 							"kind": 2048,
 							"kindString": "Method",
@@ -10556,14 +10556,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2123,
+									"id": 2130,
 									"name": "forEach",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2124,
+											"id": 2131,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -10572,7 +10572,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2125,
+											"id": 2132,
 											"name": "arr",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10586,7 +10586,7 @@
 											}
 										},
 										{
-											"id": 2126,
+											"id": 2133,
 											"name": "callback",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10594,21 +10594,21 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 2127,
+													"id": 2134,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"signatures": [
 														{
-															"id": 2128,
+															"id": 2135,
 															"name": "__call",
 															"kind": 4096,
 															"kindString": "Call signature",
 															"flags": {},
 															"parameters": [
 																{
-																	"id": 2129,
+																	"id": 2136,
 																	"name": "value",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -10636,7 +10636,7 @@
 											}
 										},
 										{
-											"id": 2130,
+											"id": 2137,
 											"name": "thisArg",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10672,7 +10672,7 @@
 							}
 						},
 						{
-							"id": 2134,
+							"id": 2141,
 							"name": "forOwn",
 							"kind": 2048,
 							"kindString": "Method",
@@ -10682,14 +10682,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2135,
+									"id": 2142,
 									"name": "forOwn",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2136,
+											"id": 2143,
 											"name": "obj",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10700,7 +10700,7 @@
 											}
 										},
 										{
-											"id": 2137,
+											"id": 2144,
 											"name": "callback",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10711,7 +10711,7 @@
 											}
 										},
 										{
-											"id": 2138,
+											"id": 2145,
 											"name": "thisArg",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10747,7 +10747,7 @@
 							}
 						},
 						{
-							"id": 2131,
+							"id": 2138,
 							"name": "formatNumber",
 							"kind": 2048,
 							"kindString": "Method",
@@ -10757,14 +10757,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2132,
+									"id": 2139,
 									"name": "formatNumber",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2133,
+											"id": 2140,
 											"name": "num",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10798,7 +10798,7 @@
 							}
 						},
 						{
-							"id": 2139,
+							"id": 2146,
 							"name": "hasKey",
 							"kind": 2048,
 							"kindString": "Method",
@@ -10808,14 +10808,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2140,
+									"id": 2147,
 									"name": "hasKey",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2141,
+											"id": 2148,
 											"name": "obj",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10826,7 +10826,7 @@
 											}
 										},
 										{
-											"id": 2142,
+											"id": 2149,
 											"name": "key",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10860,7 +10860,7 @@
 							}
 						},
 						{
-							"id": 2143,
+							"id": 2150,
 							"name": "indexOf",
 							"kind": 2048,
 							"kindString": "Method",
@@ -10870,14 +10870,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2144,
+									"id": 2151,
 									"name": "indexOf",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2145,
+											"id": 2152,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -10886,7 +10886,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2146,
+											"id": 2153,
 											"name": "arr",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10900,7 +10900,7 @@
 											}
 										},
 										{
-											"id": 2147,
+											"id": 2154,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10911,7 +10911,7 @@
 											}
 										},
 										{
-											"id": 2148,
+											"id": 2155,
 											"name": "fromIndex",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10956,7 +10956,7 @@
 							}
 						},
 						{
-							"id": 2149,
+							"id": 2156,
 							"name": "interpolate",
 							"kind": 2048,
 							"kindString": "Method",
@@ -10966,14 +10966,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2150,
+									"id": 2157,
 									"name": "interpolate",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2151,
+											"id": 2158,
 											"name": "template",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -10984,7 +10984,7 @@
 											}
 										},
 										{
-											"id": 2152,
+											"id": 2159,
 											"name": "values",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11018,7 +11018,7 @@
 							}
 						},
 						{
-							"id": 2153,
+							"id": 2160,
 							"name": "invoke",
 							"kind": 2048,
 							"kindString": "Method",
@@ -11028,14 +11028,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2154,
+									"id": 2161,
 									"name": "invoke",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2155,
+											"id": 2162,
 											"name": "benches",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11049,7 +11049,7 @@
 											}
 										},
 										{
-											"id": 2156,
+											"id": 2163,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11069,7 +11069,7 @@
 											}
 										},
 										{
-											"id": 2157,
+											"id": 2164,
 											"name": "args",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11111,7 +11111,7 @@
 							}
 						},
 						{
-							"id": 2158,
+							"id": 2165,
 							"name": "join",
 							"kind": 2048,
 							"kindString": "Method",
@@ -11121,14 +11121,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2159,
+									"id": 2166,
 									"name": "join",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2160,
+											"id": 2167,
 											"name": "obj",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11139,7 +11139,7 @@
 											}
 										},
 										{
-											"id": 2161,
+											"id": 2168,
 											"name": "separator1",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11161,7 +11161,7 @@
 											}
 										},
 										{
-											"id": 2162,
+											"id": 2169,
 											"name": "separator2",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11206,7 +11206,7 @@
 							}
 						},
 						{
-							"id": 2163,
+							"id": 2170,
 							"name": "map",
 							"kind": 2048,
 							"kindString": "Method",
@@ -11216,21 +11216,21 @@
 							},
 							"signatures": [
 								{
-									"id": 2164,
+									"id": 2171,
 									"name": "map",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2165,
+											"id": 2172,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
 											"flags": {}
 										},
 										{
-											"id": 2166,
+											"id": 2173,
 											"name": "K",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -11239,7 +11239,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2167,
+											"id": 2174,
 											"name": "arr",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11253,7 +11253,7 @@
 											}
 										},
 										{
-											"id": 2168,
+											"id": 2175,
 											"name": "callback",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11261,21 +11261,21 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 2169,
+													"id": 2176,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"signatures": [
 														{
-															"id": 2170,
+															"id": 2177,
 															"name": "__call",
 															"kind": 4096,
 															"kindString": "Call signature",
 															"flags": {},
 															"parameters": [
 																{
-																	"id": 2171,
+																	"id": 2178,
 																	"name": "value",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -11303,7 +11303,7 @@
 											}
 										},
 										{
-											"id": 2172,
+											"id": 2179,
 											"name": "thisArg",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11342,7 +11342,7 @@
 							}
 						},
 						{
-							"id": 2173,
+							"id": 2180,
 							"name": "pluck",
 							"kind": 2048,
 							"kindString": "Method",
@@ -11352,21 +11352,21 @@
 							},
 							"signatures": [
 								{
-									"id": 2174,
+									"id": 2181,
 									"name": "pluck",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2175,
+											"id": 2182,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
 											"flags": {}
 										},
 										{
-											"id": 2176,
+											"id": 2183,
 											"name": "K",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -11375,7 +11375,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2177,
+											"id": 2184,
 											"name": "arr",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11389,7 +11389,7 @@
 											}
 										},
 										{
-											"id": 2178,
+											"id": 2185,
 											"name": "key",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11426,7 +11426,7 @@
 							}
 						},
 						{
-							"id": 2179,
+							"id": 2186,
 							"name": "reduce",
 							"kind": 2048,
 							"kindString": "Method",
@@ -11436,21 +11436,21 @@
 							},
 							"signatures": [
 								{
-									"id": 2180,
+									"id": 2187,
 									"name": "reduce",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2181,
+											"id": 2188,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
 											"flags": {}
 										},
 										{
-											"id": 2182,
+											"id": 2189,
 											"name": "K",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -11459,7 +11459,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2183,
+											"id": 2190,
 											"name": "arr",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11473,7 +11473,7 @@
 											}
 										},
 										{
-											"id": 2184,
+											"id": 2191,
 											"name": "callback",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11481,21 +11481,21 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 2185,
+													"id": 2192,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"signatures": [
 														{
-															"id": 2186,
+															"id": 2193,
 															"name": "__call",
 															"kind": 4096,
 															"kindString": "Call signature",
 															"flags": {},
 															"parameters": [
 																{
-																	"id": 2187,
+																	"id": 2194,
 																	"name": "accumulator",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -11506,7 +11506,7 @@
 																	}
 																},
 																{
-																	"id": 2188,
+																	"id": 2195,
 																	"name": "value",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -11534,7 +11534,7 @@
 											}
 										},
 										{
-											"id": 2189,
+											"id": 2196,
 											"name": "thisArg",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -11575,81 +11575,81 @@
 							"title": "Classes",
 							"kind": 128,
 							"children": [
-								2309,
-								2317,
-								2328
+								2316,
+								2324,
+								2335
 							]
 						},
 						{
 							"title": "Interfaces",
 							"kind": 256,
 							"children": [
-								2252,
-								2272,
-								2296,
-								2283,
-								2304
+								2259,
+								2279,
+								2303,
+								2290,
+								2311
 							]
 						},
 						{
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								2194
+								2201
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2207,
-								2208,
-								2209,
-								2210,
-								2211,
-								2212,
-								2213,
-								2094,
 								2214,
 								2215,
-								2217,
 								2216,
+								2217,
 								2218,
-								2190,
-								2191,
-								2192,
-								2193
+								2219,
+								2220,
+								2101,
+								2221,
+								2222,
+								2224,
+								2223,
+								2225,
+								2197,
+								2198,
+								2199,
+								2200
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								2219,
-								2221,
-								2224,
-								2227,
-								2230,
-								2233,
-								2239,
-								2245,
-								2247,
-								2250,
-								2095,
-								2099,
-								2104,
-								2108,
-								2122,
-								2134,
-								2131,
-								2139,
-								2143,
-								2149,
-								2153,
-								2158,
-								2163,
-								2173,
-								2179
+								2226,
+								2228,
+								2231,
+								2234,
+								2237,
+								2240,
+								2246,
+								2252,
+								2254,
+								2257,
+								2102,
+								2106,
+								2111,
+								2115,
+								2129,
+								2141,
+								2138,
+								2146,
+								2150,
+								2156,
+								2160,
+								2165,
+								2170,
+								2180,
+								2186
 							]
 						}
 					],
@@ -11668,7 +11668,7 @@
 					]
 				},
 				{
-					"id": 2427,
+					"id": 2434,
 					"name": "BenchmarkTestOptions",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -11692,21 +11692,21 @@
 									{
 										"type": "reference",
 										"name": "BenchmarkTestProperties",
-										"id": 2062
+										"id": 2069
 									}
 								]
 							},
 							{
 								"type": "reflection",
 								"declaration": {
-									"id": 2428,
+									"id": 2435,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 2429,
+											"id": 2436,
 											"name": "name",
 											"kind": 32,
 											"kindString": "Variable",
@@ -11724,7 +11724,7 @@
 											}
 										},
 										{
-											"id": 2431,
+											"id": 2438,
 											"name": "options",
 											"kind": 32,
 											"kindString": "Variable",
@@ -11741,11 +11741,11 @@
 											"type": {
 												"type": "reference",
 												"name": "BenchmarkOptions",
-												"id": 2071
+												"id": 2078
 											}
 										},
 										{
-											"id": 2430,
+											"id": 2437,
 											"name": "test",
 											"kind": 32,
 											"kindString": "Variable",
@@ -11760,7 +11760,7 @@
 											"type": {
 												"type": "reference",
 												"name": "BenchmarkTestFunction",
-												"id": 2045
+												"id": 2052
 											}
 										}
 									],
@@ -11769,9 +11769,9 @@
 											"title": "Variables",
 											"kind": 32,
 											"children": [
-												2429,
-												2431,
-												2430
+												2436,
+												2438,
+												2437
 											]
 										}
 									],
@@ -11788,21 +11788,21 @@
 					}
 				},
 				{
-					"id": 2438,
+					"id": 2445,
 					"name": "createDeferred",
 					"kind": 64,
 					"kindString": "Function",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 2439,
+							"id": 2446,
 							"name": "createDeferred",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 2440,
+									"id": 2447,
 									"name": "benchmark",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11813,7 +11813,7 @@
 									}
 								},
 								{
-									"id": 2441,
+									"id": 2448,
 									"name": "deferred",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11831,7 +11831,7 @@
 									}
 								},
 								{
-									"id": 2442,
+									"id": 2449,
 									"name": "numCallsUntilResolution",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11875,7 +11875,7 @@
 					]
 				},
 				{
-					"id": 2435,
+					"id": 2442,
 					"name": "createLifecycle",
 					"kind": 64,
 					"kindString": "Function",
@@ -11884,14 +11884,14 @@
 					},
 					"signatures": [
 						{
-							"id": 2436,
+							"id": 2443,
 							"name": "createLifecycle",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 2437,
+									"id": 2444,
 									"name": "before",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11917,7 +11917,7 @@
 					]
 				},
 				{
-					"id": 2432,
+					"id": 2439,
 					"name": "isBenchmarkTest",
 					"kind": 64,
 					"kindString": "Function",
@@ -11926,14 +11926,14 @@
 					},
 					"signatures": [
 						{
-							"id": 2433,
+							"id": 2440,
 							"name": "isBenchmarkTest",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 2434,
+									"id": 2441,
 									"name": "value",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11964,34 +11964,34 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						1984
+						1991
 					]
 				},
 				{
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
+						2059,
+						2078,
 						2052,
-						2071,
-						2045,
-						2062,
-						2093
+						2069,
+						2100
 					]
 				},
 				{
 					"title": "Type aliases",
 					"kind": 4194304,
 					"children": [
-						2427
+						2434
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						2438,
-						2435,
-						2432
+						2445,
+						2442,
+						2439
 					]
 				}
 			],
@@ -12004,7 +12004,7 @@
 			]
 		},
 		{
-			"id": 4445,
+			"id": 4449,
 			"name": "\"lib/Channel\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -12014,7 +12014,7 @@
 			"originalName": "src/lib/Channel.ts",
 			"children": [
 				{
-					"id": 4446,
+					"id": 4450,
 					"name": "Channel",
 					"kind": 128,
 					"kindString": "Class",
@@ -12023,7 +12023,7 @@
 					},
 					"children": [
 						{
-							"id": 4448,
+							"id": 4452,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -12032,14 +12032,14 @@
 							},
 							"signatures": [
 								{
-									"id": 4449,
+									"id": 4453,
 									"name": "new Channel",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4450,
+											"id": 4454,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -12054,7 +12054,7 @@
 									"type": {
 										"type": "reference",
 										"name": "Channel",
-										"id": 4446
+										"id": 4450
 									}
 								}
 							],
@@ -12067,7 +12067,7 @@
 							]
 						},
 						{
-							"id": 4447,
+							"id": 4451,
 							"name": "options",
 							"kind": 1024,
 							"kindString": "Property",
@@ -12088,7 +12088,7 @@
 							}
 						},
 						{
-							"id": 4455,
+							"id": 4459,
 							"name": "_initialize",
 							"kind": 2048,
 							"kindString": "Method",
@@ -12098,7 +12098,7 @@
 							},
 							"signatures": [
 								{
-									"id": 4456,
+									"id": 4460,
 									"name": "_initialize",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -12124,7 +12124,7 @@
 							]
 						},
 						{
-							"id": 4451,
+							"id": 4455,
 							"name": "sendMessage",
 							"kind": 2048,
 							"kindString": "Method",
@@ -12133,14 +12133,14 @@
 							},
 							"signatures": [
 								{
-									"id": 4452,
+									"id": 4456,
 									"name": "sendMessage",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4453,
+											"id": 4457,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -12155,7 +12155,7 @@
 											}
 										},
 										{
-											"id": 4454,
+											"id": 4458,
 											"name": "data",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -12192,22 +12192,22 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								4448
+								4452
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4447
+								4451
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								4455,
-								4451
+								4459,
+								4455
 							]
 						}
 					],
@@ -12225,7 +12225,7 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						4446
+						4450
 					]
 				}
 			],
@@ -13199,7 +13199,7 @@
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							}
 						},
 						{
@@ -21032,7 +21032,7 @@
 													{
 														"type": "reference",
 														"name": "SuiteOptions",
-														"id": 3492
+														"id": 3499
 													}
 												]
 											}
@@ -21046,7 +21046,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Suite.__constructor",
-										"id": 3415
+										"id": 3422
 									}
 								}
 							],
@@ -21060,7 +21060,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Suite.__constructor",
-								"id": 3415
+								"id": 3422
 							}
 						},
 						{
@@ -21087,7 +21087,7 @@
 									{
 										"type": "reference",
 										"name": "SuiteLifecycleFunction",
-										"id": 3470
+										"id": 3477
 									},
 									{
 										"type": "intrinsic",
@@ -21098,12 +21098,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.after",
-								"id": 3401
+								"id": 3408
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.after",
-								"id": 3480
+								"id": 3487
 							}
 						},
 						{
@@ -21130,7 +21130,7 @@
 									{
 										"type": "reference",
 										"name": "TestLifecycleFunction",
-										"id": 3474
+										"id": 3481
 									},
 									{
 										"type": "intrinsic",
@@ -21141,12 +21141,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.afterEach",
-								"id": 3402
+								"id": 3409
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.afterEach",
-								"id": 3481
+								"id": 3488
 							}
 						},
 						{
@@ -21240,7 +21240,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.async",
-								"id": 3403
+								"id": 3410
 							}
 						},
 						{
@@ -21267,7 +21267,7 @@
 									{
 										"type": "reference",
 										"name": "SuiteLifecycleFunction",
-										"id": 3470
+										"id": 3477
 									},
 									{
 										"type": "intrinsic",
@@ -21278,12 +21278,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.before",
-								"id": 3407
+								"id": 3414
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.before",
-								"id": 3483
+								"id": 3490
 							}
 						},
 						{
@@ -21310,7 +21310,7 @@
 									{
 										"type": "reference",
 										"name": "TestLifecycleFunction",
-										"id": 3474
+										"id": 3481
 									},
 									{
 										"type": "intrinsic",
@@ -21321,12 +21321,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.beforeEach",
-								"id": 3408
+								"id": 3415
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.beforeEach",
-								"id": 3484
+								"id": 3491
 							}
 						},
 						{
@@ -21364,7 +21364,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.error",
-								"id": 3409
+								"id": 3416
 							}
 						},
 						{
@@ -21385,12 +21385,12 @@
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							},
 							"overwrites": {
 								"type": "reference",
 								"name": "Suite.executor",
-								"id": 3422
+								"id": 3429
 							}
 						},
 						{
@@ -21417,7 +21417,7 @@
 									{
 										"type": "reference",
 										"name": "Suite",
-										"id": 3400
+										"id": 3407
 									},
 									{
 										"type": "intrinsic",
@@ -21428,7 +21428,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.parent",
-								"id": 3410
+								"id": 3417
 							}
 						},
 						{
@@ -21457,12 +21457,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.publishAfterSetup",
-								"id": 3411
+								"id": 3418
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.publishAfterSetup",
-								"id": 3487
+								"id": 3494
 							}
 						},
 						{
@@ -21499,7 +21499,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.skipped",
-								"id": 3412
+								"id": 3419
 							}
 						},
 						{
@@ -21528,12 +21528,12 @@
 										{
 											"type": "reference",
 											"name": "Suite",
-											"id": 3400
+											"id": 3407
 										},
 										{
 											"type": "reference",
 											"name": "Test",
-											"id": 3317
+											"id": 3324
 										}
 									]
 								}
@@ -21542,7 +21542,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.tests",
-								"id": 3413
+								"id": 3420
 							}
 						},
 						{
@@ -21579,7 +21579,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.timeElapsed",
-								"id": 3414
+								"id": 3421
 							}
 						},
 						{
@@ -21610,7 +21610,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.bail",
-										"id": 3418
+										"id": 3425
 									}
 								}
 							],
@@ -21644,7 +21644,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.bail",
-										"id": 3418
+										"id": 3425
 									}
 								}
 							],
@@ -21663,12 +21663,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.bail",
-								"id": 3418
+								"id": 3425
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.bail",
-								"id": 3482
+								"id": 3489
 							}
 						},
 						{
@@ -21699,7 +21699,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.grep",
-										"id": 3426
+										"id": 3433
 									}
 								}
 							],
@@ -21733,7 +21733,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.grep",
-										"id": 3426
+										"id": 3433
 									}
 								}
 							],
@@ -21752,12 +21752,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.grep",
-								"id": 3426
+								"id": 3433
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.grep",
-								"id": 3485
+								"id": 3492
 							}
 						},
 						{
@@ -21788,7 +21788,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.hasParent",
-										"id": 3454
+										"id": 3461
 									}
 								}
 							],
@@ -21802,7 +21802,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.hasParent",
-								"id": 3454
+								"id": 3461
 							}
 						},
 						{
@@ -21833,7 +21833,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Suite.id",
-										"id": 3434
+										"id": 3441
 									}
 								}
 							],
@@ -21847,7 +21847,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Suite.id",
-								"id": 3434
+								"id": 3441
 							}
 						},
 						{
@@ -21887,7 +21887,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.name",
-										"id": 3430
+										"id": 3437
 									}
 								}
 							],
@@ -21930,7 +21930,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.name",
-										"id": 3430
+										"id": 3437
 									}
 								}
 							],
@@ -21949,12 +21949,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.name",
-								"id": 3430
+								"id": 3437
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.name",
-								"id": 3486
+								"id": 3493
 							}
 						},
 						{
@@ -21985,7 +21985,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.numFailedTests",
-										"id": 3450
+										"id": 3457
 									}
 								}
 							],
@@ -21999,7 +21999,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.numFailedTests",
-								"id": 3450
+								"id": 3457
 							}
 						},
 						{
@@ -22030,7 +22030,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.numPassedTests",
-										"id": 3448
+										"id": 3455
 									}
 								}
 							],
@@ -22044,7 +22044,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.numPassedTests",
-								"id": 3448
+								"id": 3455
 							}
 						},
 						{
@@ -22075,7 +22075,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.numSkippedTests",
-										"id": 3452
+										"id": 3459
 									}
 								}
 							],
@@ -22089,7 +22089,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.numSkippedTests",
-								"id": 3452
+								"id": 3459
 							}
 						},
 						{
@@ -22120,7 +22120,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.numTests",
-										"id": 3446
+										"id": 3453
 									}
 								}
 							],
@@ -22134,7 +22134,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.numTests",
-								"id": 3446
+								"id": 3453
 							}
 						},
 						{
@@ -22174,7 +22174,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.parentId",
-										"id": 3436
+										"id": 3443
 									}
 								}
 							],
@@ -22188,7 +22188,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.parentId",
-								"id": 3436
+								"id": 3443
 							}
 						},
 						{
@@ -22215,12 +22215,12 @@
 									"type": {
 										"type": "reference",
 										"name": "Remote",
-										"id": 2813
+										"id": 2820
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.remote",
-										"id": 3438
+										"id": 3445
 									}
 								}
 							],
@@ -22244,7 +22244,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Remote",
-												"id": 2813
+												"id": 2820
 											}
 										}
 									],
@@ -22255,7 +22255,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.remote",
-										"id": 3438
+										"id": 3445
 									}
 								}
 							],
@@ -22274,7 +22274,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.remote",
-								"id": 3438
+								"id": 3445
 							}
 						},
 						{
@@ -22305,7 +22305,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.sessionId",
-										"id": 3442
+										"id": 3449
 									}
 								}
 							],
@@ -22339,7 +22339,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.sessionId",
-										"id": 3442
+										"id": 3449
 									}
 								}
 							],
@@ -22358,7 +22358,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.sessionId",
-								"id": 3442
+								"id": 3449
 							}
 						},
 						{
@@ -22383,7 +22383,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.timeout",
-										"id": 3456
+										"id": 3463
 									}
 								}
 							],
@@ -22414,7 +22414,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.timeout",
-										"id": 3456
+										"id": 3463
 									}
 								}
 							],
@@ -22433,12 +22433,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.timeout",
-								"id": 3456
+								"id": 3463
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.timeout",
-								"id": 3488
+								"id": 3495
 							}
 						},
 						{
@@ -22472,12 +22472,12 @@
 													{
 														"type": "reference",
 														"name": "Suite",
-														"id": 3400
+														"id": 3407
 													},
 													{
 														"type": "reference",
 														"name": "Test",
-														"id": 3317
+														"id": 3324
 													}
 												]
 											}
@@ -22490,7 +22490,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.add",
-										"id": 3460
+										"id": 3467
 									}
 								}
 							],
@@ -22504,7 +22504,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.add",
-								"id": 3460
+								"id": 3467
 							}
 						},
 						{
@@ -22538,7 +22538,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Suite.run",
-										"id": 3463
+										"id": 3470
 									}
 								}
 							],
@@ -22552,7 +22552,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Suite.run",
-								"id": 3463
+								"id": 3470
 							}
 						},
 						{
@@ -22598,7 +22598,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.skip",
-										"id": 3465
+										"id": 3472
 									}
 								}
 							],
@@ -22612,7 +22612,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.skip",
-								"id": 3465
+								"id": 3472
 							}
 						},
 						{
@@ -22637,7 +22637,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Suite.toJSON",
-										"id": 3468
+										"id": 3475
 									}
 								}
 							],
@@ -22651,7 +22651,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Suite.toJSON",
-								"id": 3468
+								"id": 3475
 							}
 						}
 					],
@@ -22722,14 +22722,14 @@
 						{
 							"type": "reference",
 							"name": "Suite",
-							"id": 3400
+							"id": 3407
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "SuiteProperties",
-							"id": 3479
+							"id": 3486
 						}
 					]
 				},
@@ -22767,7 +22767,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.bail",
-								"id": 4099
+								"id": 4106
 							}
 						},
 						{
@@ -22795,7 +22795,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.basePath",
-								"id": 4101
+								"id": 4108
 							}
 						},
 						{
@@ -22820,7 +22820,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.baseline",
-								"id": 4100
+								"id": 4107
 							}
 						},
 						{
@@ -22848,7 +22848,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.benchmark",
-								"id": 4102
+								"id": 4109
 							}
 						},
 						{
@@ -22870,12 +22870,12 @@
 							"type": {
 								"type": "reference",
 								"name": "BenchmarkConfig",
-								"id": 4180
+								"id": 4187
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.benchmarkConfig",
-								"id": 4103
+								"id": 4110
 							}
 						},
 						{
@@ -22896,12 +22896,12 @@
 							"type": {
 								"type": "reference",
 								"name": "ResourceConfig",
-								"id": 4171
+								"id": 4178
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.browser",
-								"id": 4104
+								"id": 4111
 							}
 						},
 						{
@@ -23039,7 +23039,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.capabilities",
-								"id": 4116
+								"id": 4123
 							}
 						},
 						{
@@ -23067,7 +23067,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.connectTimeout",
-								"id": 4122
+								"id": 4129
 							}
 						},
 						{
@@ -23108,7 +23108,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.coverage",
-								"id": 4123
+								"id": 4130
 							}
 						},
 						{
@@ -23136,7 +23136,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.coverageVariable",
-								"id": 4105
+								"id": 4112
 							}
 						},
 						{
@@ -23164,7 +23164,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.debug",
-								"id": 4106
+								"id": 4113
 							}
 						},
 						{
@@ -23192,7 +23192,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.defaultTimeout",
-								"id": 4107
+								"id": 4114
 							}
 						},
 						{
@@ -23220,7 +23220,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.description",
-								"id": 4108
+								"id": 4115
 							}
 						},
 						{
@@ -23247,13 +23247,13 @@
 								"elementType": {
 									"type": "reference",
 									"name": "EnvironmentSpec",
-									"id": 4189
+									"id": 4196
 								}
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.environments",
-								"id": 4124
+								"id": 4131
 							}
 						},
 						{
@@ -23278,7 +23278,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.excludeInstrumentation",
-								"id": 4125
+								"id": 4132
 							}
 						},
 						{
@@ -23306,7 +23306,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.filterErrorStack",
-								"id": 4109
+								"id": 4116
 							}
 						},
 						{
@@ -23344,7 +23344,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.functionalBaseUrl",
-								"id": 4126
+								"id": 4133
 							}
 						},
 						{
@@ -23372,7 +23372,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.functionalCoverage",
-								"id": 4127
+								"id": 4134
 							}
 						},
 						{
@@ -23404,7 +23404,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.functionalSuites",
-								"id": 4128
+								"id": 4135
 							}
 						},
 						{
@@ -23576,7 +23576,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.functionalTimeouts",
-								"id": 4129
+								"id": 4136
 							}
 						},
 						{
@@ -23604,7 +23604,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.grep",
-								"id": 4110
+								"id": 4117
 							}
 						},
 						{
@@ -23642,7 +23642,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.heartbeatInterval",
-								"id": 4135
+								"id": 4142
 							}
 						},
 						{
@@ -23709,7 +23709,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.instrumenterOptions",
-								"id": 4136
+								"id": 4143
 							}
 						},
 						{
@@ -23737,7 +23737,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.internPath",
-								"id": 4111
+								"id": 4118
 							}
 						},
 						{
@@ -23775,7 +23775,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.leaveRemoteOpen",
-								"id": 4140
+								"id": 4147
 							}
 						},
 						{
@@ -23800,12 +23800,12 @@
 							"type": {
 								"type": "reference",
 								"name": "LoaderDescriptor",
-								"id": 4183
+								"id": 4190
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.loader",
-								"id": 4172
+								"id": 4179
 							}
 						},
 						{
@@ -23834,7 +23834,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.maxConcurrency",
-								"id": 4141
+								"id": 4148
 							}
 						},
 						{
@@ -23862,7 +23862,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.name",
-								"id": 4112
+								"id": 4119
 							}
 						},
 						{
@@ -23883,12 +23883,12 @@
 							"type": {
 								"type": "reference",
 								"name": "ResourceConfig",
-								"id": 4171
+								"id": 4178
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.node",
-								"id": 4113
+								"id": 4120
 							}
 						},
 						{
@@ -23914,13 +23914,13 @@
 								"elementType": {
 									"type": "reference",
 									"name": "PluginDescriptor",
-									"id": 4163
+									"id": 4170
 								}
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.plugins",
-								"id": 4174
+								"id": 4181
 							}
 						},
 						{
@@ -23958,7 +23958,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.proxy",
-								"id": 4142
+								"id": 4149
 							}
 						},
 						{
@@ -23985,13 +23985,13 @@
 								"elementType": {
 									"type": "reference",
 									"name": "ReporterDescriptor",
-									"id": 4160
+									"id": 4167
 								}
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.reporters",
-								"id": 4173
+								"id": 4180
 							}
 						},
 						{
@@ -24016,7 +24016,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.require",
-								"id": 4177
+								"id": 4184
 							}
 						},
 						{
@@ -24041,7 +24041,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.requires",
-								"id": 4178
+								"id": 4185
 							}
 						},
 						{
@@ -24066,7 +24066,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Config.runInSync",
-								"id": 4143
+								"id": 4150
 							}
 						},
 						{
@@ -24091,7 +24091,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.scripts",
-								"id": 4179
+								"id": 4186
 							}
 						},
 						{
@@ -24119,7 +24119,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.serveOnly",
-								"id": 4144
+								"id": 4151
 							}
 						},
 						{
@@ -24147,7 +24147,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.serverPort",
-								"id": 4145
+								"id": 4152
 							}
 						},
 						{
@@ -24172,7 +24172,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Config.serverUrl",
-								"id": 4146
+								"id": 4153
 							}
 						},
 						{
@@ -24197,7 +24197,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Config.sessionId",
-								"id": 4114
+								"id": 4121
 							}
 						},
 						{
@@ -24225,7 +24225,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.showConfig",
-								"id": 4115
+								"id": 4122
 							}
 						},
 						{
@@ -24260,7 +24260,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Config.socketPort",
-								"id": 4147
+								"id": 4154
 							}
 						},
 						{
@@ -24292,7 +24292,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.suites",
-								"id": 4175
+								"id": 4182
 							}
 						},
 						{
@@ -24330,7 +24330,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.tsconfig",
-								"id": 4176
+								"id": 4183
 							}
 						},
 						{
@@ -24359,7 +24359,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.tunnel",
-								"id": 4148
+								"id": 4155
 							}
 						},
 						{
@@ -24401,7 +24401,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.tunnelOptions",
-								"id": 4149
+								"id": 4156
 							}
 						},
 						{
@@ -24438,7 +24438,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.warnOnUncaughtException",
-								"id": 4151
+								"id": 4158
 							}
 						},
 						{
@@ -24475,7 +24475,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Config.warnOnUnhandledRejection",
-								"id": 4150
+								"id": 4157
 							}
 						}
 					],
@@ -24546,7 +24546,7 @@
 						{
 							"type": "reference",
 							"name": "Config",
-							"id": 4098
+							"id": 4105
 						}
 					]
 				},
@@ -24580,12 +24580,12 @@
 							"type": {
 								"type": "reference",
 								"name": "ExecutorEvent",
-								"id": 4001
+								"id": 4008
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.'*'",
-								"id": 4005
+								"id": 4012
 							}
 						},
 						{
@@ -24613,7 +24613,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.afterRun",
-								"id": 4006
+								"id": 4013
 							}
 						},
 						{
@@ -24641,7 +24641,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.beforeRun",
-								"id": 4007
+								"id": 4014
 							}
 						},
 						{
@@ -24665,12 +24665,12 @@
 							"type": {
 								"type": "reference",
 								"name": "CoverageMessage",
-								"id": 3993
+								"id": 4000
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.coverage",
-								"id": 4008
+								"id": 4015
 							}
 						},
 						{
@@ -24694,12 +24694,12 @@
 							"type": {
 								"type": "reference",
 								"name": "DeprecationMessage",
-								"id": 3997
+								"id": 4004
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.deprecated",
-								"id": 4009
+								"id": 4016
 							}
 						},
 						{
@@ -24727,7 +24727,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.error",
-								"id": 4010
+								"id": 4017
 							}
 						},
 						{
@@ -24755,7 +24755,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.log",
-								"id": 4011
+								"id": 4018
 							}
 						},
 						{
@@ -24803,7 +24803,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.runEnd",
-								"id": 4012
+								"id": 4019
 							}
 						},
 						{
@@ -24831,7 +24831,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.runStart",
-								"id": 4013
+								"id": 4020
 							}
 						},
 						{
@@ -24860,7 +24860,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "NodeEvents.serverEnd",
-								"id": 3257
+								"id": 3264
 							}
 						},
 						{
@@ -24889,7 +24889,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "NodeEvents.serverStart",
-								"id": 3258
+								"id": 3265
 							}
 						},
 						{
@@ -24913,12 +24913,12 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.suiteAdd",
-								"id": 4014
+								"id": 4021
 							}
 						},
 						{
@@ -24942,12 +24942,12 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.suiteEnd",
-								"id": 4015
+								"id": 4022
 							}
 						},
 						{
@@ -24971,12 +24971,12 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.suiteStart",
-								"id": 4016
+								"id": 4023
 							}
 						},
 						{
@@ -25000,12 +25000,12 @@
 							"type": {
 								"type": "reference",
 								"name": "Test",
-								"id": 3317
+								"id": 3324
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.testAdd",
-								"id": 4017
+								"id": 4024
 							}
 						},
 						{
@@ -25029,12 +25029,12 @@
 							"type": {
 								"type": "reference",
 								"name": "Test",
-								"id": 3317
+								"id": 3324
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.testEnd",
-								"id": 4018
+								"id": 4025
 							}
 						},
 						{
@@ -25058,12 +25058,12 @@
 							"type": {
 								"type": "reference",
 								"name": "Test",
-								"id": 3317
+								"id": 3324
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.testStart",
-								"id": 4019
+								"id": 4026
 							}
 						},
 						{
@@ -25087,12 +25087,12 @@
 							"type": {
 								"type": "reference",
 								"name": "TunnelMessage",
-								"id": 3252
+								"id": 3259
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "NodeEvents.tunnelDownloadProgress",
-								"id": 3259
+								"id": 3266
 							}
 						},
 						{
@@ -25116,12 +25116,12 @@
 							"type": {
 								"type": "reference",
 								"name": "TunnelMessage",
-								"id": 3252
+								"id": 3259
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "NodeEvents.tunnelStart",
-								"id": 3260
+								"id": 3267
 							}
 						},
 						{
@@ -25145,12 +25145,12 @@
 							"type": {
 								"type": "reference",
 								"name": "TunnelMessage",
-								"id": 3252
+								"id": 3259
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "NodeEvents.tunnelStatus",
-								"id": 3261
+								"id": 3268
 							}
 						},
 						{
@@ -25174,12 +25174,12 @@
 							"type": {
 								"type": "reference",
 								"name": "TunnelMessage",
-								"id": 3252
+								"id": 3259
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "NodeEvents.tunnelStop",
-								"id": 3262
+								"id": 3269
 							}
 						},
 						{
@@ -25207,7 +25207,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.warning",
-								"id": 4020
+								"id": 4027
 							}
 						}
 					],
@@ -25253,7 +25253,7 @@
 						{
 							"type": "reference",
 							"name": "NodeEvents",
-							"id": 3256
+							"id": 3263
 						}
 					]
 				},
@@ -25628,7 +25628,7 @@
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -25982,7 +25982,7 @@
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							}
 						},
 						{
@@ -26183,7 +26183,7 @@
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							}
 						},
 						{
@@ -26329,7 +26329,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Node",
-												"id": 2600
+												"id": 2607
 											}
 										}
 									],
@@ -26494,7 +26494,7 @@
 			]
 		},
 		{
-			"id": 3399,
+			"id": 3406,
 			"name": "\"lib/Suite\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -26504,7 +26504,7 @@
 			"originalName": "src/lib/Suite.ts",
 			"children": [
 				{
-					"id": 3400,
+					"id": 3407,
 					"name": "Suite",
 					"kind": 128,
 					"kindString": "Class",
@@ -26516,7 +26516,7 @@
 					},
 					"children": [
 						{
-							"id": 3415,
+							"id": 3422,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -26526,7 +26526,7 @@
 							"comment": {},
 							"signatures": [
 								{
-									"id": 3416,
+									"id": 3423,
 									"name": "new Suite",
 									"kind": 16384,
 									"kindString": "Constructor signature",
@@ -26534,7 +26534,7 @@
 									"comment": {},
 									"parameters": [
 										{
-											"id": 3417,
+											"id": 3424,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -26548,12 +26548,12 @@
 													{
 														"type": "reference",
 														"name": "SuiteOptions",
-														"id": 3492
+														"id": 3499
 													},
 													{
 														"type": "reference",
 														"name": "RootSuiteOptions",
-														"id": 3497
+														"id": 3504
 													}
 												]
 											}
@@ -26562,7 +26562,7 @@
 									"type": {
 										"type": "reference",
 										"name": "Suite",
-										"id": 3400
+										"id": 3407
 									}
 								}
 							],
@@ -26575,7 +26575,7 @@
 							]
 						},
 						{
-							"id": 3401,
+							"id": 3408,
 							"name": "after",
 							"kind": 1024,
 							"kindString": "Property",
@@ -26598,7 +26598,7 @@
 									{
 										"type": "reference",
 										"name": "SuiteLifecycleFunction",
-										"id": 3470
+										"id": 3477
 									},
 									{
 										"type": "intrinsic",
@@ -26609,11 +26609,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.after",
-								"id": 3480
+								"id": 3487
 							}
 						},
 						{
-							"id": 3402,
+							"id": 3409,
 							"name": "afterEach",
 							"kind": 1024,
 							"kindString": "Property",
@@ -26636,7 +26636,7 @@
 									{
 										"type": "reference",
 										"name": "TestLifecycleFunction",
-										"id": 3474
+										"id": 3481
 									},
 									{
 										"type": "intrinsic",
@@ -26647,11 +26647,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.afterEach",
-								"id": 3481
+								"id": 3488
 							}
 						},
 						{
-							"id": 3403,
+							"id": 3410,
 							"name": "async",
 							"kind": 1024,
 							"kindString": "Property",
@@ -26674,21 +26674,21 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 3404,
+											"id": 3411,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 3405,
+													"id": 3412,
 													"name": "__call",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 3406,
+															"id": 3413,
 															"name": "timeout",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -26740,7 +26740,7 @@
 							}
 						},
 						{
-							"id": 3407,
+							"id": 3414,
 							"name": "before",
 							"kind": 1024,
 							"kindString": "Property",
@@ -26763,7 +26763,7 @@
 									{
 										"type": "reference",
 										"name": "SuiteLifecycleFunction",
-										"id": 3470
+										"id": 3477
 									},
 									{
 										"type": "intrinsic",
@@ -26774,11 +26774,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.before",
-								"id": 3483
+								"id": 3490
 							}
 						},
 						{
-							"id": 3408,
+							"id": 3415,
 							"name": "beforeEach",
 							"kind": 1024,
 							"kindString": "Property",
@@ -26801,7 +26801,7 @@
 									{
 										"type": "reference",
 										"name": "TestLifecycleFunction",
-										"id": 3474
+										"id": 3481
 									},
 									{
 										"type": "intrinsic",
@@ -26812,11 +26812,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.beforeEach",
-								"id": 3484
+								"id": 3491
 							}
 						},
 						{
-							"id": 3409,
+							"id": 3416,
 							"name": "error",
 							"kind": 1024,
 							"kindString": "Property",
@@ -26849,7 +26849,7 @@
 							}
 						},
 						{
-							"id": 3410,
+							"id": 3417,
 							"name": "parent",
 							"kind": 1024,
 							"kindString": "Property",
@@ -26872,7 +26872,7 @@
 									{
 										"type": "reference",
 										"name": "Suite",
-										"id": 3400
+										"id": 3407
 									},
 									{
 										"type": "intrinsic",
@@ -26882,7 +26882,7 @@
 							}
 						},
 						{
-							"id": 3411,
+							"id": 3418,
 							"name": "publishAfterSetup",
 							"kind": 1024,
 							"kindString": "Property",
@@ -26907,11 +26907,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.publishAfterSetup",
-								"id": 3487
+								"id": 3494
 							}
 						},
 						{
-							"id": 3412,
+							"id": 3419,
 							"name": "skipped",
 							"kind": 1024,
 							"kindString": "Property",
@@ -26943,7 +26943,7 @@
 							}
 						},
 						{
-							"id": 3413,
+							"id": 3420,
 							"name": "tests",
 							"kind": 1024,
 							"kindString": "Property",
@@ -26968,12 +26968,12 @@
 										{
 											"type": "reference",
 											"name": "Suite",
-											"id": 3400
+											"id": 3407
 										},
 										{
 											"type": "reference",
 											"name": "Test",
-											"id": 3317
+											"id": 3324
 										}
 									]
 								}
@@ -26981,7 +26981,7 @@
 							"defaultValue": " []"
 						},
 						{
-							"id": 3414,
+							"id": 3421,
 							"name": "timeElapsed",
 							"kind": 1024,
 							"kindString": "Property",
@@ -27013,7 +27013,7 @@
 							}
 						},
 						{
-							"id": 3418,
+							"id": 3425,
 							"name": "bail",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -27025,7 +27025,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3419,
+									"id": 3426,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -27041,7 +27041,7 @@
 							],
 							"setSignature": [
 								{
-									"id": 3420,
+									"id": 3427,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -27051,7 +27051,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3421,
+											"id": 3428,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -27083,11 +27083,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.bail",
-								"id": 3482
+								"id": 3489
 							}
 						},
 						{
-							"id": 3422,
+							"id": 3429,
 							"name": "executor",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -27099,7 +27099,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3423,
+									"id": 3430,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -27110,13 +27110,13 @@
 									"type": {
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 3424,
+									"id": 3431,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -27126,7 +27126,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3425,
+											"id": 3432,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -27134,7 +27134,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Executor",
-												"id": 3780
+												"id": 3787
 											}
 										}
 									],
@@ -27158,7 +27158,7 @@
 							]
 						},
 						{
-							"id": 3426,
+							"id": 3433,
 							"name": "grep",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -27170,7 +27170,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3427,
+									"id": 3434,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -27186,7 +27186,7 @@
 							],
 							"setSignature": [
 								{
-									"id": 3428,
+									"id": 3435,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -27196,7 +27196,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3429,
+											"id": 3436,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -27228,11 +27228,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.grep",
-								"id": 3485
+								"id": 3492
 							}
 						},
 						{
-							"id": 3454,
+							"id": 3461,
 							"name": "hasParent",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -27244,7 +27244,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3455,
+									"id": 3462,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -27267,7 +27267,7 @@
 							]
 						},
 						{
-							"id": 3434,
+							"id": 3441,
 							"name": "id",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -27279,7 +27279,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3435,
+									"id": 3442,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -27302,7 +27302,7 @@
 							]
 						},
 						{
-							"id": 3430,
+							"id": 3437,
 							"name": "name",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -27314,7 +27314,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3431,
+									"id": 3438,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -27339,7 +27339,7 @@
 							],
 							"setSignature": [
 								{
-									"id": 3432,
+									"id": 3439,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -27349,7 +27349,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3433,
+											"id": 3440,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -27390,11 +27390,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.name",
-								"id": 3486
+								"id": 3493
 							}
 						},
 						{
-							"id": 3450,
+							"id": 3457,
 							"name": "numFailedTests",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -27406,7 +27406,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3451,
+									"id": 3458,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -27429,7 +27429,7 @@
 							]
 						},
 						{
-							"id": 3448,
+							"id": 3455,
 							"name": "numPassedTests",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -27441,7 +27441,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3449,
+									"id": 3456,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -27464,7 +27464,7 @@
 							]
 						},
 						{
-							"id": 3452,
+							"id": 3459,
 							"name": "numSkippedTests",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -27476,7 +27476,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3453,
+									"id": 3460,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -27499,7 +27499,7 @@
 							]
 						},
 						{
-							"id": 3446,
+							"id": 3453,
 							"name": "numTests",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -27511,7 +27511,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3447,
+									"id": 3454,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -27534,7 +27534,7 @@
 							]
 						},
 						{
-							"id": 3436,
+							"id": 3443,
 							"name": "parentId",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -27546,7 +27546,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3437,
+									"id": 3444,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -27578,7 +27578,7 @@
 							]
 						},
 						{
-							"id": 3438,
+							"id": 3445,
 							"name": "remote",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -27590,7 +27590,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3439,
+									"id": 3446,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -27601,13 +27601,13 @@
 									"type": {
 										"type": "reference",
 										"name": "Remote",
-										"id": 2813
+										"id": 2820
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 3440,
+									"id": 3447,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -27617,7 +27617,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3441,
+											"id": 3448,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -27625,7 +27625,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Remote",
-												"id": 2813
+												"id": 2820
 											}
 										}
 									],
@@ -27649,7 +27649,7 @@
 							]
 						},
 						{
-							"id": 3442,
+							"id": 3449,
 							"name": "sessionId",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -27661,7 +27661,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3443,
+									"id": 3450,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -27677,7 +27677,7 @@
 							],
 							"setSignature": [
 								{
-									"id": 3444,
+									"id": 3451,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -27687,7 +27687,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3445,
+											"id": 3452,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -27718,7 +27718,7 @@
 							]
 						},
 						{
-							"id": 3456,
+							"id": 3463,
 							"name": "timeout",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -27727,7 +27727,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3457,
+									"id": 3464,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -27740,14 +27740,14 @@
 							],
 							"setSignature": [
 								{
-									"id": 3458,
+									"id": 3465,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3459,
+											"id": 3466,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -27779,11 +27779,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "SuiteProperties.timeout",
-								"id": 3488
+								"id": 3495
 							}
 						},
 						{
-							"id": 3460,
+							"id": 3467,
 							"name": "add",
 							"kind": 2048,
 							"kindString": "Method",
@@ -27792,7 +27792,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3461,
+									"id": 3468,
 									"name": "add",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -27802,7 +27802,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3462,
+											"id": 3469,
 											"name": "suiteOrTest",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -27813,12 +27813,12 @@
 													{
 														"type": "reference",
 														"name": "Suite",
-														"id": 3400
+														"id": 3407
 													},
 													{
 														"type": "reference",
 														"name": "Test",
-														"id": 3317
+														"id": 3324
 													}
 												]
 											}
@@ -27839,7 +27839,7 @@
 							]
 						},
 						{
-							"id": 3463,
+							"id": 3470,
 							"name": "run",
 							"kind": 2048,
 							"kindString": "Method",
@@ -27848,7 +27848,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3464,
+									"id": 3471,
 									"name": "run",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -27878,7 +27878,7 @@
 							]
 						},
 						{
-							"id": 3465,
+							"id": 3472,
 							"name": "skip",
 							"kind": 2048,
 							"kindString": "Method",
@@ -27887,7 +27887,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3466,
+									"id": 3473,
 									"name": "skip",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -27898,7 +27898,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3467,
+											"id": 3474,
 											"name": "message",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -27928,7 +27928,7 @@
 							]
 						},
 						{
-							"id": 3468,
+							"id": 3475,
 							"name": "toJSON",
 							"kind": 2048,
 							"kindString": "Method",
@@ -27937,7 +27937,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3469,
+									"id": 3476,
 									"name": "toJSON",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -27962,54 +27962,54 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								3415
+								3422
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3401,
-								3402,
-								3403,
-								3407,
 								3408,
 								3409,
 								3410,
-								3411,
-								3412,
-								3413,
-								3414
+								3414,
+								3415,
+								3416,
+								3417,
+								3418,
+								3419,
+								3420,
+								3421
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								3418,
-								3422,
-								3426,
-								3454,
-								3434,
-								3430,
-								3450,
-								3448,
-								3452,
-								3446,
-								3436,
-								3438,
-								3442,
-								3456
+								3425,
+								3429,
+								3433,
+								3461,
+								3441,
+								3437,
+								3457,
+								3455,
+								3459,
+								3453,
+								3443,
+								3445,
+								3449,
+								3463
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								3460,
-								3463,
-								3465,
-								3468
+								3467,
+								3470,
+								3472,
+								3475
 							]
 						}
 					],
@@ -28029,19 +28029,19 @@
 						{
 							"type": "reference",
 							"name": "BenchmarkSuite",
-							"id": 3653
+							"id": 3660
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "SuiteProperties",
-							"id": 3479
+							"id": 3486
 						}
 					]
 				},
 				{
-					"id": 3470,
+					"id": 3477,
 					"name": "SuiteLifecycleFunction",
 					"kind": 256,
 					"kindString": "Interface",
@@ -28050,14 +28050,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3471,
+							"id": 3478,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3472,
+									"id": 3479,
 									"name": "this",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -28065,11 +28065,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Suite",
-										"id": 3400
+										"id": 3407
 									}
 								},
 								{
-									"id": 3473,
+									"id": 3480,
 									"name": "suite",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -28077,7 +28077,7 @@
 									"type": {
 										"type": "reference",
 										"name": "Suite",
-										"id": 3400
+										"id": 3407
 									}
 								}
 							],
@@ -28111,7 +28111,7 @@
 					]
 				},
 				{
-					"id": 3479,
+					"id": 3486,
 					"name": "SuiteProperties",
 					"kind": 256,
 					"kindString": "Interface",
@@ -28124,7 +28124,7 @@
 					},
 					"children": [
 						{
-							"id": 3480,
+							"id": 3487,
 							"name": "after",
 							"kind": 1024,
 							"kindString": "Property",
@@ -28144,7 +28144,7 @@
 									{
 										"type": "reference",
 										"name": "SuiteLifecycleFunction",
-										"id": 3470
+										"id": 3477
 									},
 									{
 										"type": "intrinsic",
@@ -28154,7 +28154,7 @@
 							}
 						},
 						{
-							"id": 3481,
+							"id": 3488,
 							"name": "afterEach",
 							"kind": 1024,
 							"kindString": "Property",
@@ -28174,7 +28174,7 @@
 									{
 										"type": "reference",
 										"name": "TestLifecycleFunction",
-										"id": 3474
+										"id": 3481
 									},
 									{
 										"type": "intrinsic",
@@ -28184,7 +28184,7 @@
 							}
 						},
 						{
-							"id": 3482,
+							"id": 3489,
 							"name": "bail",
 							"kind": 1024,
 							"kindString": "Property",
@@ -28213,7 +28213,7 @@
 							}
 						},
 						{
-							"id": 3483,
+							"id": 3490,
 							"name": "before",
 							"kind": 1024,
 							"kindString": "Property",
@@ -28233,7 +28233,7 @@
 									{
 										"type": "reference",
 										"name": "SuiteLifecycleFunction",
-										"id": 3470
+										"id": 3477
 									},
 									{
 										"type": "intrinsic",
@@ -28243,7 +28243,7 @@
 							}
 						},
 						{
-							"id": 3484,
+							"id": 3491,
 							"name": "beforeEach",
 							"kind": 1024,
 							"kindString": "Property",
@@ -28263,7 +28263,7 @@
 									{
 										"type": "reference",
 										"name": "TestLifecycleFunction",
-										"id": 3474
+										"id": 3481
 									},
 									{
 										"type": "intrinsic",
@@ -28273,7 +28273,7 @@
 							}
 						},
 						{
-							"id": 3485,
+							"id": 3492,
 							"name": "grep",
 							"kind": 1024,
 							"kindString": "Property",
@@ -28293,7 +28293,7 @@
 							}
 						},
 						{
-							"id": 3486,
+							"id": 3493,
 							"name": "name",
 							"kind": 1024,
 							"kindString": "Property",
@@ -28322,7 +28322,7 @@
 							}
 						},
 						{
-							"id": 3487,
+							"id": 3494,
 							"name": "publishAfterSetup",
 							"kind": 1024,
 							"kindString": "Property",
@@ -28342,7 +28342,7 @@
 							}
 						},
 						{
-							"id": 3488,
+							"id": 3495,
 							"name": "timeout",
 							"kind": 1024,
 							"kindString": "Property",
@@ -28367,15 +28367,15 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3480,
-								3481,
-								3482,
-								3483,
-								3484,
-								3485,
-								3486,
 								3487,
-								3488
+								3488,
+								3489,
+								3490,
+								3491,
+								3492,
+								3493,
+								3494,
+								3495
 							]
 						}
 					],
@@ -28390,14 +28390,14 @@
 						{
 							"type": "reference",
 							"name": "BenchmarkSuiteProperties",
-							"id": 3725
+							"id": 3732
 						}
 					],
 					"implementedBy": [
 						{
 							"type": "reference",
 							"name": "BenchmarkSuite",
-							"id": 3653
+							"id": 3660
 						},
 						{
 							"type": "reference",
@@ -28407,12 +28407,12 @@
 						{
 							"type": "reference",
 							"name": "Suite",
-							"id": 3400
+							"id": 3407
 						}
 					]
 				},
 				{
-					"id": 3474,
+					"id": 3481,
 					"name": "TestLifecycleFunction",
 					"kind": 256,
 					"kindString": "Interface",
@@ -28421,14 +28421,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3475,
+							"id": 3482,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3476,
+									"id": 3483,
 									"name": "this",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -28436,11 +28436,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Suite",
-										"id": 3400
+										"id": 3407
 									}
 								},
 								{
-									"id": 3477,
+									"id": 3484,
 									"name": "test",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -28448,11 +28448,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Test",
-										"id": 3317
+										"id": 3324
 									}
 								},
 								{
-									"id": 3478,
+									"id": 3485,
 									"name": "suite",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -28460,7 +28460,7 @@
 									"type": {
 										"type": "reference",
 										"name": "Suite",
-										"id": 3400
+										"id": 3407
 									}
 								}
 							],
@@ -28494,7 +28494,7 @@
 					]
 				},
 				{
-					"id": 3502,
+					"id": 3509,
 					"name": "LifecycleMethod",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -28548,7 +28548,7 @@
 					}
 				},
 				{
-					"id": 3497,
+					"id": 3504,
 					"name": "RootSuiteOptions",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -28575,21 +28575,21 @@
 									{
 										"type": "reference",
 										"name": "SuiteProperties",
-										"id": 3479
+										"id": 3486
 									}
 								]
 							},
 							{
 								"type": "reflection",
 								"declaration": {
-									"id": 3498,
+									"id": 3505,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 3499,
+											"id": 3506,
 											"name": "executor",
 											"kind": 32,
 											"kindString": "Variable",
@@ -28604,11 +28604,11 @@
 											"type": {
 												"type": "reference",
 												"name": "Executor",
-												"id": 3780
+												"id": 3787
 											}
 										},
 										{
-											"id": 3500,
+											"id": 3507,
 											"name": "tests",
 											"kind": 32,
 											"kindString": "Variable",
@@ -28630,12 +28630,12 @@
 														{
 															"type": "reference",
 															"name": "Suite",
-															"id": 3400
+															"id": 3407
 														},
 														{
 															"type": "reference",
 															"name": "Test",
-															"id": 3317
+															"id": 3324
 														}
 													]
 												}
@@ -28647,8 +28647,8 @@
 											"title": "Variables",
 											"kind": 32,
 											"children": [
-												3499,
-												3500
+												3506,
+												3507
 											]
 										}
 									],
@@ -28665,7 +28665,7 @@
 					}
 				},
 				{
-					"id": 3492,
+					"id": 3499,
 					"name": "SuiteOptions",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -28692,21 +28692,21 @@
 									{
 										"type": "reference",
 										"name": "SuiteProperties",
-										"id": 3479
+										"id": 3486
 									}
 								]
 							},
 							{
 								"type": "reflection",
 								"declaration": {
-									"id": 3493,
+									"id": 3500,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 3494,
+											"id": 3501,
 											"name": "name",
 											"kind": 32,
 											"kindString": "Variable",
@@ -28724,7 +28724,7 @@
 											}
 										},
 										{
-											"id": 3495,
+											"id": 3502,
 											"name": "parent",
 											"kind": 32,
 											"kindString": "Variable",
@@ -28739,11 +28739,11 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										},
 										{
-											"id": 3496,
+											"id": 3503,
 											"name": "tests",
 											"kind": 32,
 											"kindString": "Variable",
@@ -28765,12 +28765,12 @@
 														{
 															"type": "reference",
 															"name": "Suite",
-															"id": 3400
+															"id": 3407
 														},
 														{
 															"type": "reference",
 															"name": "Test",
-															"id": 3317
+															"id": 3324
 														}
 													]
 												}
@@ -28782,9 +28782,9 @@
 											"title": "Variables",
 											"kind": 32,
 											"children": [
-												3494,
-												3495,
-												3496
+												3501,
+												3502,
+												3503
 											]
 										}
 									],
@@ -28801,7 +28801,7 @@
 					}
 				},
 				{
-					"id": 3501,
+					"id": 3508,
 					"name": "BAIL_REASON",
 					"kind": 32,
 					"kindString": "Variable",
@@ -28822,7 +28822,7 @@
 					"defaultValue": "\"bailed\""
 				},
 				{
-					"id": 3489,
+					"id": 3496,
 					"name": "isSuite",
 					"kind": 64,
 					"kindString": "Function",
@@ -28831,14 +28831,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3490,
+							"id": 3497,
 							"name": "isSuite",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3491,
+									"id": 3498,
 									"name": "value",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -28869,39 +28869,39 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						3400
+						3407
 					]
 				},
 				{
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						3470,
-						3479,
-						3474
+						3477,
+						3486,
+						3481
 					]
 				},
 				{
 					"title": "Type aliases",
 					"kind": 4194304,
 					"children": [
-						3502,
-						3497,
-						3492
+						3509,
+						3504,
+						3499
 					]
 				},
 				{
 					"title": "Variables",
 					"kind": 32,
 					"children": [
-						3501
+						3508
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						3489
+						3496
 					]
 				}
 			],
@@ -28914,7 +28914,7 @@
 			]
 		},
 		{
-			"id": 3316,
+			"id": 3323,
 			"name": "\"lib/Test\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -28924,7 +28924,7 @@
 			"originalName": "src/lib/Test.ts",
 			"children": [
 				{
-					"id": 3317,
+					"id": 3324,
 					"name": "Test",
 					"kind": 128,
 					"kindString": "Class",
@@ -28936,7 +28936,7 @@
 					},
 					"children": [
 						{
-							"id": 3331,
+							"id": 3338,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -28945,14 +28945,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3332,
+									"id": 3339,
 									"name": "new Test",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3333,
+											"id": 3340,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -28963,19 +28963,19 @@
 													{
 														"type": "reference",
 														"name": "TestOptions",
-														"id": 3394
+														"id": 3401
 													},
 													{
 														"type": "reflection",
 														"declaration": {
-															"id": 3334,
+															"id": 3341,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 3336,
+																	"id": 3343,
 																	"name": "hasPassed",
 																	"kind": 32,
 																	"kindString": "Variable",
@@ -29008,7 +29008,7 @@
 																	}
 																},
 																{
-																	"id": 3335,
+																	"id": 3342,
 																	"name": "timeElapsed",
 																	"kind": 32,
 																	"kindString": "Variable",
@@ -29042,8 +29042,8 @@
 																	"title": "Variables",
 																	"kind": 32,
 																	"children": [
-																		3336,
-																		3335
+																		3343,
+																		3342
 																	]
 																}
 															],
@@ -29063,7 +29063,7 @@
 									"type": {
 										"type": "reference",
 										"name": "Test",
-										"id": 3317
+										"id": 3324
 									}
 								}
 							],
@@ -29076,7 +29076,7 @@
 							]
 						},
 						{
-							"id": 3324,
+							"id": 3331,
 							"name": "_hasPassed",
 							"kind": 1024,
 							"kindString": "Property",
@@ -29098,7 +29098,7 @@
 							"defaultValue": "false"
 						},
 						{
-							"id": 3325,
+							"id": 3332,
 							"name": "_isAsync",
 							"kind": 1024,
 							"kindString": "Property",
@@ -29120,7 +29120,7 @@
 							"defaultValue": "false"
 						},
 						{
-							"id": 3327,
+							"id": 3334,
 							"name": "_runTask",
 							"kind": 1024,
 							"kindString": "Property",
@@ -29156,7 +29156,7 @@
 							}
 						},
 						{
-							"id": 3328,
+							"id": 3335,
 							"name": "_timeElapsed",
 							"kind": 1024,
 							"kindString": "Property",
@@ -29186,7 +29186,7 @@
 							}
 						},
 						{
-							"id": 3326,
+							"id": 3333,
 							"name": "_timeout",
 							"kind": 1024,
 							"kindString": "Property",
@@ -29216,7 +29216,7 @@
 							}
 						},
 						{
-							"id": 3329,
+							"id": 3336,
 							"name": "_timer",
 							"kind": 1024,
 							"kindString": "Property",
@@ -29246,7 +29246,7 @@
 							}
 						},
 						{
-							"id": 3330,
+							"id": 3337,
 							"name": "_usesRemote",
 							"kind": 1024,
 							"kindString": "Property",
@@ -29268,7 +29268,7 @@
 							"defaultValue": "false"
 						},
 						{
-							"id": 3322,
+							"id": 3329,
 							"name": "error",
 							"kind": 1024,
 							"kindString": "Property",
@@ -29301,7 +29301,7 @@
 							}
 						},
 						{
-							"id": 3318,
+							"id": 3325,
 							"name": "name",
 							"kind": 1024,
 							"kindString": "Property",
@@ -29325,11 +29325,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "TestProperties.name",
-								"id": 3380
+								"id": 3387
 							}
 						},
 						{
-							"id": 3319,
+							"id": 3326,
 							"name": "parent",
 							"kind": 1024,
 							"kindString": "Property",
@@ -29349,16 +29349,16 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "TestProperties.parent",
-								"id": 3381
+								"id": 3388
 							}
 						},
 						{
-							"id": 3320,
+							"id": 3327,
 							"name": "skipped",
 							"kind": 1024,
 							"kindString": "Property",
@@ -29391,11 +29391,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "TestProperties.skipped",
-								"id": 3382
+								"id": 3389
 							}
 						},
 						{
-							"id": 3323,
+							"id": 3330,
 							"name": "suiteError",
 							"kind": 1024,
 							"kindString": "Property",
@@ -29428,7 +29428,7 @@
 							}
 						},
 						{
-							"id": 3321,
+							"id": 3328,
 							"name": "test",
 							"kind": 1024,
 							"kindString": "Property",
@@ -29448,16 +29448,16 @@
 							"type": {
 								"type": "reference",
 								"name": "TestFunction",
-								"id": 3374
+								"id": 3381
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "TestProperties.test",
-								"id": 3383
+								"id": 3390
 							}
 						},
 						{
-							"id": 3337,
+							"id": 3344,
 							"name": "executor",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -29469,7 +29469,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3338,
+									"id": 3345,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -29480,7 +29480,7 @@
 									"type": {
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									}
 								}
 							],
@@ -29493,7 +29493,7 @@
 							]
 						},
 						{
-							"id": 3339,
+							"id": 3346,
 							"name": "hasPassed",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -29505,7 +29505,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3340,
+									"id": 3347,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -29529,11 +29529,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "TestProperties.hasPassed",
-								"id": 3379
+								"id": 3386
 							}
 						},
 						{
-							"id": 3341,
+							"id": 3348,
 							"name": "id",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -29545,7 +29545,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3342,
+									"id": 3349,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -29568,7 +29568,7 @@
 							]
 						},
 						{
-							"id": 3343,
+							"id": 3350,
 							"name": "isAsync",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -29580,7 +29580,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3344,
+									"id": 3351,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -29603,7 +29603,7 @@
 							]
 						},
 						{
-							"id": 3345,
+							"id": 3352,
 							"name": "parentId",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -29615,7 +29615,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3346,
+									"id": 3353,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -29638,7 +29638,7 @@
 							]
 						},
 						{
-							"id": 3347,
+							"id": 3354,
 							"name": "remote",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -29656,7 +29656,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3348,
+									"id": 3355,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -29673,7 +29673,7 @@
 									"type": {
 										"type": "reference",
 										"name": "Remote",
-										"id": 2813
+										"id": 2820
 									}
 								}
 							],
@@ -29686,7 +29686,7 @@
 							]
 						},
 						{
-							"id": 3349,
+							"id": 3356,
 							"name": "sessionId",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -29698,7 +29698,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3350,
+									"id": 3357,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -29721,7 +29721,7 @@
 							]
 						},
 						{
-							"id": 3351,
+							"id": 3358,
 							"name": "timeElapsed",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -29733,7 +29733,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3352,
+									"id": 3359,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -29765,7 +29765,7 @@
 							]
 						},
 						{
-							"id": 3353,
+							"id": 3360,
 							"name": "timeout",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -29777,7 +29777,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3354,
+									"id": 3361,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -29793,7 +29793,7 @@
 							],
 							"setSignature": [
 								{
-									"id": 3355,
+									"id": 3362,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
@@ -29803,7 +29803,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3356,
+											"id": 3363,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -29835,11 +29835,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "TestProperties.timeout",
-								"id": 3384
+								"id": 3391
 							}
 						},
 						{
-							"id": 3357,
+							"id": 3364,
 							"name": "async",
 							"kind": 2048,
 							"kindString": "Method",
@@ -29848,7 +29848,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3358,
+									"id": 3365,
 									"name": "async",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -29860,7 +29860,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3359,
+											"id": 3366,
 											"name": "timeout",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -29885,7 +29885,7 @@
 											}
 										},
 										{
-											"id": 3360,
+											"id": 3367,
 											"name": "numCallsUntilResolution",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -29932,7 +29932,7 @@
 							]
 						},
 						{
-							"id": 3361,
+							"id": 3368,
 							"name": "restartTimeout",
 							"kind": 2048,
 							"kindString": "Method",
@@ -29941,7 +29941,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3362,
+									"id": 3369,
 									"name": "restartTimeout",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -29951,7 +29951,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3363,
+											"id": 3370,
 											"name": "timeout",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -29988,7 +29988,7 @@
 							]
 						},
 						{
-							"id": 3364,
+							"id": 3371,
 							"name": "run",
 							"kind": 2048,
 							"kindString": "Method",
@@ -29997,7 +29997,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3365,
+									"id": 3372,
 									"name": "run",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -30026,7 +30026,7 @@
 							]
 						},
 						{
-							"id": 3366,
+							"id": 3373,
 							"name": "skip",
 							"kind": 2048,
 							"kindString": "Method",
@@ -30035,7 +30035,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3367,
+									"id": 3374,
 									"name": "skip",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -30046,7 +30046,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3368,
+											"id": 3375,
 											"name": "message",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -30076,7 +30076,7 @@
 							]
 						},
 						{
-							"id": 3369,
+							"id": 3376,
 							"name": "toJSON",
 							"kind": 2048,
 							"kindString": "Method",
@@ -30085,7 +30085,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3370,
+									"id": 3377,
 									"name": "toJSON",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -30096,21 +30096,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 3371,
+											"id": 3378,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 3372,
+													"id": 3379,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 3373,
+															"id": 3380,
 															"name": "key",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -30145,52 +30145,52 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								3331
+								3338
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3324,
-								3325,
-								3327,
-								3328,
-								3326,
+								3331,
+								3332,
+								3334,
+								3335,
+								3333,
+								3336,
+								3337,
 								3329,
+								3325,
+								3326,
+								3327,
 								3330,
-								3322,
-								3318,
-								3319,
-								3320,
-								3323,
-								3321
+								3328
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								3337,
-								3339,
-								3341,
-								3343,
-								3345,
-								3347,
-								3349,
-								3351,
-								3353
+								3344,
+								3346,
+								3348,
+								3350,
+								3352,
+								3354,
+								3356,
+								3358,
+								3360
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								3357,
-								3361,
 								3364,
-								3366,
-								3369
+								3368,
+								3371,
+								3373,
+								3376
 							]
 						}
 					],
@@ -30205,19 +30205,19 @@
 						{
 							"type": "reference",
 							"name": "BenchmarkTest",
-							"id": 1984
+							"id": 1991
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "TestProperties",
-							"id": 3378
+							"id": 3385
 						}
 					]
 				},
 				{
-					"id": 3374,
+					"id": 3381,
 					"name": "TestFunction",
 					"kind": 256,
 					"kindString": "Interface",
@@ -30226,14 +30226,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3375,
+							"id": 3382,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3376,
+									"id": 3383,
 									"name": "this",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -30241,11 +30241,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Test",
-										"id": 3317
+										"id": 3324
 									}
 								},
 								{
-									"id": 3377,
+									"id": 3384,
 									"name": "test",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -30253,7 +30253,7 @@
 									"type": {
 										"type": "reference",
 										"name": "Test",
-										"id": 3317
+										"id": 3324
 									}
 								}
 							],
@@ -30289,12 +30289,12 @@
 						{
 							"type": "reference",
 							"name": "BenchmarkTestFunction",
-							"id": 2045
+							"id": 2052
 						}
 					]
 				},
 				{
-					"id": 3378,
+					"id": 3385,
 					"name": "TestProperties",
 					"kind": 256,
 					"kindString": "Interface",
@@ -30303,7 +30303,7 @@
 					},
 					"children": [
 						{
-							"id": 3379,
+							"id": 3386,
 							"name": "hasPassed",
 							"kind": 1024,
 							"kindString": "Property",
@@ -30323,7 +30323,7 @@
 							}
 						},
 						{
-							"id": 3380,
+							"id": 3387,
 							"name": "name",
 							"kind": 1024,
 							"kindString": "Property",
@@ -30343,7 +30343,7 @@
 							}
 						},
 						{
-							"id": 3381,
+							"id": 3388,
 							"name": "parent",
 							"kind": 1024,
 							"kindString": "Property",
@@ -30360,11 +30360,11 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							}
 						},
 						{
-							"id": 3382,
+							"id": 3389,
 							"name": "skipped",
 							"kind": 1024,
 							"kindString": "Property",
@@ -30393,7 +30393,7 @@
 							}
 						},
 						{
-							"id": 3383,
+							"id": 3390,
 							"name": "test",
 							"kind": 1024,
 							"kindString": "Property",
@@ -30410,11 +30410,11 @@
 							"type": {
 								"type": "reference",
 								"name": "TestFunction",
-								"id": 3374
+								"id": 3381
 							}
 						},
 						{
-							"id": 3384,
+							"id": 3391,
 							"name": "timeout",
 							"kind": 1024,
 							"kindString": "Property",
@@ -30439,12 +30439,12 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3379,
-								3380,
-								3381,
-								3382,
-								3383,
-								3384
+								3386,
+								3387,
+								3388,
+								3389,
+								3390,
+								3391
 							]
 						}
 					],
@@ -30459,24 +30459,24 @@
 						{
 							"type": "reference",
 							"name": "BenchmarkTestProperties",
-							"id": 2062
+							"id": 2069
 						}
 					],
 					"implementedBy": [
 						{
 							"type": "reference",
 							"name": "BenchmarkTest",
-							"id": 1984
+							"id": 1991
 						},
 						{
 							"type": "reference",
 							"name": "Test",
-							"id": 3317
+							"id": 3324
 						}
 					]
 				},
 				{
-					"id": 3394,
+					"id": 3401,
 					"name": "TestOptions",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -30500,21 +30500,21 @@
 									{
 										"type": "reference",
 										"name": "TestProperties",
-										"id": 3378
+										"id": 3385
 									}
 								]
 							},
 							{
 								"type": "reflection",
 								"declaration": {
-									"id": 3395,
+									"id": 3402,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 3396,
+											"id": 3403,
 											"name": "name",
 											"kind": 32,
 											"kindString": "Variable",
@@ -30532,7 +30532,7 @@
 											}
 										},
 										{
-											"id": 3397,
+											"id": 3404,
 											"name": "test",
 											"kind": 32,
 											"kindString": "Variable",
@@ -30547,7 +30547,7 @@
 											"type": {
 												"type": "reference",
 												"name": "TestFunction",
-												"id": 3374
+												"id": 3381
 											}
 										}
 									],
@@ -30556,8 +30556,8 @@
 											"title": "Variables",
 											"kind": 32,
 											"children": [
-												3396,
-												3397
+												3403,
+												3404
 											]
 										}
 									],
@@ -30574,7 +30574,7 @@
 					}
 				},
 				{
-					"id": 3398,
+					"id": 3405,
 					"name": "SKIP",
 					"kind": 32,
 					"kindString": "Variable",
@@ -30595,7 +30595,7 @@
 					}
 				},
 				{
-					"id": 3385,
+					"id": 3392,
 					"name": "isTest",
 					"kind": 64,
 					"kindString": "Function",
@@ -30604,14 +30604,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3386,
+							"id": 3393,
 							"name": "isTest",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3387,
+									"id": 3394,
 									"name": "value",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -30637,7 +30637,7 @@
 					]
 				},
 				{
-					"id": 3391,
+					"id": 3398,
 					"name": "isTestFunction",
 					"kind": 64,
 					"kindString": "Function",
@@ -30646,14 +30646,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3392,
+							"id": 3399,
 							"name": "isTestFunction",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3393,
+									"id": 3400,
 									"name": "value",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -30679,7 +30679,7 @@
 					]
 				},
 				{
-					"id": 3388,
+					"id": 3395,
 					"name": "isTestOptions",
 					"kind": 64,
 					"kindString": "Function",
@@ -30688,14 +30688,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3389,
+							"id": 3396,
 							"name": "isTestOptions",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3390,
+									"id": 3397,
 									"name": "value",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -30726,38 +30726,38 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						3317
+						3324
 					]
 				},
 				{
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						3374,
-						3378
+						3381,
+						3385
 					]
 				},
 				{
 					"title": "Type aliases",
 					"kind": 4194304,
 					"children": [
-						3394
+						3401
 					]
 				},
 				{
 					"title": "Variables",
 					"kind": 32,
 					"children": [
-						3398
+						3405
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						3385,
-						3391,
-						3388
+						3392,
+						3398,
+						3395
 					]
 				}
 			],
@@ -31724,12 +31724,12 @@
 						{
 							"type": "reference",
 							"name": "WebSocketChannel",
-							"id": 4370
+							"id": 4374
 						},
 						{
 							"type": "reference",
 							"name": "HttpChannel",
-							"id": 4408
+							"id": 4412
 						}
 					]
 				},
@@ -31905,7 +31905,7 @@
 						{
 							"type": "reference",
 							"name": "HttpChannelOptions",
-							"id": 4429
+							"id": 4433
 						}
 					]
 				},
@@ -32101,7 +32101,7 @@
 			]
 		},
 		{
-			"id": 4407,
+			"id": 4411,
 			"name": "\"lib/channels/Http\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -32112,7 +32112,7 @@
 			"originalName": "src/lib/channels/Http.ts",
 			"children": [
 				{
-					"id": 4408,
+					"id": 4412,
 					"name": "HttpChannel",
 					"kind": 128,
 					"kindString": "Class",
@@ -32122,7 +32122,7 @@
 					},
 					"children": [
 						{
-							"id": 4414,
+							"id": 4418,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -32132,14 +32132,14 @@
 							},
 							"signatures": [
 								{
-									"id": 4415,
+									"id": 4419,
 									"name": "new HttpChannel",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4416,
+											"id": 4420,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -32147,14 +32147,14 @@
 											"type": {
 												"type": "reference",
 												"name": "HttpChannelOptions",
-												"id": 4429
+												"id": 4433
 											}
 										}
 									],
 									"type": {
 										"type": "reference",
 										"name": "HttpChannel",
-										"id": 4408
+										"id": 4412
 									},
 									"overwrites": {
 										"type": "reference",
@@ -32177,7 +32177,7 @@
 							}
 						},
 						{
-							"id": 4413,
+							"id": 4417,
 							"name": "_activeRequest",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32214,7 +32214,7 @@
 							}
 						},
 						{
-							"id": 4409,
+							"id": 4413,
 							"name": "_lastRequest",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32242,7 +32242,7 @@
 							}
 						},
 						{
-							"id": 4412,
+							"id": 4416,
 							"name": "_maxPostSize",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32264,7 +32264,7 @@
 							}
 						},
 						{
-							"id": 4410,
+							"id": 4414,
 							"name": "_messageBuffer",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32285,12 +32285,12 @@
 								"elementType": {
 									"type": "reference",
 									"name": "MessageEntry",
-									"id": 4435
+									"id": 4439
 								}
 							}
 						},
 						{
-							"id": 4411,
+							"id": 4415,
 							"name": "_sequence",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32312,7 +32312,7 @@
 							}
 						},
 						{
-							"id": 4424,
+							"id": 4428,
 							"name": "sessionId",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32338,7 +32338,7 @@
 							}
 						},
 						{
-							"id": 4423,
+							"id": 4427,
 							"name": "url",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32364,7 +32364,7 @@
 							}
 						},
 						{
-							"id": 4417,
+							"id": 4421,
 							"name": "_sendData",
 							"kind": 2048,
 							"kindString": "Method",
@@ -32375,14 +32375,14 @@
 							},
 							"signatures": [
 								{
-									"id": 4418,
+									"id": 4422,
 									"name": "_sendData",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4419,
+											"id": 4423,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -32397,7 +32397,7 @@
 											}
 										},
 										{
-											"id": 4420,
+											"id": 4424,
 											"name": "data",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -32433,7 +32433,7 @@
 							}
 						},
 						{
-							"id": 4421,
+							"id": 4425,
 							"name": "_sendMessages",
 							"kind": 2048,
 							"kindString": "Method",
@@ -32444,7 +32444,7 @@
 							},
 							"signatures": [
 								{
-									"id": 4422,
+									"id": 4426,
 									"name": "_sendMessages",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -32482,7 +32482,7 @@
 							]
 						},
 						{
-							"id": 4425,
+							"id": 4429,
 							"name": "sendMessage",
 							"kind": 2048,
 							"kindString": "Method",
@@ -32492,7 +32492,7 @@
 							},
 							"signatures": [
 								{
-									"id": 4426,
+									"id": 4430,
 									"name": "sendMessage",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -32502,7 +32502,7 @@
 									},
 									"parameters": [
 										{
-											"id": 4427,
+											"id": 4431,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -32517,7 +32517,7 @@
 											}
 										},
 										{
-											"id": 4428,
+											"id": 4432,
 											"name": "data",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -32564,29 +32564,29 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								4414
+								4418
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
+								4417,
 								4413,
-								4409,
-								4412,
-								4410,
-								4411,
-								4424,
-								4423
+								4416,
+								4414,
+								4415,
+								4428,
+								4427
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								4417,
 								4421,
-								4425
+								4425,
+								4429
 							]
 						}
 					],
@@ -32606,7 +32606,7 @@
 					]
 				},
 				{
-					"id": 4429,
+					"id": 4433,
 					"name": "HttpChannelOptions",
 					"kind": 256,
 					"kindString": "Interface",
@@ -32616,7 +32616,7 @@
 					},
 					"children": [
 						{
-							"id": 4430,
+							"id": 4434,
 							"name": "maxPostSize",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32647,7 +32647,7 @@
 							}
 						},
 						{
-							"id": 4433,
+							"id": 4437,
 							"name": "port",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32691,7 +32691,7 @@
 							}
 						},
 						{
-							"id": 4431,
+							"id": 4435,
 							"name": "sessionId",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32722,7 +32722,7 @@
 							}
 						},
 						{
-							"id": 4434,
+							"id": 4438,
 							"name": "timeout",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32766,7 +32766,7 @@
 							}
 						},
 						{
-							"id": 4432,
+							"id": 4436,
 							"name": "url",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32805,11 +32805,11 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4430,
-								4433,
-								4431,
 								4434,
-								4432
+								4437,
+								4435,
+								4438,
+								4436
 							]
 						}
 					],
@@ -32829,7 +32829,7 @@
 					]
 				},
 				{
-					"id": 4435,
+					"id": 4439,
 					"name": "MessageEntry",
 					"kind": 256,
 					"kindString": "Interface",
@@ -32839,7 +32839,7 @@
 					},
 					"children": [
 						{
-							"id": 4436,
+							"id": 4440,
 							"name": "message",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32860,7 +32860,7 @@
 							}
 						},
 						{
-							"id": 4441,
+							"id": 4445,
 							"name": "reject",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32878,21 +32878,21 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 4442,
+									"id": 4446,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"signatures": [
 										{
-											"id": 4443,
+											"id": 4447,
 											"name": "__call",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 4444,
+													"id": 4448,
 													"name": "error",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -32920,7 +32920,7 @@
 							}
 						},
 						{
-							"id": 4437,
+							"id": 4441,
 							"name": "resolve",
 							"kind": 1024,
 							"kindString": "Property",
@@ -32938,21 +32938,21 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 4438,
+									"id": 4442,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"signatures": [
 										{
-											"id": 4439,
+											"id": 4443,
 											"name": "__call",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 4440,
+													"id": 4444,
 													"name": "value",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -32985,9 +32985,9 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4436,
-								4441,
-								4437
+								4440,
+								4445,
+								4441
 							]
 						}
 					],
@@ -33005,15 +33005,15 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						4408
+						4412
 					]
 				},
 				{
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						4429,
-						4435
+						4433,
+						4439
 					]
 				}
 			],
@@ -33026,7 +33026,7 @@
 			]
 		},
 		{
-			"id": 4369,
+			"id": 4373,
 			"name": "\"lib/channels/WebSocket\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -33037,7 +33037,7 @@
 			"originalName": "src/lib/channels/WebSocket.ts",
 			"children": [
 				{
-					"id": 4370,
+					"id": 4374,
 					"name": "WebSocketChannel",
 					"kind": 128,
 					"kindString": "Class",
@@ -33047,7 +33047,7 @@
 					},
 					"children": [
 						{
-							"id": 4388,
+							"id": 4392,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -33057,14 +33057,14 @@
 							},
 							"signatures": [
 								{
-									"id": 4389,
+									"id": 4393,
 									"name": "new WebSocketChannel",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4390,
+											"id": 4394,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -33079,7 +33079,7 @@
 									"type": {
 										"type": "reference",
 										"name": "WebSocketChannel",
-										"id": 4370
+										"id": 4374
 									},
 									"overwrites": {
 										"type": "reference",
@@ -33102,7 +33102,7 @@
 							}
 						},
 						{
-							"id": 4386,
+							"id": 4390,
 							"name": "_ready",
 							"kind": 1024,
 							"kindString": "Property",
@@ -33130,7 +33130,7 @@
 							}
 						},
 						{
-							"id": 4373,
+							"id": 4377,
 							"name": "_sendQueue",
 							"kind": 1024,
 							"kindString": "Property",
@@ -33149,21 +33149,21 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 4374,
+									"id": 4378,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"indexSignature": [
 										{
-											"id": 4375,
+											"id": 4379,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 4376,
+													"id": 4380,
 													"name": "key",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -33180,14 +33180,14 @@
 													{
 														"type": "reflection",
 														"declaration": {
-															"id": 4377,
+															"id": 4381,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 4382,
+																	"id": 4386,
 																	"name": "reject",
 																	"kind": 32,
 																	"kindString": "Variable",
@@ -33204,21 +33204,21 @@
 																	"type": {
 																		"type": "reflection",
 																		"declaration": {
-																			"id": 4383,
+																			"id": 4387,
 																			"name": "__type",
 																			"kind": 65536,
 																			"kindString": "Type literal",
 																			"flags": {},
 																			"signatures": [
 																				{
-																					"id": 4384,
+																					"id": 4388,
 																					"name": "__call",
 																					"kind": 4096,
 																					"kindString": "Call signature",
 																					"flags": {},
 																					"parameters": [
 																						{
-																							"id": 4385,
+																							"id": 4389,
 																							"name": "error",
 																							"kind": 32768,
 																							"kindString": "Parameter",
@@ -33246,7 +33246,7 @@
 																	}
 																},
 																{
-																	"id": 4378,
+																	"id": 4382,
 																	"name": "resolve",
 																	"kind": 32,
 																	"kindString": "Variable",
@@ -33263,21 +33263,21 @@
 																	"type": {
 																		"type": "reflection",
 																		"declaration": {
-																			"id": 4379,
+																			"id": 4383,
 																			"name": "__type",
 																			"kind": 65536,
 																			"kindString": "Type literal",
 																			"flags": {},
 																			"signatures": [
 																				{
-																					"id": 4380,
+																					"id": 4384,
 																					"name": "__call",
 																					"kind": 4096,
 																					"kindString": "Call signature",
 																					"flags": {},
 																					"parameters": [
 																						{
-																							"id": 4381,
+																							"id": 4385,
 																							"name": "value",
 																							"kind": 32768,
 																							"kindString": "Parameter",
@@ -33310,8 +33310,8 @@
 																	"title": "Variables",
 																	"kind": 32,
 																	"children": [
-																		4382,
-																		4378
+																		4386,
+																		4382
 																	]
 																}
 															],
@@ -33343,7 +33343,7 @@
 							}
 						},
 						{
-							"id": 4387,
+							"id": 4391,
 							"name": "_sequence",
 							"kind": 1024,
 							"kindString": "Property",
@@ -33365,7 +33365,7 @@
 							}
 						},
 						{
-							"id": 4372,
+							"id": 4376,
 							"name": "_socket",
 							"kind": 1024,
 							"kindString": "Property",
@@ -33387,7 +33387,7 @@
 							}
 						},
 						{
-							"id": 4402,
+							"id": 4406,
 							"name": "sessionId",
 							"kind": 1024,
 							"kindString": "Property",
@@ -33413,7 +33413,7 @@
 							}
 						},
 						{
-							"id": 4371,
+							"id": 4375,
 							"name": "timeout",
 							"kind": 1024,
 							"kindString": "Property",
@@ -33437,7 +33437,7 @@
 							}
 						},
 						{
-							"id": 4401,
+							"id": 4405,
 							"name": "url",
 							"kind": 1024,
 							"kindString": "Property",
@@ -33463,7 +33463,7 @@
 							}
 						},
 						{
-							"id": 4398,
+							"id": 4402,
 							"name": "_handleError",
 							"kind": 2048,
 							"kindString": "Method",
@@ -33474,14 +33474,14 @@
 							},
 							"signatures": [
 								{
-									"id": 4399,
+									"id": 4403,
 									"name": "_handleError",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4400,
+											"id": 4404,
 											"name": "error",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -33507,7 +33507,7 @@
 							]
 						},
 						{
-							"id": 4395,
+							"id": 4399,
 							"name": "_handleMessage",
 							"kind": 2048,
 							"kindString": "Method",
@@ -33518,14 +33518,14 @@
 							},
 							"signatures": [
 								{
-									"id": 4396,
+									"id": 4400,
 									"name": "_handleMessage",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4397,
+											"id": 4401,
 											"name": "message",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -33551,7 +33551,7 @@
 							]
 						},
 						{
-							"id": 4391,
+							"id": 4395,
 							"name": "_sendData",
 							"kind": 2048,
 							"kindString": "Method",
@@ -33562,14 +33562,14 @@
 							},
 							"signatures": [
 								{
-									"id": 4392,
+									"id": 4396,
 									"name": "_sendData",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4393,
+											"id": 4397,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -33580,7 +33580,7 @@
 											}
 										},
 										{
-											"id": 4394,
+											"id": 4398,
 											"name": "data",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -33622,7 +33622,7 @@
 							}
 						},
 						{
-							"id": 4403,
+							"id": 4407,
 							"name": "sendMessage",
 							"kind": 2048,
 							"kindString": "Method",
@@ -33632,7 +33632,7 @@
 							},
 							"signatures": [
 								{
-									"id": 4404,
+									"id": 4408,
 									"name": "sendMessage",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -33642,7 +33642,7 @@
 									},
 									"parameters": [
 										{
-											"id": 4405,
+											"id": 4409,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -33657,7 +33657,7 @@
 											}
 										},
 										{
-											"id": 4406,
+											"id": 4410,
 											"name": "data",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -33704,30 +33704,30 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								4388
+								4392
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4386,
-								4373,
-								4387,
-								4372,
-								4402,
-								4371,
-								4401
+								4390,
+								4377,
+								4391,
+								4376,
+								4406,
+								4375,
+								4405
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								4398,
+								4402,
+								4399,
 								4395,
-								4391,
-								4403
+								4407
 							]
 						}
 					],
@@ -33752,7 +33752,7 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						4370
+						4374
 					]
 				}
 			],
@@ -33811,7 +33811,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Executor",
-												"id": 3780
+												"id": 3787
 											}
 										}
 									],
@@ -33849,7 +33849,7 @@
 							"type": {
 								"type": "reference",
 								"name": "Executor",
-								"id": 3780
+								"id": 3787
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -34506,7 +34506,7 @@
 							"type": {
 								"type": "reference",
 								"name": "Executor",
-								"id": 3780
+								"id": 3787
 							}
 						}
 					],
@@ -34566,7 +34566,7 @@
 			]
 		},
 		{
-			"id": 4097,
+			"id": 4104,
 			"name": "\"lib/common/config\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -34577,7 +34577,7 @@
 			"originalName": "src/lib/common/config.ts",
 			"children": [
 				{
-					"id": 4180,
+					"id": 4187,
 					"name": "BenchmarkConfig",
 					"kind": 256,
 					"kindString": "Interface",
@@ -34587,7 +34587,7 @@
 					},
 					"children": [
 						{
-							"id": 4181,
+							"id": 4188,
 							"name": "id",
 							"kind": 1024,
 							"kindString": "Property",
@@ -34613,7 +34613,7 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4181
+								4188
 							]
 						}
 					],
@@ -34628,7 +34628,7 @@
 						{
 							"type": "reflection",
 							"declaration": {
-								"id": 4182,
+								"id": 4189,
 								"name": "__type",
 								"kind": 65536,
 								"kindString": "Type literal",
@@ -34645,7 +34645,7 @@
 					]
 				},
 				{
-					"id": 4098,
+					"id": 4105,
 					"name": "Config",
 					"kind": 256,
 					"kindString": "Interface",
@@ -34658,7 +34658,7 @@
 					},
 					"children": [
 						{
-							"id": 4099,
+							"id": 4106,
 							"name": "bail",
 							"kind": 1024,
 							"kindString": "Property",
@@ -34682,7 +34682,7 @@
 							}
 						},
 						{
-							"id": 4101,
+							"id": 4108,
 							"name": "basePath",
 							"kind": 1024,
 							"kindString": "Property",
@@ -34706,7 +34706,7 @@
 							}
 						},
 						{
-							"id": 4100,
+							"id": 4107,
 							"name": "baseline",
 							"kind": 1024,
 							"kindString": "Property",
@@ -34727,7 +34727,7 @@
 							}
 						},
 						{
-							"id": 4102,
+							"id": 4109,
 							"name": "benchmark",
 							"kind": 1024,
 							"kindString": "Property",
@@ -34751,7 +34751,7 @@
 							}
 						},
 						{
-							"id": 4103,
+							"id": 4110,
 							"name": "benchmarkConfig",
 							"kind": 1024,
 							"kindString": "Property",
@@ -34770,11 +34770,11 @@
 							"type": {
 								"type": "reference",
 								"name": "BenchmarkConfig",
-								"id": 4180
+								"id": 4187
 							}
 						},
 						{
-							"id": 4104,
+							"id": 4111,
 							"name": "browser",
 							"kind": 1024,
 							"kindString": "Property",
@@ -34792,11 +34792,11 @@
 							"type": {
 								"type": "reference",
 								"name": "ResourceConfig",
-								"id": 4171
+								"id": 4178
 							}
 						},
 						{
-							"id": 4116,
+							"id": 4123,
 							"name": "capabilities",
 							"kind": 1024,
 							"kindString": "Property",
@@ -34818,21 +34818,21 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 4117,
+									"id": 4124,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"indexSignature": [
 										{
-											"id": 4120,
+											"id": 4127,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 4121,
+													"id": 4128,
 													"name": "key",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -34851,7 +34851,7 @@
 									],
 									"children": [
 										{
-											"id": 4119,
+											"id": 4126,
 											"name": "build",
 											"kind": 32,
 											"kindString": "Variable",
@@ -34881,7 +34881,7 @@
 											}
 										},
 										{
-											"id": 4118,
+											"id": 4125,
 											"name": "name",
 											"kind": 32,
 											"kindString": "Variable",
@@ -34916,8 +34916,8 @@
 											"title": "Variables",
 											"kind": 32,
 											"children": [
-												4119,
-												4118
+												4126,
+												4125
 											]
 										}
 									],
@@ -34932,7 +34932,7 @@
 							}
 						},
 						{
-							"id": 4122,
+							"id": 4129,
 							"name": "connectTimeout",
 							"kind": 1024,
 							"kindString": "Property",
@@ -34956,7 +34956,7 @@
 							}
 						},
 						{
-							"id": 4123,
+							"id": 4130,
 							"name": "coverage",
 							"kind": 1024,
 							"kindString": "Property",
@@ -34993,7 +34993,7 @@
 							}
 						},
 						{
-							"id": 4105,
+							"id": 4112,
 							"name": "coverageVariable",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35017,7 +35017,7 @@
 							}
 						},
 						{
-							"id": 4106,
+							"id": 4113,
 							"name": "debug",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35041,7 +35041,7 @@
 							}
 						},
 						{
-							"id": 4107,
+							"id": 4114,
 							"name": "defaultTimeout",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35065,7 +35065,7 @@
 							}
 						},
 						{
-							"id": 4108,
+							"id": 4115,
 							"name": "description",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35089,7 +35089,7 @@
 							}
 						},
 						{
-							"id": 4124,
+							"id": 4131,
 							"name": "environments",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35113,12 +35113,12 @@
 								"elementType": {
 									"type": "reference",
 									"name": "EnvironmentSpec",
-									"id": 4189
+									"id": 4196
 								}
 							}
 						},
 						{
-							"id": 4125,
+							"id": 4132,
 							"name": "excludeInstrumentation",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35139,7 +35139,7 @@
 							}
 						},
 						{
-							"id": 4109,
+							"id": 4116,
 							"name": "filterErrorStack",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35163,7 +35163,7 @@
 							}
 						},
 						{
-							"id": 4126,
+							"id": 4133,
 							"name": "functionalBaseUrl",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35197,7 +35197,7 @@
 							}
 						},
 						{
-							"id": 4127,
+							"id": 4134,
 							"name": "functionalCoverage",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35221,7 +35221,7 @@
 							}
 						},
 						{
-							"id": 4128,
+							"id": 4135,
 							"name": "functionalSuites",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35249,7 +35249,7 @@
 							}
 						},
 						{
-							"id": 4129,
+							"id": 4136,
 							"name": "functionalTimeouts",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35271,14 +35271,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 4130,
+									"id": 4137,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 4131,
+											"id": 4138,
 											"name": "connectTimeout",
 											"kind": 32,
 											"kindString": "Variable",
@@ -35299,7 +35299,7 @@
 											}
 										},
 										{
-											"id": 4133,
+											"id": 4140,
 											"name": "executeAsync",
 											"kind": 32,
 											"kindString": "Variable",
@@ -35332,7 +35332,7 @@
 											}
 										},
 										{
-											"id": 4132,
+											"id": 4139,
 											"name": "find",
 											"kind": 32,
 											"kindString": "Variable",
@@ -35365,7 +35365,7 @@
 											}
 										},
 										{
-											"id": 4134,
+											"id": 4141,
 											"name": "pageLoad",
 											"kind": 32,
 											"kindString": "Variable",
@@ -35403,10 +35403,10 @@
 											"title": "Variables",
 											"kind": 32,
 											"children": [
-												4131,
-												4133,
-												4132,
-												4134
+												4138,
+												4140,
+												4139,
+												4141
 											]
 										}
 									],
@@ -35421,7 +35421,7 @@
 							}
 						},
 						{
-							"id": 4110,
+							"id": 4117,
 							"name": "grep",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35445,7 +35445,7 @@
 							}
 						},
 						{
-							"id": 4135,
+							"id": 4142,
 							"name": "heartbeatInterval",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35479,7 +35479,7 @@
 							}
 						},
 						{
-							"id": 4136,
+							"id": 4143,
 							"name": "instrumenterOptions",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35500,21 +35500,21 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 4137,
+									"id": 4144,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"indexSignature": [
 										{
-											"id": 4138,
+											"id": 4145,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 4139,
+													"id": 4146,
 													"name": "key",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -35542,7 +35542,7 @@
 							}
 						},
 						{
-							"id": 4111,
+							"id": 4118,
 							"name": "internPath",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35566,7 +35566,7 @@
 							}
 						},
 						{
-							"id": 4140,
+							"id": 4147,
 							"name": "leaveRemoteOpen",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35600,7 +35600,7 @@
 							}
 						},
 						{
-							"id": 4152,
+							"id": 4159,
 							"name": "loader",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35622,16 +35622,16 @@
 							"type": {
 								"type": "reference",
 								"name": "LoaderDescriptor",
-								"id": 4183
+								"id": 4190
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.loader",
-								"id": 4172
+								"id": 4179
 							}
 						},
 						{
-							"id": 4141,
+							"id": 4148,
 							"name": "maxConcurrency",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35656,7 +35656,7 @@
 							}
 						},
 						{
-							"id": 4112,
+							"id": 4119,
 							"name": "name",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35680,7 +35680,7 @@
 							}
 						},
 						{
-							"id": 4113,
+							"id": 4120,
 							"name": "node",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35698,11 +35698,11 @@
 							"type": {
 								"type": "reference",
 								"name": "ResourceConfig",
-								"id": 4171
+								"id": 4178
 							}
 						},
 						{
-							"id": 4154,
+							"id": 4161,
 							"name": "plugins",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35725,17 +35725,17 @@
 								"elementType": {
 									"type": "reference",
 									"name": "PluginDescriptor",
-									"id": 4163
+									"id": 4170
 								}
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.plugins",
-								"id": 4174
+								"id": 4181
 							}
 						},
 						{
-							"id": 4142,
+							"id": 4149,
 							"name": "proxy",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35769,7 +35769,7 @@
 							}
 						},
 						{
-							"id": 4153,
+							"id": 4160,
 							"name": "reporters",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35793,17 +35793,17 @@
 								"elementType": {
 									"type": "reference",
 									"name": "ReporterDescriptor",
-									"id": 4160
+									"id": 4167
 								}
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.reporters",
-								"id": 4173
+								"id": 4180
 							}
 						},
 						{
-							"id": 4157,
+							"id": 4164,
 							"name": "require",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35825,11 +35825,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.require",
-								"id": 4177
+								"id": 4184
 							}
 						},
 						{
-							"id": 4158,
+							"id": 4165,
 							"name": "requires",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35851,11 +35851,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.requires",
-								"id": 4178
+								"id": 4185
 							}
 						},
 						{
-							"id": 4143,
+							"id": 4150,
 							"name": "runInSync",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35879,7 +35879,7 @@
 							}
 						},
 						{
-							"id": 4159,
+							"id": 4166,
 							"name": "scripts",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35901,11 +35901,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.scripts",
-								"id": 4179
+								"id": 4186
 							}
 						},
 						{
-							"id": 4144,
+							"id": 4151,
 							"name": "serveOnly",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35929,7 +35929,7 @@
 							}
 						},
 						{
-							"id": 4145,
+							"id": 4152,
 							"name": "serverPort",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35953,7 +35953,7 @@
 							}
 						},
 						{
-							"id": 4146,
+							"id": 4153,
 							"name": "serverUrl",
 							"kind": 1024,
 							"kindString": "Property",
@@ -35977,7 +35977,7 @@
 							}
 						},
 						{
-							"id": 4114,
+							"id": 4121,
 							"name": "sessionId",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36001,7 +36001,7 @@
 							}
 						},
 						{
-							"id": 4115,
+							"id": 4122,
 							"name": "showConfig",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36025,7 +36025,7 @@
 							}
 						},
 						{
-							"id": 4147,
+							"id": 4154,
 							"name": "socketPort",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36059,7 +36059,7 @@
 							}
 						},
 						{
-							"id": 4155,
+							"id": 4162,
 							"name": "suites",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36088,11 +36088,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.suites",
-								"id": 4175
+								"id": 4182
 							}
 						},
 						{
-							"id": 4156,
+							"id": 4163,
 							"name": "tsconfig",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36127,11 +36127,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ResourceConfig.tsconfig",
-								"id": 4176
+								"id": 4183
 							}
 						},
 						{
-							"id": 4148,
+							"id": 4155,
 							"name": "tunnel",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36156,7 +36156,7 @@
 							}
 						},
 						{
-							"id": 4149,
+							"id": 4156,
 							"name": "tunnelOptions",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36194,7 +36194,7 @@
 							}
 						},
 						{
-							"id": 4151,
+							"id": 4158,
 							"name": "warnOnUncaughtException",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36227,7 +36227,7 @@
 							}
 						},
 						{
-							"id": 4150,
+							"id": 4157,
 							"name": "warnOnUnhandledRejection",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36265,54 +36265,54 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4099,
-								4101,
-								4100,
-								4102,
-								4103,
-								4104,
-								4116,
-								4122,
-								4123,
-								4105,
 								4106,
-								4107,
 								4108,
-								4124,
-								4125,
+								4107,
 								4109,
-								4126,
-								4127,
-								4128,
-								4129,
 								4110,
-								4135,
-								4136,
 								4111,
-								4140,
-								4152,
-								4141,
+								4123,
+								4129,
+								4130,
 								4112,
 								4113,
-								4154,
-								4142,
-								4153,
-								4157,
-								4158,
-								4143,
-								4159,
-								4144,
-								4145,
-								4146,
 								4114,
 								4115,
+								4131,
+								4132,
+								4116,
+								4133,
+								4134,
+								4135,
+								4136,
+								4117,
+								4142,
+								4143,
+								4118,
 								4147,
+								4159,
+								4148,
+								4119,
+								4120,
+								4161,
+								4149,
+								4160,
+								4164,
+								4165,
+								4150,
+								4166,
+								4151,
+								4152,
+								4153,
+								4121,
+								4122,
+								4154,
+								4162,
+								4163,
 								4155,
 								4156,
-								4148,
-								4149,
-								4151,
-								4150
+								4158,
+								4157
 							]
 						}
 					],
@@ -36327,7 +36327,7 @@
 						{
 							"type": "reference",
 							"name": "ResourceConfig",
-							"id": 4171
+							"id": 4178
 						}
 					],
 					"extendedBy": [
@@ -36339,7 +36339,7 @@
 					]
 				},
 				{
-					"id": 4189,
+					"id": 4196,
 					"name": "EnvironmentSpec",
 					"kind": 256,
 					"kindString": "Interface",
@@ -36349,14 +36349,14 @@
 					},
 					"indexSignature": [
 						{
-							"id": 4191,
+							"id": 4198,
 							"name": "__index",
 							"kind": 8192,
 							"kindString": "Index signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 4192,
+									"id": 4199,
 									"name": "key",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -36375,7 +36375,7 @@
 					],
 					"children": [
 						{
-							"id": 4190,
+							"id": 4197,
 							"name": "browserName",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36401,7 +36401,7 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4190
+								4197
 							]
 						}
 					],
@@ -36414,7 +36414,7 @@
 					]
 				},
 				{
-					"id": 4167,
+					"id": 4174,
 					"name": "Listener",
 					"kind": 256,
 					"kindString": "Interface",
@@ -36427,7 +36427,7 @@
 					},
 					"typeParameter": [
 						{
-							"id": 4168,
+							"id": 4175,
 							"name": "T",
 							"kind": 131072,
 							"kindString": "Type parameter",
@@ -36436,7 +36436,7 @@
 					],
 					"signatures": [
 						{
-							"id": 4169,
+							"id": 4176,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -36446,7 +36446,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4170,
+									"id": 4177,
 									"name": "arg",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -36487,7 +36487,7 @@
 					]
 				},
 				{
-					"id": 4183,
+					"id": 4190,
 					"name": "LoaderDescriptor",
 					"kind": 256,
 					"kindString": "Interface",
@@ -36497,7 +36497,7 @@
 					},
 					"children": [
 						{
-							"id": 4185,
+							"id": 4192,
 							"name": "options",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36523,21 +36523,21 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 4186,
+											"id": 4193,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 4187,
+													"id": 4194,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 4188,
+															"id": 4195,
 															"name": "key",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -36560,7 +36560,7 @@
 							}
 						},
 						{
-							"id": 4184,
+							"id": 4191,
 							"name": "script",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36586,8 +36586,8 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4185,
-								4184
+								4192,
+								4191
 							]
 						}
 					],
@@ -36600,7 +36600,7 @@
 					]
 				},
 				{
-					"id": 4163,
+					"id": 4170,
 					"name": "PluginDescriptor",
 					"kind": 256,
 					"kindString": "Interface",
@@ -36613,7 +36613,7 @@
 					},
 					"children": [
 						{
-							"id": 4166,
+							"id": 4173,
 							"name": "options",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36635,7 +36635,7 @@
 							}
 						},
 						{
-							"id": 4164,
+							"id": 4171,
 							"name": "script",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36656,7 +36656,7 @@
 							}
 						},
 						{
-							"id": 4165,
+							"id": 4172,
 							"name": "useLoader",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36696,9 +36696,9 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4166,
-								4164,
-								4165
+								4173,
+								4171,
+								4172
 							]
 						}
 					],
@@ -36711,7 +36711,7 @@
 					]
 				},
 				{
-					"id": 4160,
+					"id": 4167,
 					"name": "ReporterDescriptor",
 					"kind": 256,
 					"kindString": "Interface",
@@ -36724,7 +36724,7 @@
 					},
 					"children": [
 						{
-							"id": 4161,
+							"id": 4168,
 							"name": "name",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36745,7 +36745,7 @@
 							}
 						},
 						{
-							"id": 4162,
+							"id": 4169,
 							"name": "options",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36764,7 +36764,7 @@
 							"type": {
 								"type": "reference",
 								"name": "ReporterOptions",
-								"id": 4092
+								"id": 4099
 							}
 						}
 					],
@@ -36773,8 +36773,8 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4161,
-								4162
+								4168,
+								4169
 							]
 						}
 					],
@@ -36787,7 +36787,7 @@
 					]
 				},
 				{
-					"id": 4171,
+					"id": 4178,
 					"name": "ResourceConfig",
 					"kind": 256,
 					"kindString": "Interface",
@@ -36797,7 +36797,7 @@
 					},
 					"children": [
 						{
-							"id": 4172,
+							"id": 4179,
 							"name": "loader",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36819,11 +36819,11 @@
 							"type": {
 								"type": "reference",
 								"name": "LoaderDescriptor",
-								"id": 4183
+								"id": 4190
 							}
 						},
 						{
-							"id": 4174,
+							"id": 4181,
 							"name": "plugins",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36846,12 +36846,12 @@
 								"elementType": {
 									"type": "reference",
 									"name": "PluginDescriptor",
-									"id": 4163
+									"id": 4170
 								}
 							}
 						},
 						{
-							"id": 4173,
+							"id": 4180,
 							"name": "reporters",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36875,12 +36875,12 @@
 								"elementType": {
 									"type": "reference",
 									"name": "ReporterDescriptor",
-									"id": 4160
+									"id": 4167
 								}
 							}
 						},
 						{
-							"id": 4177,
+							"id": 4184,
 							"name": "require",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36901,7 +36901,7 @@
 							}
 						},
 						{
-							"id": 4178,
+							"id": 4185,
 							"name": "requires",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36922,7 +36922,7 @@
 							}
 						},
 						{
-							"id": 4179,
+							"id": 4186,
 							"name": "scripts",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36943,7 +36943,7 @@
 							}
 						},
 						{
-							"id": 4175,
+							"id": 4182,
 							"name": "suites",
 							"kind": 1024,
 							"kindString": "Property",
@@ -36971,7 +36971,7 @@
 							}
 						},
 						{
-							"id": 4176,
+							"id": 4183,
 							"name": "tsconfig",
 							"kind": 1024,
 							"kindString": "Property",
@@ -37010,14 +37010,14 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4172,
-								4174,
-								4173,
-								4177,
-								4178,
 								4179,
-								4175,
-								4176
+								4181,
+								4180,
+								4184,
+								4185,
+								4186,
+								4182,
+								4183
 							]
 						}
 					],
@@ -37032,7 +37032,7 @@
 						{
 							"type": "reference",
 							"name": "Config",
-							"id": 4098
+							"id": 4105
 						}
 					]
 				}
@@ -37042,14 +37042,14 @@
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						4180,
-						4098,
-						4189,
+						4187,
+						4105,
+						4196,
+						4174,
+						4190,
+						4170,
 						4167,
-						4183,
-						4163,
-						4160,
-						4171
+						4178
 					]
 				}
 			],
@@ -37531,7 +37531,7 @@
 			]
 		},
 		{
-			"id": 4193,
+			"id": 4200,
 			"name": "\"lib/common/util\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -37542,7 +37542,7 @@
 			"originalName": "src/lib/common/util.ts",
 			"children": [
 				{
-					"id": 4194,
+					"id": 4201,
 					"name": "EvaluatedProperty",
 					"kind": 256,
 					"kindString": "Interface",
@@ -37552,7 +37552,7 @@
 					},
 					"children": [
 						{
-							"id": 4196,
+							"id": 4203,
 							"name": "addToExisting",
 							"kind": 1024,
 							"kindString": "Property",
@@ -37573,7 +37573,7 @@
 							}
 						},
 						{
-							"id": 4195,
+							"id": 4202,
 							"name": "name",
 							"kind": 1024,
 							"kindString": "Property",
@@ -37603,8 +37603,8 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4196,
-								4195
+								4203,
+								4202
 							]
 						}
 					],
@@ -37617,7 +37617,7 @@
 					]
 				},
 				{
-					"id": 4197,
+					"id": 4204,
 					"name": "TextLoader",
 					"kind": 256,
 					"kindString": "Interface",
@@ -37627,14 +37627,14 @@
 					},
 					"signatures": [
 						{
-							"id": 4198,
+							"id": 4205,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 4199,
+									"id": 4206,
 									"name": "path",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -37666,7 +37666,7 @@
 					]
 				},
 				{
-					"id": 4201,
+					"id": 4208,
 					"name": "Parser",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -37676,7 +37676,7 @@
 					},
 					"typeParameter": [
 						{
-							"id": 4202,
+							"id": 4209,
 							"name": "T",
 							"kind": 131072,
 							"kindString": "Type parameter",
@@ -37693,21 +37693,21 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 4203,
+							"id": 4210,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"signatures": [
 								{
-									"id": 4204,
+									"id": 4211,
 									"name": "__call",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4205,
+											"id": 4212,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -37735,7 +37735,7 @@
 					}
 				},
 				{
-					"id": 4200,
+					"id": 4207,
 					"name": "TypeName",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -37785,7 +37785,7 @@
 					}
 				},
 				{
-					"id": 4292,
+					"id": 4299,
 					"name": "configPathSeparator",
 					"kind": 32,
 					"kindString": "Variable",
@@ -37807,7 +37807,7 @@
 					"defaultValue": "\"@\""
 				},
 				{
-					"id": 4283,
+					"id": 4290,
 					"name": "_loadConfig",
 					"kind": 64,
 					"kindString": "Function",
@@ -37816,14 +37816,14 @@
 					},
 					"signatures": [
 						{
-							"id": 4284,
+							"id": 4291,
 							"name": "_loadConfig",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 4285,
+									"id": 4292,
 									"name": "configPath",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -37834,7 +37834,7 @@
 									}
 								},
 								{
-									"id": 4286,
+									"id": 4293,
 									"name": "loadText",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -37842,11 +37842,11 @@
 									"type": {
 										"type": "reference",
 										"name": "TextLoader",
-										"id": 4197
+										"id": 4204
 									}
 								},
 								{
-									"id": 4287,
+									"id": 4294,
 									"name": "args",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -37863,21 +37863,21 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 4288,
+													"id": 4295,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"indexSignature": [
 														{
-															"id": 4289,
+															"id": 4296,
 															"name": "__index",
 															"kind": 8192,
 															"kindString": "Index signature",
 															"flags": {},
 															"parameters": [
 																{
-																	"id": 4290,
+																	"id": 4297,
 																	"name": "key",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -37900,7 +37900,7 @@
 									}
 								},
 								{
-									"id": 4291,
+									"id": 4298,
 									"name": "childConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -37946,63 +37946,7 @@
 					]
 				},
 				{
-					"id": 4297,
-					"name": "errorToJSON",
-					"kind": 64,
-					"kindString": "Function",
-					"flags": {
-						"isExported": true,
-						"isExternal": true
-					},
-					"signatures": [
-						{
-							"id": 4298,
-							"name": "errorToJSON",
-							"kind": 4096,
-							"kindString": "Call signature",
-							"flags": {},
-							"parameters": [
-								{
-									"id": 4299,
-									"name": "error",
-									"kind": 32768,
-									"kindString": "Parameter",
-									"flags": {
-										"isOptional": true
-									},
-									"type": {
-										"type": "reference",
-										"name": "InternError",
-										"id": 23
-									}
-								}
-							],
-							"type": {
-								"type": "union",
-								"types": [
-									{
-										"type": "reference",
-										"name": "InternError",
-										"id": 23
-									},
-									{
-										"type": "intrinsic",
-										"name": "undefined"
-									}
-								]
-							}
-						}
-					],
-					"sources": [
-						{
-							"fileName": "lib/common/util.ts",
-							"line": 1002,
-							"character": 27
-						}
-					]
-				},
-				{
-					"id": 4206,
+					"id": 4213,
 					"name": "evalProperty",
 					"kind": 64,
 					"kindString": "Function",
@@ -38012,7 +37956,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4207,
+							"id": 4214,
 							"name": "evalProperty",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -38022,7 +37966,7 @@
 							},
 							"typeParameter": [
 								{
-									"id": 4208,
+									"id": 4215,
 									"name": "C",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -38031,7 +37975,7 @@
 							],
 							"parameters": [
 								{
-									"id": 4209,
+									"id": 4216,
 									"name": "key",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38049,7 +37993,7 @@
 							"type": {
 								"type": "reference",
 								"name": "EvaluatedProperty",
-								"id": 4194
+								"id": 4201
 							}
 						}
 					],
@@ -38062,7 +38006,7 @@
 					]
 				},
 				{
-					"id": 4210,
+					"id": 4217,
 					"name": "getBasePath",
 					"kind": 64,
 					"kindString": "Function",
@@ -38072,7 +38016,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4211,
+							"id": 4218,
 							"name": "getBasePath",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -38083,7 +38027,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4212,
+									"id": 4219,
 									"name": "configFile",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38094,7 +38038,7 @@
 									}
 								},
 								{
-									"id": 4213,
+									"id": 4220,
 									"name": "basePath",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38105,7 +38049,7 @@
 									}
 								},
 								{
-									"id": 4214,
+									"id": 4221,
 									"name": "isAbsolute",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38113,21 +38057,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 4215,
+											"id": 4222,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 4216,
+													"id": 4223,
 													"name": "__call",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 4217,
+															"id": 4224,
 															"name": "path",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -38155,7 +38099,7 @@
 									}
 								},
 								{
-									"id": 4218,
+									"id": 4225,
 									"name": "pathSep",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38192,7 +38136,7 @@
 					]
 				},
 				{
-					"id": 4219,
+					"id": 4226,
 					"name": "getConfigDescription",
 					"kind": 64,
 					"kindString": "Function",
@@ -38202,7 +38146,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4220,
+							"id": 4227,
 							"name": "getConfigDescription",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -38212,7 +38156,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4221,
+									"id": 4228,
 									"name": "config",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38223,7 +38167,7 @@
 									}
 								},
 								{
-									"id": 4222,
+									"id": 4229,
 									"name": "prefix",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38250,7 +38194,7 @@
 					]
 				},
 				{
-					"id": 4223,
+					"id": 4230,
 					"name": "loadConfig",
 					"kind": 64,
 					"kindString": "Function",
@@ -38260,7 +38204,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4224,
+							"id": 4231,
 							"name": "loadConfig",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -38270,7 +38214,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4225,
+									"id": 4232,
 									"name": "configPath",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38281,7 +38225,7 @@
 									}
 								},
 								{
-									"id": 4226,
+									"id": 4233,
 									"name": "loadText",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38289,11 +38233,11 @@
 									"type": {
 										"type": "reference",
 										"name": "TextLoader",
-										"id": 4197
+										"id": 4204
 									}
 								},
 								{
-									"id": 4227,
+									"id": 4234,
 									"name": "args",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38310,21 +38254,21 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 4228,
+													"id": 4235,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"indexSignature": [
 														{
-															"id": 4229,
+															"id": 4236,
 															"name": "__index",
 															"kind": 8192,
 															"kindString": "Index signature",
 															"flags": {},
 															"parameters": [
 																{
-																	"id": 4230,
+																	"id": 4237,
 																	"name": "key",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -38347,7 +38291,7 @@
 									}
 								},
 								{
-									"id": 4231,
+									"id": 4238,
 									"name": "childConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38393,7 +38337,7 @@
 					]
 				},
 				{
-					"id": 4232,
+					"id": 4239,
 					"name": "parseArgs",
 					"kind": 64,
 					"kindString": "Function",
@@ -38403,7 +38347,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4233,
+							"id": 4240,
 							"name": "parseArgs",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -38413,7 +38357,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4234,
+									"id": 4241,
 									"name": "rawArgs",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38430,21 +38374,21 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 4235,
+									"id": 4242,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"indexSignature": [
 										{
-											"id": 4236,
+											"id": 4243,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 4237,
+													"id": 4244,
 													"name": "key",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -38474,7 +38418,7 @@
 					]
 				},
 				{
-					"id": 4238,
+					"id": 4245,
 					"name": "parseJson",
 					"kind": 64,
 					"kindString": "Function",
@@ -38484,7 +38428,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4239,
+							"id": 4246,
 							"name": "parseJson",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -38494,7 +38438,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4240,
+									"id": 4247,
 									"name": "json",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38520,7 +38464,7 @@
 					]
 				},
 				{
-					"id": 4241,
+					"id": 4248,
 					"name": "parseValue",
 					"kind": 64,
 					"kindString": "Function",
@@ -38530,7 +38474,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4242,
+							"id": 4249,
 							"name": "parseValue",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -38540,7 +38484,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4243,
+									"id": 4250,
 									"name": "name",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38554,7 +38498,7 @@
 									}
 								},
 								{
-									"id": 4244,
+									"id": 4251,
 									"name": "value",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38568,7 +38512,7 @@
 									}
 								},
 								{
-									"id": 4245,
+									"id": 4252,
 									"name": "parser",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38582,18 +38526,18 @@
 											{
 												"type": "reference",
 												"name": "TypeName",
-												"id": 4200
+												"id": 4207
 											},
 											{
 												"type": "reference",
 												"name": "Parser",
-												"id": 4201
+												"id": 4208
 											}
 										]
 									}
 								},
 								{
-									"id": 4246,
+									"id": 4253,
 									"name": "requiredProperty",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38633,7 +38577,7 @@
 					]
 				},
 				{
-					"id": 4247,
+					"id": 4254,
 					"name": "prefix",
 					"kind": 64,
 					"kindString": "Function",
@@ -38643,7 +38587,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4248,
+							"id": 4255,
 							"name": "prefix",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -38653,7 +38597,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4249,
+									"id": 4256,
 									"name": "message",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38664,7 +38608,7 @@
 									}
 								},
 								{
-									"id": 4250,
+									"id": 4257,
 									"name": "prefix",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38690,7 +38634,7 @@
 					]
 				},
 				{
-					"id": 4251,
+					"id": 4258,
 					"name": "processOption",
 					"kind": 64,
 					"kindString": "Function",
@@ -38700,7 +38644,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4252,
+							"id": 4259,
 							"name": "processOption",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -38711,7 +38655,7 @@
 							},
 							"typeParameter": [
 								{
-									"id": 4253,
+									"id": 4260,
 									"name": "C",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -38719,13 +38663,13 @@
 									"type": {
 										"type": "reference",
 										"name": "Config",
-										"id": 4098
+										"id": 4105
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 4254,
+									"id": 4261,
 									"name": "key",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38739,13 +38683,13 @@
 											"constraint": {
 												"type": "reference",
 												"name": "Config",
-												"id": 4098
+												"id": 4105
 											}
 										}
 									}
 								},
 								{
-									"id": 4255,
+									"id": 4262,
 									"name": "value",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38756,7 +38700,7 @@
 									}
 								},
 								{
-									"id": 4256,
+									"id": 4263,
 									"name": "config",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38767,12 +38711,12 @@
 										"constraint": {
 											"type": "reference",
 											"name": "Config",
-											"id": 4098
+											"id": 4105
 										}
 									}
 								},
 								{
-									"id": 4257,
+									"id": 4264,
 									"name": "executor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38782,7 +38726,7 @@
 									"type": {
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									}
 								}
 							],
@@ -38801,7 +38745,7 @@
 					]
 				},
 				{
-					"id": 4258,
+					"id": 4265,
 					"name": "pullFromArray",
 					"kind": 64,
 					"kindString": "Function",
@@ -38811,7 +38755,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4259,
+							"id": 4266,
 							"name": "pullFromArray",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -38821,7 +38765,7 @@
 							},
 							"typeParameter": [
 								{
-									"id": 4260,
+									"id": 4267,
 									"name": "T",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -38830,7 +38774,7 @@
 							],
 							"parameters": [
 								{
-									"id": 4261,
+									"id": 4268,
 									"name": "haystack",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38844,7 +38788,7 @@
 									}
 								},
 								{
-									"id": 4262,
+									"id": 4269,
 									"name": "needle",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38873,7 +38817,7 @@
 					]
 				},
 				{
-					"id": 4263,
+					"id": 4270,
 					"name": "removeComments",
 					"kind": 64,
 					"kindString": "Function",
@@ -38882,7 +38826,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4264,
+							"id": 4271,
 							"name": "removeComments",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -38892,7 +38836,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4265,
+									"id": 4272,
 									"name": "text",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38918,7 +38862,7 @@
 					]
 				},
 				{
-					"id": 4293,
+					"id": 4300,
 					"name": "serializeReplacer",
 					"kind": 64,
 					"kindString": "Function",
@@ -38927,7 +38871,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4294,
+							"id": 4301,
 							"name": "serializeReplacer",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -38937,7 +38881,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4295,
+									"id": 4302,
 									"name": "_key",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38948,7 +38892,7 @@
 									}
 								},
 								{
-									"id": 4296,
+									"id": 4303,
 									"name": "value",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -38974,7 +38918,7 @@
 					]
 				},
 				{
-					"id": 4266,
+					"id": 4273,
 					"name": "setOption",
 					"kind": 64,
 					"kindString": "Function",
@@ -38984,7 +38928,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4267,
+							"id": 4274,
 							"name": "setOption",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -38994,7 +38938,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4268,
+									"id": 4275,
 									"name": "config",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -39002,11 +38946,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Config",
-										"id": 4098
+										"id": 4105
 									}
 								},
 								{
-									"id": 4269,
+									"id": 4276,
 									"name": "name",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -39021,7 +38965,7 @@
 									}
 								},
 								{
-									"id": 4270,
+									"id": 4277,
 									"name": "value",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -39032,7 +38976,7 @@
 									}
 								},
 								{
-									"id": 4271,
+									"id": 4278,
 									"name": "addToExisting",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -39059,7 +39003,7 @@
 					]
 				},
 				{
-					"id": 4272,
+					"id": 4279,
 					"name": "splitConfigPath",
 					"kind": 64,
 					"kindString": "Function",
@@ -39069,7 +39013,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4273,
+							"id": 4280,
 							"name": "splitConfigPath",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -39080,7 +39024,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4274,
+									"id": 4281,
 									"name": "path",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -39091,7 +39035,7 @@
 									}
 								},
 								{
-									"id": 4275,
+									"id": 4282,
 									"name": "separator",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -39106,14 +39050,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 4276,
+									"id": 4283,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 4278,
+											"id": 4285,
 											"name": "childConfig",
 											"kind": 32,
 											"kindString": "Variable",
@@ -39143,7 +39087,7 @@
 											}
 										},
 										{
-											"id": 4277,
+											"id": 4284,
 											"name": "configFile",
 											"kind": 32,
 											"kindString": "Variable",
@@ -39168,8 +39112,8 @@
 											"title": "Variables",
 											"kind": 32,
 											"children": [
-												4278,
-												4277
+												4285,
+												4284
 											]
 										}
 									],
@@ -39193,7 +39137,7 @@
 					]
 				},
 				{
-					"id": 4279,
+					"id": 4286,
 					"name": "stringify",
 					"kind": 64,
 					"kindString": "Function",
@@ -39203,7 +39147,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4280,
+							"id": 4287,
 							"name": "stringify",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -39214,7 +39158,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4281,
+									"id": 4288,
 									"name": "object",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -39228,7 +39172,7 @@
 									}
 								},
 								{
-									"id": 4282,
+									"id": 4289,
 									"name": "indent",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -39270,46 +39214,45 @@
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						4194,
-						4197
+						4201,
+						4204
 					]
 				},
 				{
 					"title": "Type aliases",
 					"kind": 4194304,
 					"children": [
-						4201,
-						4200
+						4208,
+						4207
 					]
 				},
 				{
 					"title": "Variables",
 					"kind": 32,
 					"children": [
-						4292
+						4299
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						4283,
-						4297,
-						4206,
-						4210,
-						4219,
-						4223,
-						4232,
-						4238,
-						4241,
-						4247,
-						4251,
+						4290,
+						4213,
+						4217,
+						4226,
+						4230,
+						4239,
+						4245,
+						4248,
+						4254,
 						4258,
-						4263,
-						4293,
-						4266,
-						4272,
-						4279
+						4265,
+						4270,
+						4300,
+						4273,
+						4279,
+						4286
 					]
 				}
 			],
@@ -39399,7 +39342,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "BaseExecutor.__constructor",
-										"id": 3850
+										"id": 3857
 									}
 								}
 							],
@@ -39413,7 +39356,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "BaseExecutor.__constructor",
-								"id": 3850
+								"id": 3857
 							}
 						},
 						{
@@ -39436,12 +39379,12 @@
 							"type": {
 								"type": "reference",
 								"name": "Config",
-								"id": 4098
+								"id": 4105
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._config",
-								"id": 3824
+								"id": 3831
 							}
 						},
 						{
@@ -39478,7 +39421,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._errorFormatter",
-								"id": 3827
+								"id": 3834
 							}
 						},
 						{
@@ -39503,12 +39446,12 @@
 								"elementType": {
 									"type": "reference",
 									"name": "InternEvent",
-									"id": 3985,
+									"id": 3992,
 									"typeArguments": [
 										{
 											"type": "reference",
 											"name": "Events",
-											"id": 4004
+											"id": 4011
 										}
 									]
 								}
@@ -39516,7 +39459,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._events",
-								"id": 3826
+								"id": 3833
 							}
 						},
 						{
@@ -39544,7 +39487,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._hasEmittedErrors",
-								"id": 3830
+								"id": 3837
 							}
 						},
 						{
@@ -39572,7 +39515,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._hasSuiteErrors",
-								"id": 3828
+								"id": 3835
 							}
 						},
 						{
@@ -39600,7 +39543,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._hasTestErrors",
-								"id": 3829
+								"id": 3836
 							}
 						},
 						{
@@ -39653,7 +39596,7 @@
 												"elementType": {
 													"type": "reference",
 													"name": "Listener",
-													"id": 3989,
+													"id": 3996,
 													"typeArguments": [
 														{
 															"type": "intrinsic",
@@ -39676,7 +39619,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._listeners",
-								"id": 3839
+								"id": 3846
 							}
 						},
 						{
@@ -39699,12 +39642,12 @@
 							"type": {
 								"type": "reference",
 								"name": "Loader",
-								"id": 4023
+								"id": 4030
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loader",
-								"id": 3831
+								"id": 3838
 							}
 						},
 						{
@@ -39734,7 +39677,7 @@
 											{
 												"type": "reference",
 												"name": "Loader",
-												"id": 4023
+												"id": 4030
 											}
 										]
 									},
@@ -39747,7 +39690,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loaderInit",
-								"id": 3833
+								"id": 3840
 							}
 						},
 						{
@@ -39774,7 +39717,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loaderOptions",
-								"id": 3832
+								"id": 3839
 							}
 						},
 						{
@@ -39810,7 +39753,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loadingPluginOptions",
-								"id": 3838
+								"id": 3845
 							}
 						},
 						{
@@ -39911,7 +39854,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loadingPlugins",
-								"id": 3834
+								"id": 3841
 							}
 						},
 						{
@@ -39977,7 +39920,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._plugins",
-								"id": 3843
+								"id": 3850
 							}
 						},
 						{
@@ -40002,13 +39945,13 @@
 								"elementType": {
 									"type": "reference",
 									"name": "Reporter",
-									"id": 4042
+									"id": 4049
 								}
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._reporters",
-								"id": 3847
+								"id": 3854
 							}
 						},
 						{
@@ -40035,7 +39978,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._reportersInitialized",
-								"id": 3849
+								"id": 3856
 							}
 						},
 						{
@@ -40058,12 +40001,12 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._rootSuite",
-								"id": 3825
+								"id": 3832
 							}
 						},
 						{
@@ -40105,7 +40048,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._runTask",
-								"id": 3848
+								"id": 3855
 							}
 						},
 						{
@@ -40137,7 +40080,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.config",
-										"id": 3856
+										"id": 3863
 									}
 								}
 							],
@@ -40151,12 +40094,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.config",
-								"id": 3856
+								"id": 3863
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.config",
-								"id": 3781
+								"id": 3788
 							}
 						},
 						{
@@ -40183,7 +40126,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "BaseExecutor.environment",
-										"id": 3854
+										"id": 3861
 									}
 								}
 							],
@@ -40197,7 +40140,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "BaseExecutor.environment",
-								"id": 3854
+								"id": 3861
 							}
 						},
 						{
@@ -40227,13 +40170,13 @@
 										"elementType": {
 											"type": "reference",
 											"name": "Suite",
-											"id": 3400
+											"id": 3407
 										}
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.suites",
-										"id": 3858
+										"id": 3865
 									}
 								}
 							],
@@ -40247,12 +40190,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.suites",
-								"id": 3858
+								"id": 3865
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.suites",
-								"id": 3782
+								"id": 3789
 							}
 						},
 						{
@@ -40288,7 +40231,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._afterRun",
-										"id": 3947
+										"id": 3954
 									}
 								}
 							],
@@ -40302,7 +40245,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._afterRun",
-								"id": 3947
+								"id": 3954
 							}
 						},
 						{
@@ -40356,7 +40299,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._assignPlugin",
-										"id": 3949
+										"id": 3956
 									}
 								}
 							],
@@ -40370,7 +40313,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._assignPlugin",
-								"id": 3949
+								"id": 3956
 							}
 						},
 						{
@@ -40407,7 +40350,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._beforeRun",
-										"id": 3953
+										"id": 3960
 									}
 								}
 							],
@@ -40421,7 +40364,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._beforeRun",
-								"id": 3953
+								"id": 3960
 							}
 						},
 						{
@@ -40457,7 +40400,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._drainEventQueue",
-										"id": 3957
+										"id": 3964
 									}
 								}
 							],
@@ -40471,7 +40414,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._drainEventQueue",
-								"id": 3957
+								"id": 3964
 							}
 						},
 						{
@@ -40537,7 +40480,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._emitCoverage",
-										"id": 3959
+										"id": 3966
 									}
 								}
 							],
@@ -40551,7 +40494,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._emitCoverage",
-								"id": 3959
+								"id": 3966
 							}
 						},
 						{
@@ -40587,7 +40530,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._initReporters",
-										"id": 3955
+										"id": 3962
 									}
 								}
 							],
@@ -40601,7 +40544,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._initReporters",
-								"id": 3955
+								"id": 3962
 							}
 						},
 						{
@@ -40637,7 +40580,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._loadLoader",
-										"id": 3962
+										"id": 3969
 									}
 								}
 							],
@@ -40651,7 +40594,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loadLoader",
-								"id": 3962
+								"id": 3969
 							}
 						},
 						{
@@ -40687,7 +40630,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._loadPlugins",
-										"id": 3966
+										"id": 3973
 									}
 								}
 							],
@@ -40701,7 +40644,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loadPlugins",
-								"id": 3966
+								"id": 3973
 							}
 						},
 						{
@@ -40737,7 +40680,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._loadPluginsWithLoader",
-										"id": 3964
+										"id": 3971
 									}
 								}
 							],
@@ -40751,7 +40694,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loadPluginsWithLoader",
-								"id": 3964
+								"id": 3971
 							}
 						},
 						{
@@ -40786,7 +40729,7 @@
 												"elementType": {
 													"type": "reference",
 													"name": "PluginDescriptor",
-													"id": 4163
+													"id": 4170
 												}
 											}
 										},
@@ -40860,7 +40803,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._loadScripts",
-										"id": 3968
+										"id": 3975
 									}
 								}
 							],
@@ -40874,7 +40817,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loadScripts",
-								"id": 3968
+								"id": 3975
 							}
 						},
 						{
@@ -40910,7 +40853,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._loadSuites",
-										"id": 3975
+										"id": 3982
 									}
 								}
 							],
@@ -40924,7 +40867,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loadSuites",
-								"id": 3975
+								"id": 3982
 							}
 						},
 						{
@@ -40982,7 +40925,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._processOption",
-										"id": 3977
+										"id": 3984
 									}
 								}
 							],
@@ -40996,7 +40939,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._processOption",
-								"id": 3977
+								"id": 3984
 							}
 						},
 						{
@@ -41029,7 +40972,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "BaseExecutor._resolveConfig",
-										"id": 3981
+										"id": 3988
 									}
 								}
 							],
@@ -41043,7 +40986,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "BaseExecutor._resolveConfig",
-								"id": 3981
+								"id": 3988
 							}
 						},
 						{
@@ -41079,7 +41022,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._runTests",
-										"id": 3983
+										"id": 3990
 									}
 								}
 							],
@@ -41093,7 +41036,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._runTests",
-								"id": 3983
+								"id": 3990
 							}
 						},
 						{
@@ -41151,7 +41094,7 @@
 																	"type": {
 																		"type": "reference",
 																		"name": "Suite",
-																		"id": 3400
+																		"id": 3407
 																	}
 																}
 															],
@@ -41179,7 +41122,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.addSuite",
-										"id": 3867
+										"id": 3874
 									}
 								}
 							],
@@ -41193,12 +41136,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.addSuite",
-								"id": 3867
+								"id": 3874
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.addSuite",
-								"id": 3783
+								"id": 3790
 							}
 						},
 						{
@@ -41253,7 +41196,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.configure",
-										"id": 3873
+										"id": 3880
 									}
 								}
 							],
@@ -41267,12 +41210,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.configure",
-								"id": 3873
+								"id": 3880
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.configure",
-								"id": 3789
+								"id": 3796
 							}
 						},
 						{
@@ -41306,7 +41249,7 @@
 											"type": {
 												"type": "reference",
 												"name": "NoDataEvents",
-												"id": 4043
+												"id": 4050
 											}
 										}
 									],
@@ -41326,7 +41269,7 @@
 												"constraint": {
 													"type": "reference",
 													"name": "NoDataEvents",
-													"id": 4043
+													"id": 4050
 												}
 											}
 										}
@@ -41344,12 +41287,12 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.emit",
-										"id": 3877
+										"id": 3884
 									},
 									"implementationOf": {
 										"type": "reference",
 										"name": "Executor.emit",
-										"id": 3796
+										"id": 3803
 									}
 								},
 								{
@@ -41420,7 +41363,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.emit",
-										"id": 3877
+										"id": 3884
 									}
 								}
 							],
@@ -41444,12 +41387,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.emit",
-								"id": 3877
+								"id": 3884
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.emit",
-								"id": 3795
+								"id": 3802
 							}
 						},
 						{
@@ -41505,12 +41448,12 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.formatError",
-										"id": 3860
+										"id": 3867
 									},
 									"implementationOf": {
 										"type": "reference",
 										"name": "Executor.formatError",
-										"id": 3804
+										"id": 3811
 									}
 								}
 							],
@@ -41524,12 +41467,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.formatError",
-								"id": 3860
+								"id": 3867
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.formatError",
-								"id": 3803
+								"id": 3810
 							}
 						},
 						{
@@ -41572,12 +41515,12 @@
 									"type": {
 										"type": "reference",
 										"name": "ObjectInterface",
-										"id": 3504
+										"id": 3511
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getInterface",
-										"id": 3885
+										"id": 3892
 									}
 								},
 								{
@@ -41602,12 +41545,12 @@
 									"type": {
 										"type": "reference",
 										"name": "TddInterface",
-										"id": 3551
+										"id": 3558
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getInterface",
-										"id": 3885
+										"id": 3892
 									}
 								},
 								{
@@ -41632,12 +41575,12 @@
 									"type": {
 										"type": "reference",
 										"name": "BddInterface",
-										"id": 3628
+										"id": 3635
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getInterface",
-										"id": 3885
+										"id": 3892
 									}
 								},
 								{
@@ -41662,12 +41605,12 @@
 									"type": {
 										"type": "reference",
 										"name": "BenchmarkInterface",
-										"id": 3743
+										"id": 3750
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getInterface",
-										"id": 3885
+										"id": 3892
 									}
 								}
 							],
@@ -41701,7 +41644,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.getInterface",
-								"id": 3885
+								"id": 3892
 							}
 						},
 						{
@@ -41786,7 +41729,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getPlugin",
-										"id": 3894
+										"id": 3901
 									}
 								},
 								{
@@ -41815,7 +41758,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getPlugin",
-										"id": 3894
+										"id": 3901
 									}
 								},
 								{
@@ -41840,12 +41783,12 @@
 									"type": {
 										"type": "reference",
 										"name": "ObjectInterface",
-										"id": 3504
+										"id": 3511
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getPlugin",
-										"id": 3894
+										"id": 3901
 									}
 								},
 								{
@@ -41870,12 +41813,12 @@
 									"type": {
 										"type": "reference",
 										"name": "TddInterface",
-										"id": 3551
+										"id": 3558
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getPlugin",
-										"id": 3894
+										"id": 3901
 									}
 								},
 								{
@@ -41900,12 +41843,12 @@
 									"type": {
 										"type": "reference",
 										"name": "BddInterface",
-										"id": 3628
+										"id": 3635
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getPlugin",
-										"id": 3894
+										"id": 3901
 									}
 								},
 								{
@@ -41930,12 +41873,12 @@
 									"type": {
 										"type": "reference",
 										"name": "BenchmarkInterface",
-										"id": 3743
+										"id": 3750
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getPlugin",
-										"id": 3894
+										"id": 3901
 									}
 								},
 								{
@@ -41973,7 +41916,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getPlugin",
-										"id": 3894
+										"id": 3901
 									}
 								}
 							],
@@ -42022,7 +41965,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.getPlugin",
-								"id": 3894
+								"id": 3901
 							}
 						},
 						{
@@ -42097,7 +42040,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "BaseExecutor.loadScript",
-										"id": 3864
+										"id": 3871
 									}
 								}
 							],
@@ -42111,7 +42054,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "BaseExecutor.loadScript",
-								"id": 3864
+								"id": 3871
 							}
 						},
 						{
@@ -42169,12 +42112,12 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.log",
-										"id": 3912
+										"id": 3919
 									},
 									"implementationOf": {
 										"type": "reference",
 										"name": "Executor.log",
-										"id": 3808
+										"id": 3815
 									}
 								}
 							],
@@ -42188,12 +42131,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.log",
-								"id": 3912
+								"id": 3919
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.log",
-								"id": 3807
+								"id": 3814
 							}
 						},
 						{
@@ -42269,7 +42212,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Listener",
-												"id": 3989,
+												"id": 3996,
 												"typeArguments": [
 													{
 														"type": "unknown",
@@ -42286,12 +42229,12 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.on",
-										"id": 3915
+										"id": 3922
 									},
 									"implementationOf": {
 										"type": "reference",
 										"name": "Executor.on",
-										"id": 3811
+										"id": 3818
 									}
 								},
 								{
@@ -42310,7 +42253,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Listener",
-												"id": 3989,
+												"id": 3996,
 												"typeArguments": [
 													{
 														"type": "reflection",
@@ -42393,12 +42336,12 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.on",
-										"id": 3915
+										"id": 3922
 									},
 									"implementationOf": {
 										"type": "reference",
 										"name": "Executor.on",
-										"id": 3815
+										"id": 3822
 									}
 								}
 							],
@@ -42422,12 +42365,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.on",
-								"id": 3915
+								"id": 3922
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.on",
-								"id": 3810
+								"id": 3817
 							}
 						},
 						{
@@ -42481,7 +42424,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.registerInterface",
-										"id": 3925
+										"id": 3932
 									}
 								}
 							],
@@ -42495,7 +42438,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.registerInterface",
-								"id": 3925
+								"id": 3932
 							}
 						},
 						{
@@ -42531,7 +42474,7 @@
 											"type": {
 												"type": "reference",
 												"name": "LoaderInit",
-												"id": 4026
+												"id": 4033
 											}
 										}
 									],
@@ -42542,7 +42485,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.registerLoader",
-										"id": 3929
+										"id": 3936
 									}
 								}
 							],
@@ -42556,7 +42499,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.registerLoader",
-								"id": 3929
+								"id": 3936
 							}
 						},
 						{
@@ -42642,7 +42585,7 @@
 											"type": {
 												"type": "reference",
 												"name": "PluginInitializer",
-												"id": 4032,
+												"id": 4039,
 												"typeArguments": [
 													{
 														"type": "unknown",
@@ -42659,7 +42602,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.registerPlugin",
-										"id": 3932
+										"id": 3939
 									}
 								},
 								{
@@ -42689,7 +42632,7 @@
 											"type": {
 												"type": "reference",
 												"name": "PluginInitializer",
-												"id": 4032
+												"id": 4039
 											}
 										}
 									],
@@ -42700,7 +42643,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.registerPlugin",
-										"id": 3932
+										"id": 3939
 									}
 								}
 							],
@@ -42724,7 +42667,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.registerPlugin",
-								"id": 3932
+								"id": 3939
 							}
 						},
 						{
@@ -42771,7 +42714,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterInitializer",
-												"id": 4039
+												"id": 4046
 											}
 										}
 									],
@@ -42782,7 +42725,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.registerReporter",
-										"id": 3941
+										"id": 3948
 									}
 								}
 							],
@@ -42796,7 +42739,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.registerReporter",
-								"id": 3941
+								"id": 3948
 							}
 						},
 						{
@@ -42832,7 +42775,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.run",
-										"id": 3945
+										"id": 3952
 									}
 								}
 							],
@@ -42846,7 +42789,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.run",
-								"id": 3945
+								"id": 3952
 							}
 						}
 					],
@@ -42936,22 +42879,22 @@
 						{
 							"type": "reference",
 							"name": "BaseExecutor",
-							"id": 3820,
+							"id": 3827,
 							"typeArguments": [
 								{
 									"type": "reference",
 									"name": "Events",
-									"id": 4004
+									"id": 4011
 								},
 								{
 									"type": "reference",
 									"name": "Config",
-									"id": 4098
+									"id": 4105
 								},
 								{
 									"type": "reference",
 									"name": "Plugins",
-									"id": 4021
+									"id": 4028
 								}
 							]
 						}
@@ -42960,7 +42903,7 @@
 						{
 							"type": "reference",
 							"name": "Executor",
-							"id": 3780
+							"id": 3787
 						}
 					]
 				},
@@ -43049,7 +42992,7 @@
 			]
 		},
 		{
-			"id": 3779,
+			"id": 3786,
 			"name": "\"lib/executors/Executor\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -43060,7 +43003,7 @@
 			"originalName": "src/lib/executors/Executor.ts",
 			"children": [
 				{
-					"id": 3820,
+					"id": 3827,
 					"name": "BaseExecutor",
 					"kind": 128,
 					"kindString": "Class",
@@ -43075,7 +43018,7 @@
 					},
 					"typeParameter": [
 						{
-							"id": 3821,
+							"id": 3828,
 							"name": "E",
 							"kind": 131072,
 							"kindString": "Type parameter",
@@ -43083,11 +43026,11 @@
 							"type": {
 								"type": "reference",
 								"name": "Events",
-								"id": 4004
+								"id": 4011
 							}
 						},
 						{
-							"id": 3822,
+							"id": 3829,
 							"name": "C",
 							"kind": 131072,
 							"kindString": "Type parameter",
@@ -43095,11 +43038,11 @@
 							"type": {
 								"type": "reference",
 								"name": "Config",
-								"id": 4098
+								"id": 4105
 							}
 						},
 						{
-							"id": 3823,
+							"id": 3830,
 							"name": "P",
 							"kind": 131072,
 							"kindString": "Type parameter",
@@ -43107,13 +43050,13 @@
 							"type": {
 								"type": "reference",
 								"name": "Plugins",
-								"id": 4021
+								"id": 4028
 							}
 						}
 					],
 					"children": [
 						{
-							"id": 3850,
+							"id": 3857,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -43123,14 +43066,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3851,
+									"id": 3858,
 									"name": "new BaseExecutor",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3852,
+											"id": 3859,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -43147,7 +43090,7 @@
 													{
 														"type": "reflection",
 														"declaration": {
-															"id": 3853,
+															"id": 3860,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
@@ -43161,7 +43104,7 @@
 									"type": {
 										"type": "reference",
 										"name": "BaseExecutor",
-										"id": 3820
+										"id": 3827
 									}
 								}
 							],
@@ -43174,7 +43117,7 @@
 							]
 						},
 						{
-							"id": 3824,
+							"id": 3831,
 							"name": "_config",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43196,12 +43139,12 @@
 								"constraint": {
 									"type": "reference",
 									"name": "Config",
-									"id": 4098
+									"id": 4105
 								}
 							}
 						},
 						{
-							"id": 3827,
+							"id": 3834,
 							"name": "_errorFormatter",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43233,7 +43176,7 @@
 							}
 						},
 						{
-							"id": 3826,
+							"id": 3833,
 							"name": "_events",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43254,7 +43197,7 @@
 								"elementType": {
 									"type": "reference",
 									"name": "InternEvent",
-									"id": 3985,
+									"id": 3992,
 									"typeArguments": [
 										{
 											"type": "typeParameter",
@@ -43262,7 +43205,7 @@
 											"constraint": {
 												"type": "reference",
 												"name": "Events",
-												"id": 4004
+												"id": 4011
 											}
 										}
 									]
@@ -43270,7 +43213,7 @@
 							}
 						},
 						{
-							"id": 3830,
+							"id": 3837,
 							"name": "_hasEmittedErrors",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43293,7 +43236,7 @@
 							"defaultValue": "false"
 						},
 						{
-							"id": 3828,
+							"id": 3835,
 							"name": "_hasSuiteErrors",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43316,7 +43259,7 @@
 							"defaultValue": "false"
 						},
 						{
-							"id": 3829,
+							"id": 3836,
 							"name": "_hasTestErrors",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43339,7 +43282,7 @@
 							"defaultValue": "false"
 						},
 						{
-							"id": 3839,
+							"id": 3846,
 							"name": "_listeners",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43358,21 +43301,21 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3840,
+									"id": 3847,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"indexSignature": [
 										{
-											"id": 3841,
+											"id": 3848,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 3842,
+													"id": 3849,
 													"name": "event",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -43388,7 +43331,7 @@
 												"elementType": {
 													"type": "reference",
 													"name": "Listener",
-													"id": 3989,
+													"id": 3996,
 													"typeArguments": [
 														{
 															"type": "intrinsic",
@@ -43410,7 +43353,7 @@
 							}
 						},
 						{
-							"id": 3831,
+							"id": 3838,
 							"name": "_loader",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43429,11 +43372,11 @@
 							"type": {
 								"type": "reference",
 								"name": "Loader",
-								"id": 4023
+								"id": 4030
 							}
 						},
 						{
-							"id": 3833,
+							"id": 3840,
 							"name": "_loaderInit",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43459,7 +43402,7 @@
 											{
 												"type": "reference",
 												"name": "Loader",
-												"id": 4023
+												"id": 4030
 											}
 										]
 									},
@@ -43471,7 +43414,7 @@
 							}
 						},
 						{
-							"id": 3832,
+							"id": 3839,
 							"name": "_loaderOptions",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43493,7 +43436,7 @@
 							}
 						},
 						{
-							"id": 3838,
+							"id": 3845,
 							"name": "_loadingPluginOptions",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43524,7 +43467,7 @@
 							}
 						},
 						{
-							"id": 3834,
+							"id": 3841,
 							"name": "_loadingPlugins",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43545,14 +43488,14 @@
 								"elementType": {
 									"type": "reflection",
 									"declaration": {
-										"id": 3835,
+										"id": 3842,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
 										"flags": {},
 										"children": [
 											{
-												"id": 3837,
+												"id": 3844,
 												"name": "init",
 												"kind": 32,
 												"kindString": "Variable",
@@ -43578,7 +43521,7 @@
 												}
 											},
 											{
-												"id": 3836,
+												"id": 3843,
 												"name": "name",
 												"kind": 32,
 												"kindString": "Variable",
@@ -43603,8 +43546,8 @@
 												"title": "Variables",
 												"kind": 32,
 												"children": [
-													3837,
-													3836
+													3844,
+													3843
 												]
 											}
 										],
@@ -43620,7 +43563,7 @@
 							}
 						},
 						{
-							"id": 3843,
+							"id": 3850,
 							"name": "_plugins",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43639,21 +43582,21 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3844,
+									"id": 3851,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"indexSignature": [
 										{
-											"id": 3845,
+											"id": 3852,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 3846,
+													"id": 3853,
 													"name": "name",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -43681,7 +43624,7 @@
 							}
 						},
 						{
-							"id": 3847,
+							"id": 3854,
 							"name": "_reporters",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43702,12 +43645,12 @@
 								"elementType": {
 									"type": "reference",
 									"name": "Reporter",
-									"id": 4042
+									"id": 4049
 								}
 							}
 						},
 						{
-							"id": 3849,
+							"id": 3856,
 							"name": "_reportersInitialized",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43729,7 +43672,7 @@
 							}
 						},
 						{
-							"id": 3825,
+							"id": 3832,
 							"name": "_rootSuite",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43748,11 +43691,11 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							}
 						},
 						{
-							"id": 3848,
+							"id": 3855,
 							"name": "_runTask",
 							"kind": 1024,
 							"kindString": "Property",
@@ -43789,7 +43732,7 @@
 							}
 						},
 						{
-							"id": 3856,
+							"id": 3863,
 							"name": "config",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -43802,7 +43745,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3857,
+									"id": 3864,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -43826,11 +43769,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.config",
-								"id": 3781
+								"id": 3788
 							}
 						},
 						{
-							"id": 3854,
+							"id": 3861,
 							"name": "environment",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -43843,7 +43786,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3855,
+									"id": 3862,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -43867,7 +43810,7 @@
 							]
 						},
 						{
-							"id": 3858,
+							"id": 3865,
 							"name": "suites",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -43880,7 +43823,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 3859,
+									"id": 3866,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -43893,7 +43836,7 @@
 										"elementType": {
 											"type": "reference",
 											"name": "Suite",
-											"id": 3400
+											"id": 3407
 										}
 									}
 								}
@@ -43908,11 +43851,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.suites",
-								"id": 3782
+								"id": 3789
 							}
 						},
 						{
-							"id": 3947,
+							"id": 3954,
 							"name": "_afterRun",
 							"kind": 2048,
 							"kindString": "Method",
@@ -43923,7 +43866,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3948,
+									"id": 3955,
 									"name": "_afterRun",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -43952,7 +43895,7 @@
 							]
 						},
 						{
-							"id": 3949,
+							"id": 3956,
 							"name": "_assignPlugin",
 							"kind": 2048,
 							"kindString": "Method",
@@ -43963,7 +43906,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3950,
+									"id": 3957,
 									"name": "_assignPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -43973,7 +43916,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3951,
+											"id": 3958,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -43984,7 +43927,7 @@
 											}
 										},
 										{
-											"id": 3952,
+											"id": 3959,
 											"name": "plugin",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -44010,7 +43953,7 @@
 							]
 						},
 						{
-							"id": 3953,
+							"id": 3960,
 							"name": "_beforeRun",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44021,7 +43964,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3954,
+									"id": 3961,
 									"name": "_beforeRun",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44051,7 +43994,7 @@
 							]
 						},
 						{
-							"id": 3957,
+							"id": 3964,
 							"name": "_drainEventQueue",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44062,7 +44005,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3958,
+									"id": 3965,
 									"name": "_drainEventQueue",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44091,7 +44034,7 @@
 							]
 						},
 						{
-							"id": 3959,
+							"id": 3966,
 							"name": "_emitCoverage",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44102,14 +44045,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3960,
+									"id": 3967,
 									"name": "_emitCoverage",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3961,
+											"id": 3968,
 											"name": "source",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -44161,7 +44104,7 @@
 							]
 						},
 						{
-							"id": 3955,
+							"id": 3962,
 							"name": "_initReporters",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44172,7 +44115,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3956,
+									"id": 3963,
 									"name": "_initReporters",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44201,7 +44144,7 @@
 							]
 						},
 						{
-							"id": 3962,
+							"id": 3969,
 							"name": "_loadLoader",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44212,7 +44155,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3963,
+									"id": 3970,
 									"name": "_loadLoader",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44241,7 +44184,7 @@
 							]
 						},
 						{
-							"id": 3966,
+							"id": 3973,
 							"name": "_loadPlugins",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44252,7 +44195,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3967,
+									"id": 3974,
 									"name": "_loadPlugins",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44281,7 +44224,7 @@
 							]
 						},
 						{
-							"id": 3964,
+							"id": 3971,
 							"name": "_loadPluginsWithLoader",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44292,7 +44235,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3965,
+									"id": 3972,
 									"name": "_loadPluginsWithLoader",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44321,7 +44264,7 @@
 							]
 						},
 						{
-							"id": 3968,
+							"id": 3975,
 							"name": "_loadScripts",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44332,7 +44275,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3969,
+									"id": 3976,
 									"name": "_loadScripts",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44342,7 +44285,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3970,
+											"id": 3977,
 											"name": "scripts",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -44352,12 +44295,12 @@
 												"elementType": {
 													"type": "reference",
 													"name": "PluginDescriptor",
-													"id": 4163
+													"id": 4170
 												}
 											}
 										},
 										{
-											"id": 3971,
+											"id": 3978,
 											"name": "loader",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -44365,21 +44308,21 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 3972,
+													"id": 3979,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"signatures": [
 														{
-															"id": 3973,
+															"id": 3980,
 															"name": "__call",
 															"kind": 4096,
 															"kindString": "Call signature",
 															"flags": {},
 															"parameters": [
 																{
-																	"id": 3974,
+																	"id": 3981,
 																	"name": "script",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -44434,7 +44377,7 @@
 							]
 						},
 						{
-							"id": 3975,
+							"id": 3982,
 							"name": "_loadSuites",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44445,7 +44388,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3976,
+									"id": 3983,
 									"name": "_loadSuites",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44474,7 +44417,7 @@
 							]
 						},
 						{
-							"id": 3977,
+							"id": 3984,
 							"name": "_processOption",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44485,7 +44428,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3978,
+									"id": 3985,
 									"name": "_processOption",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44495,7 +44438,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3979,
+											"id": 3986,
 											"name": "key",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -44509,13 +44452,13 @@
 													"constraint": {
 														"type": "reference",
 														"name": "Config",
-														"id": 4098
+														"id": 4105
 													}
 												}
 											}
 										},
 										{
-											"id": 3980,
+											"id": 3987,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -44541,7 +44484,7 @@
 							]
 						},
 						{
-							"id": 3981,
+							"id": 3988,
 							"name": "_resolveConfig",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44552,7 +44495,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3982,
+									"id": 3989,
 									"name": "_resolveConfig",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44581,7 +44524,7 @@
 							]
 						},
 						{
-							"id": 3983,
+							"id": 3990,
 							"name": "_runTests",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44592,7 +44535,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3984,
+									"id": 3991,
 									"name": "_runTests",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44621,7 +44564,7 @@
 							]
 						},
 						{
-							"id": 3867,
+							"id": 3874,
 							"name": "addSuite",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44631,7 +44574,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3868,
+									"id": 3875,
 									"name": "addSuite",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44642,7 +44585,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3869,
+											"id": 3876,
 											"name": "factory",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -44653,21 +44596,21 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 3870,
+													"id": 3877,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"signatures": [
 														{
-															"id": 3871,
+															"id": 3878,
 															"name": "__call",
 															"kind": 4096,
 															"kindString": "Call signature",
 															"flags": {},
 															"parameters": [
 																{
-																	"id": 3872,
+																	"id": 3879,
 																	"name": "parentSuite",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -44675,7 +44618,7 @@
 																	"type": {
 																		"type": "reference",
 																		"name": "Suite",
-																		"id": 3400
+																		"id": 3407
 																	}
 																}
 															],
@@ -44712,11 +44655,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.addSuite",
-								"id": 3783
+								"id": 3790
 							}
 						},
 						{
-							"id": 3873,
+							"id": 3880,
 							"name": "configure",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44726,7 +44669,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3874,
+									"id": 3881,
 									"name": "configure",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44736,7 +44679,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3875,
+											"id": 3882,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -44744,7 +44687,7 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 3876,
+													"id": 3883,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
@@ -44776,11 +44719,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.configure",
-								"id": 3789
+								"id": 3796
 							}
 						},
 						{
-							"id": 3877,
+							"id": 3884,
 							"name": "emit",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44790,7 +44733,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3878,
+									"id": 3885,
 									"name": "emit",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44802,7 +44745,7 @@
 									},
 									"typeParameter": [
 										{
-											"id": 3879,
+											"id": 3886,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -44810,13 +44753,13 @@
 											"type": {
 												"type": "reference",
 												"name": "NoDataEvents",
-												"id": 4043
+												"id": 4050
 											}
 										}
 									],
 									"parameters": [
 										{
-											"id": 3880,
+											"id": 3887,
 											"name": "eventName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -44830,7 +44773,7 @@
 												"constraint": {
 													"type": "reference",
 													"name": "NoDataEvents",
-													"id": 4043
+													"id": 4050
 												}
 											}
 										}
@@ -44848,18 +44791,18 @@
 									"implementationOf": {
 										"type": "reference",
 										"name": "Executor.emit",
-										"id": 3796
+										"id": 3803
 									}
 								},
 								{
-									"id": 3881,
+									"id": 3888,
 									"name": "emit",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 3882,
+											"id": 3889,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -44873,7 +44816,7 @@
 													"constraint": {
 														"type": "reference",
 														"name": "Events",
-														"id": 4004
+														"id": 4011
 													}
 												}
 											}
@@ -44881,7 +44824,7 @@
 									],
 									"parameters": [
 										{
-											"id": 3883,
+											"id": 3890,
 											"name": "eventName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -44898,14 +44841,14 @@
 														"constraint": {
 															"type": "reference",
 															"name": "Events",
-															"id": 4004
+															"id": 4011
 														}
 													}
 												}
 											}
 										},
 										{
-											"id": 3884,
+											"id": 3891,
 											"name": "data",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -44948,11 +44891,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.emit",
-								"id": 3795
+								"id": 3802
 							}
 						},
 						{
-							"id": 3860,
+							"id": 3867,
 							"name": "formatError",
 							"kind": 2048,
 							"kindString": "Method",
@@ -44962,7 +44905,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3861,
+									"id": 3868,
 									"name": "formatError",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -44972,7 +44915,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3862,
+											"id": 3869,
 											"name": "error",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -44983,7 +44926,7 @@
 											}
 										},
 										{
-											"id": 3863,
+											"id": 3870,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45004,7 +44947,7 @@
 									"implementationOf": {
 										"type": "reference",
 										"name": "Executor.formatError",
-										"id": 3804
+										"id": 3811
 									}
 								}
 							],
@@ -45018,11 +44961,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.formatError",
-								"id": 3803
+								"id": 3810
 							}
 						},
 						{
-							"id": 3885,
+							"id": 3892,
 							"name": "getInterface",
 							"kind": 2048,
 							"kindString": "Method",
@@ -45032,7 +44975,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3886,
+									"id": 3893,
 									"name": "getInterface",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -45044,7 +44987,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3887,
+											"id": 3894,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45061,18 +45004,18 @@
 									"type": {
 										"type": "reference",
 										"name": "ObjectInterface",
-										"id": 3504
+										"id": 3511
 									}
 								},
 								{
-									"id": 3888,
+									"id": 3895,
 									"name": "getInterface",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3889,
+											"id": 3896,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45086,18 +45029,18 @@
 									"type": {
 										"type": "reference",
 										"name": "TddInterface",
-										"id": 3551
+										"id": 3558
 									}
 								},
 								{
-									"id": 3890,
+									"id": 3897,
 									"name": "getInterface",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3891,
+											"id": 3898,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45111,18 +45054,18 @@
 									"type": {
 										"type": "reference",
 										"name": "BddInterface",
-										"id": 3628
+										"id": 3635
 									}
 								},
 								{
-									"id": 3892,
+									"id": 3899,
 									"name": "getInterface",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3893,
+											"id": 3900,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45136,7 +45079,7 @@
 									"type": {
 										"type": "reference",
 										"name": "BenchmarkInterface",
-										"id": 3743
+										"id": 3750
 									}
 								}
 							],
@@ -45169,7 +45112,7 @@
 							]
 						},
 						{
-							"id": 3894,
+							"id": 3901,
 							"name": "getPlugin",
 							"kind": 2048,
 							"kindString": "Method",
@@ -45179,7 +45122,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3895,
+									"id": 3902,
 									"name": "getPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -45190,7 +45133,7 @@
 									},
 									"typeParameter": [
 										{
-											"id": 3896,
+											"id": 3903,
 											"name": "Y",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -45204,7 +45147,7 @@
 													"constraint": {
 														"type": "reference",
 														"name": "Plugins",
-														"id": 4021
+														"id": 4028
 													}
 												}
 											}
@@ -45212,7 +45155,7 @@
 									],
 									"parameters": [
 										{
-											"id": 3897,
+											"id": 3904,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45232,14 +45175,14 @@
 														"constraint": {
 															"type": "reference",
 															"name": "Plugins",
-															"id": 4021
+															"id": 4028
 														}
 													}
 												}
 											}
 										},
 										{
-											"id": 3898,
+											"id": 3905,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45259,14 +45202,14 @@
 									}
 								},
 								{
-									"id": 3899,
+									"id": 3906,
 									"name": "getPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3900,
+											"id": 3907,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45283,14 +45226,14 @@
 									}
 								},
 								{
-									"id": 3901,
+									"id": 3908,
 									"name": "getPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3902,
+											"id": 3909,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45304,18 +45247,18 @@
 									"type": {
 										"type": "reference",
 										"name": "ObjectInterface",
-										"id": 3504
+										"id": 3511
 									}
 								},
 								{
-									"id": 3903,
+									"id": 3910,
 									"name": "getPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3904,
+											"id": 3911,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45329,18 +45272,18 @@
 									"type": {
 										"type": "reference",
 										"name": "TddInterface",
-										"id": 3551
+										"id": 3558
 									}
 								},
 								{
-									"id": 3905,
+									"id": 3912,
 									"name": "getPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3906,
+											"id": 3913,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45354,18 +45297,18 @@
 									"type": {
 										"type": "reference",
 										"name": "BddInterface",
-										"id": 3628
+										"id": 3635
 									}
 								},
 								{
-									"id": 3907,
+									"id": 3914,
 									"name": "getPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3908,
+											"id": 3915,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45379,18 +45322,18 @@
 									"type": {
 										"type": "reference",
 										"name": "BenchmarkInterface",
-										"id": 3743
+										"id": 3750
 									}
 								},
 								{
-									"id": 3909,
+									"id": 3916,
 									"name": "getPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 3910,
+											"id": 3917,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -45399,7 +45342,7 @@
 									],
 									"parameters": [
 										{
-											"id": 3911,
+											"id": 3918,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45460,7 +45403,7 @@
 							]
 						},
 						{
-							"id": 3864,
+							"id": 3871,
 							"name": "loadScript",
 							"kind": 2048,
 							"kindString": "Method",
@@ -45471,7 +45414,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3865,
+									"id": 3872,
 									"name": "loadScript",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -45481,7 +45424,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3866,
+											"id": 3873,
 											"name": "script",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45528,7 +45471,7 @@
 							]
 						},
 						{
-							"id": 3912,
+							"id": 3919,
 							"name": "log",
 							"kind": 2048,
 							"kindString": "Method",
@@ -45538,7 +45481,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3913,
+									"id": 3920,
 									"name": "log",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -45550,7 +45493,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3914,
+											"id": 3921,
 											"name": "args",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45582,7 +45525,7 @@
 									"implementationOf": {
 										"type": "reference",
 										"name": "Executor.log",
-										"id": 3808
+										"id": 3815
 									}
 								}
 							],
@@ -45596,11 +45539,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.log",
-								"id": 3807
+								"id": 3814
 							}
 						},
 						{
-							"id": 3915,
+							"id": 3922,
 							"name": "on",
 							"kind": 2048,
 							"kindString": "Method",
@@ -45610,7 +45553,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3916,
+									"id": 3923,
 									"name": "on",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -45622,7 +45565,7 @@
 									},
 									"typeParameter": [
 										{
-											"id": 3917,
+											"id": 3924,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -45636,7 +45579,7 @@
 													"constraint": {
 														"type": "reference",
 														"name": "Events",
-														"id": 4004
+														"id": 4011
 													}
 												}
 											}
@@ -45644,7 +45587,7 @@
 									],
 									"parameters": [
 										{
-											"id": 3918,
+											"id": 3925,
 											"name": "eventName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45664,14 +45607,14 @@
 														"constraint": {
 															"type": "reference",
 															"name": "Events",
-															"id": 4004
+															"id": 4011
 														}
 													}
 												}
 											}
 										},
 										{
-											"id": 3919,
+											"id": 3926,
 											"name": "listener",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45682,7 +45625,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Listener",
-												"id": 3989,
+												"id": 3996,
 												"typeArguments": [
 													{
 														"type": "unknown",
@@ -45698,14 +45641,14 @@
 									}
 								},
 								{
-									"id": 3920,
+									"id": 3927,
 									"name": "on",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3921,
+											"id": 3928,
 											"name": "listener",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45713,19 +45656,19 @@
 											"type": {
 												"type": "reference",
 												"name": "Listener",
-												"id": 3989,
+												"id": 3996,
 												"typeArguments": [
 													{
 														"type": "reflection",
 														"declaration": {
-															"id": 3922,
+															"id": 3929,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 3924,
+																	"id": 3931,
 																	"name": "data",
 																	"kind": 32,
 																	"kindString": "Variable",
@@ -45746,7 +45689,7 @@
 																	}
 																},
 																{
-																	"id": 3923,
+																	"id": 3930,
 																	"name": "name",
 																	"kind": 32,
 																	"kindString": "Variable",
@@ -45771,8 +45714,8 @@
 																	"title": "Variables",
 																	"kind": 32,
 																	"children": [
-																		3924,
-																		3923
+																		3931,
+																		3930
 																	]
 																}
 															],
@@ -45796,7 +45739,7 @@
 									"implementationOf": {
 										"type": "reference",
 										"name": "Executor.on",
-										"id": 3815
+										"id": 3822
 									}
 								}
 							],
@@ -45820,11 +45763,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.on",
-								"id": 3810
+								"id": 3817
 							}
 						},
 						{
-							"id": 3925,
+							"id": 3932,
 							"name": "registerInterface",
 							"kind": 2048,
 							"kindString": "Method",
@@ -45834,7 +45777,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3926,
+									"id": 3933,
 									"name": "registerInterface",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -45845,7 +45788,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3927,
+											"id": 3934,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45856,7 +45799,7 @@
 											}
 										},
 										{
-											"id": 3928,
+											"id": 3935,
 											"name": "iface",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45882,7 +45825,7 @@
 							]
 						},
 						{
-							"id": 3929,
+							"id": 3936,
 							"name": "registerLoader",
 							"kind": 2048,
 							"kindString": "Method",
@@ -45892,7 +45835,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3930,
+									"id": 3937,
 									"name": "registerLoader",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -45903,7 +45846,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3931,
+											"id": 3938,
 											"name": "init",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45914,7 +45857,7 @@
 											"type": {
 												"type": "reference",
 												"name": "LoaderInit",
-												"id": 4026
+												"id": 4033
 											}
 										}
 									],
@@ -45933,7 +45876,7 @@
 							]
 						},
 						{
-							"id": 3932,
+							"id": 3939,
 							"name": "registerPlugin",
 							"kind": 2048,
 							"kindString": "Method",
@@ -45943,7 +45886,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3933,
+									"id": 3940,
 									"name": "registerPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -45954,7 +45897,7 @@
 									},
 									"typeParameter": [
 										{
-											"id": 3934,
+											"id": 3941,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -45968,7 +45911,7 @@
 													"constraint": {
 														"type": "reference",
 														"name": "Plugins",
-														"id": 4021
+														"id": 4028
 													}
 												}
 											}
@@ -45976,7 +45919,7 @@
 									],
 									"parameters": [
 										{
-											"id": 3935,
+											"id": 3942,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -45993,14 +45936,14 @@
 														"constraint": {
 															"type": "reference",
 															"name": "Plugins",
-															"id": 4021
+															"id": 4028
 														}
 													}
 												}
 											}
 										},
 										{
-											"id": 3936,
+											"id": 3943,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -46014,7 +45957,7 @@
 											}
 										},
 										{
-											"id": 3937,
+											"id": 3944,
 											"name": "init",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -46025,7 +45968,7 @@
 											"type": {
 												"type": "reference",
 												"name": "PluginInitializer",
-												"id": 4032,
+												"id": 4039,
 												"typeArguments": [
 													{
 														"type": "unknown",
@@ -46041,14 +45984,14 @@
 									}
 								},
 								{
-									"id": 3938,
+									"id": 3945,
 									"name": "registerPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3939,
+											"id": 3946,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -46059,7 +46002,7 @@
 											}
 										},
 										{
-											"id": 3940,
+											"id": 3947,
 											"name": "init",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -46067,7 +46010,7 @@
 											"type": {
 												"type": "reference",
 												"name": "PluginInitializer",
-												"id": 4032
+												"id": 4039
 											}
 										}
 									],
@@ -46096,7 +46039,7 @@
 							]
 						},
 						{
-							"id": 3941,
+							"id": 3948,
 							"name": "registerReporter",
 							"kind": 2048,
 							"kindString": "Method",
@@ -46106,7 +46049,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3942,
+									"id": 3949,
 									"name": "registerReporter",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -46117,7 +46060,7 @@
 									},
 									"parameters": [
 										{
-											"id": 3943,
+											"id": 3950,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -46131,7 +46074,7 @@
 											}
 										},
 										{
-											"id": 3944,
+											"id": 3951,
 											"name": "init",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -46139,7 +46082,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterInitializer",
-												"id": 4039
+												"id": 4046
 											}
 										}
 									],
@@ -46158,7 +46101,7 @@
 							]
 						},
 						{
-							"id": 3945,
+							"id": 3952,
 							"name": "run",
 							"kind": 2048,
 							"kindString": "Method",
@@ -46168,7 +46111,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3946,
+									"id": 3953,
 									"name": "run",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -46203,73 +46146,73 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								3850
+								3857
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3824,
-								3827,
-								3826,
-								3830,
-								3828,
-								3829,
-								3839,
 								3831,
-								3833,
-								3832,
-								3838,
 								3834,
-								3843,
-								3847,
-								3849,
-								3825,
-								3848
+								3833,
+								3837,
+								3835,
+								3836,
+								3846,
+								3838,
+								3840,
+								3839,
+								3845,
+								3841,
+								3850,
+								3854,
+								3856,
+								3832,
+								3855
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								3856,
-								3854,
-								3858
+								3863,
+								3861,
+								3865
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								3947,
-								3949,
-								3953,
-								3957,
-								3959,
-								3955,
-								3962,
-								3966,
+								3954,
+								3956,
+								3960,
 								3964,
-								3968,
+								3966,
+								3962,
+								3969,
+								3973,
+								3971,
 								3975,
-								3977,
-								3981,
-								3983,
+								3982,
+								3984,
+								3988,
+								3990,
+								3874,
+								3880,
+								3884,
 								3867,
-								3873,
-								3877,
-								3860,
-								3885,
-								3894,
-								3864,
-								3912,
-								3915,
-								3925,
-								3929,
+								3892,
+								3901,
+								3871,
+								3919,
+								3922,
 								3932,
-								3941,
-								3945
+								3936,
+								3939,
+								3948,
+								3952
 							]
 						}
 					],
@@ -46289,19 +46232,19 @@
 						{
 							"type": "reference",
 							"name": "Node",
-							"id": 2600
+							"id": 2607
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "Executor",
-							"id": 3780
+							"id": 3787
 						}
 					]
 				},
 				{
-					"id": 3993,
+					"id": 4000,
 					"name": "CoverageMessage",
 					"kind": 256,
 					"kindString": "Interface",
@@ -46314,7 +46257,7 @@
 					},
 					"children": [
 						{
-							"id": 3996,
+							"id": 4003,
 							"name": "coverage",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46335,7 +46278,7 @@
 							}
 						},
 						{
-							"id": 3994,
+							"id": 4001,
 							"name": "sessionId",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46366,7 +46309,7 @@
 							}
 						},
 						{
-							"id": 3995,
+							"id": 4002,
 							"name": "source",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46402,9 +46345,9 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3996,
-								3994,
-								3995
+								4003,
+								4001,
+								4002
 							]
 						}
 					],
@@ -46417,7 +46360,7 @@
 					]
 				},
 				{
-					"id": 3997,
+					"id": 4004,
 					"name": "DeprecationMessage",
 					"kind": 256,
 					"kindString": "Interface",
@@ -46427,7 +46370,7 @@
 					},
 					"children": [
 						{
-							"id": 4000,
+							"id": 4007,
 							"name": "message",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46458,7 +46401,7 @@
 							}
 						},
 						{
-							"id": 3998,
+							"id": 4005,
 							"name": "original",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46479,7 +46422,7 @@
 							}
 						},
 						{
-							"id": 3999,
+							"id": 4006,
 							"name": "replacement",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46515,9 +46458,9 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4000,
-								3998,
-								3999
+								4007,
+								4005,
+								4006
 							]
 						}
 					],
@@ -46530,7 +46473,7 @@
 					]
 				},
 				{
-					"id": 4004,
+					"id": 4011,
 					"name": "Events",
 					"kind": 256,
 					"kindString": "Interface",
@@ -46543,7 +46486,7 @@
 					},
 					"children": [
 						{
-							"id": 4005,
+							"id": 4012,
 							"name": "*",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46564,11 +46507,11 @@
 							"type": {
 								"type": "reference",
 								"name": "ExecutorEvent",
-								"id": 4001
+								"id": 4008
 							}
 						},
 						{
-							"id": 4006,
+							"id": 4013,
 							"name": "afterRun",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46592,7 +46535,7 @@
 							}
 						},
 						{
-							"id": 4007,
+							"id": 4014,
 							"name": "beforeRun",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46616,7 +46559,7 @@
 							}
 						},
 						{
-							"id": 4008,
+							"id": 4015,
 							"name": "coverage",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46637,11 +46580,11 @@
 							"type": {
 								"type": "reference",
 								"name": "CoverageMessage",
-								"id": 3993
+								"id": 4000
 							}
 						},
 						{
-							"id": 4009,
+							"id": 4016,
 							"name": "deprecated",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46662,11 +46605,11 @@
 							"type": {
 								"type": "reference",
 								"name": "DeprecationMessage",
-								"id": 3997
+								"id": 4004
 							}
 						},
 						{
-							"id": 4010,
+							"id": 4017,
 							"name": "error",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46690,7 +46633,7 @@
 							}
 						},
 						{
-							"id": 4011,
+							"id": 4018,
 							"name": "log",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46714,7 +46657,7 @@
 							}
 						},
 						{
-							"id": 4012,
+							"id": 4019,
 							"name": "runEnd",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46738,7 +46681,7 @@
 							}
 						},
 						{
-							"id": 4013,
+							"id": 4020,
 							"name": "runStart",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46762,7 +46705,7 @@
 							}
 						},
 						{
-							"id": 4014,
+							"id": 4021,
 							"name": "suiteAdd",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46783,11 +46726,11 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							}
 						},
 						{
-							"id": 4015,
+							"id": 4022,
 							"name": "suiteEnd",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46808,11 +46751,11 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							}
 						},
 						{
-							"id": 4016,
+							"id": 4023,
 							"name": "suiteStart",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46833,11 +46776,11 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							}
 						},
 						{
-							"id": 4017,
+							"id": 4024,
 							"name": "testAdd",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46858,11 +46801,11 @@
 							"type": {
 								"type": "reference",
 								"name": "Test",
-								"id": 3317
+								"id": 3324
 							}
 						},
 						{
-							"id": 4018,
+							"id": 4025,
 							"name": "testEnd",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46883,11 +46826,11 @@
 							"type": {
 								"type": "reference",
 								"name": "Test",
-								"id": 3317
+								"id": 3324
 							}
 						},
 						{
-							"id": 4019,
+							"id": 4026,
 							"name": "testStart",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46908,11 +46851,11 @@
 							"type": {
 								"type": "reference",
 								"name": "Test",
-								"id": 3317
+								"id": 3324
 							}
 						},
 						{
-							"id": 4020,
+							"id": 4027,
 							"name": "warning",
 							"kind": 1024,
 							"kindString": "Property",
@@ -46941,13 +46884,6 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4005,
-								4006,
-								4007,
-								4008,
-								4009,
-								4010,
-								4011,
 								4012,
 								4013,
 								4014,
@@ -46956,7 +46892,14 @@
 								4017,
 								4018,
 								4019,
-								4020
+								4020,
+								4021,
+								4022,
+								4023,
+								4024,
+								4025,
+								4026,
+								4027
 							]
 						}
 					],
@@ -46971,12 +46914,12 @@
 						{
 							"type": "reference",
 							"name": "NodeEvents",
-							"id": 3256
+							"id": 3263
 						}
 					]
 				},
 				{
-					"id": 3780,
+					"id": 3787,
 					"name": "Executor",
 					"kind": 256,
 					"kindString": "Interface",
@@ -46989,7 +46932,7 @@
 					},
 					"children": [
 						{
-							"id": 3781,
+							"id": 3788,
 							"name": "config",
 							"kind": 1024,
 							"kindString": "Property",
@@ -47007,11 +46950,11 @@
 							"type": {
 								"type": "reference",
 								"name": "Config",
-								"id": 4098
+								"id": 4105
 							}
 						},
 						{
-							"id": 3782,
+							"id": 3789,
 							"name": "suites",
 							"kind": 1024,
 							"kindString": "Property",
@@ -47031,12 +46974,12 @@
 								"elementType": {
 									"type": "reference",
 									"name": "Suite",
-									"id": 3400
+									"id": 3407
 								}
 							}
 						},
 						{
-							"id": 3783,
+							"id": 3790,
 							"name": "addSuite",
 							"kind": 2048,
 							"kindString": "Method",
@@ -47046,14 +46989,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3784,
+									"id": 3791,
 									"name": "addSuite",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3785,
+											"id": 3792,
 											"name": "factory",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -47061,21 +47004,21 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 3786,
+													"id": 3793,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"signatures": [
 														{
-															"id": 3787,
+															"id": 3794,
 															"name": "__call",
 															"kind": 4096,
 															"kindString": "Call signature",
 															"flags": {},
 															"parameters": [
 																{
-																	"id": 3788,
+																	"id": 3795,
 																	"name": "parentSuite",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -47083,7 +47026,7 @@
 																	"type": {
 																		"type": "reference",
 																		"name": "Suite",
-																		"id": 3400
+																		"id": 3407
 																	}
 																}
 															],
@@ -47119,7 +47062,7 @@
 							]
 						},
 						{
-							"id": 3789,
+							"id": 3796,
 							"name": "configure",
 							"kind": 2048,
 							"kindString": "Method",
@@ -47129,14 +47072,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3790,
+									"id": 3797,
 									"name": "configure",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3791,
+											"id": 3798,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -47144,21 +47087,21 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 3792,
+													"id": 3799,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"indexSignature": [
 														{
-															"id": 3793,
+															"id": 3800,
 															"name": "__index",
 															"kind": 8192,
 															"kindString": "Index signature",
 															"flags": {},
 															"parameters": [
 																{
-																	"id": 3794,
+																	"id": 3801,
 																	"name": "key",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -47201,7 +47144,7 @@
 							]
 						},
 						{
-							"id": 3795,
+							"id": 3802,
 							"name": "emit",
 							"kind": 2048,
 							"kindString": "Method",
@@ -47211,14 +47154,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3796,
+									"id": 3803,
 									"name": "emit",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 3797,
+											"id": 3804,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -47226,13 +47169,13 @@
 											"type": {
 												"type": "reference",
 												"name": "NoDataEvents",
-												"id": 4043
+												"id": 4050
 											}
 										}
 									],
 									"parameters": [
 										{
-											"id": 3798,
+											"id": 3805,
 											"name": "eventName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -47243,7 +47186,7 @@
 												"constraint": {
 													"type": "reference",
 													"name": "NoDataEvents",
-													"id": 4043
+													"id": 4050
 												}
 											}
 										}
@@ -47260,14 +47203,14 @@
 									}
 								},
 								{
-									"id": 3799,
+									"id": 3806,
 									"name": "emit",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 3800,
+											"id": 3807,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -47284,7 +47227,7 @@
 									],
 									"parameters": [
 										{
-											"id": 3801,
+											"id": 3808,
 											"name": "eventName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -47303,7 +47246,7 @@
 											}
 										},
 										{
-											"id": 3802,
+											"id": 3809,
 											"name": "data",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -47340,7 +47283,7 @@
 							]
 						},
 						{
-							"id": 3803,
+							"id": 3810,
 							"name": "formatError",
 							"kind": 2048,
 							"kindString": "Method",
@@ -47350,14 +47293,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3804,
+									"id": 3811,
 									"name": "formatError",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3805,
+											"id": 3812,
 											"name": "error",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -47368,7 +47311,7 @@
 											}
 										},
 										{
-											"id": 3806,
+											"id": 3813,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -47397,7 +47340,7 @@
 							]
 						},
 						{
-							"id": 3807,
+							"id": 3814,
 							"name": "log",
 							"kind": 2048,
 							"kindString": "Method",
@@ -47407,14 +47350,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3808,
+									"id": 3815,
 									"name": "log",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3809,
+											"id": 3816,
 											"name": "args",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -47451,7 +47394,7 @@
 							]
 						},
 						{
-							"id": 3810,
+							"id": 3817,
 							"name": "on",
 							"kind": 2048,
 							"kindString": "Method",
@@ -47461,14 +47404,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3811,
+									"id": 3818,
 									"name": "on",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 3812,
+											"id": 3819,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -47485,7 +47428,7 @@
 									],
 									"parameters": [
 										{
-											"id": 3813,
+											"id": 3820,
 											"name": "eventName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -47504,7 +47447,7 @@
 											}
 										},
 										{
-											"id": 3814,
+											"id": 3821,
 											"name": "listener",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -47512,7 +47455,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Listener",
-												"id": 3989,
+												"id": 3996,
 												"typeArguments": [
 													{
 														"type": "unknown",
@@ -47528,14 +47471,14 @@
 									}
 								},
 								{
-									"id": 3815,
+									"id": 3822,
 									"name": "on",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3816,
+											"id": 3823,
 											"name": "listener",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -47543,19 +47486,19 @@
 											"type": {
 												"type": "reference",
 												"name": "Listener",
-												"id": 3989,
+												"id": 3996,
 												"typeArguments": [
 													{
 														"type": "reflection",
 														"declaration": {
-															"id": 3817,
+															"id": 3824,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 3819,
+																	"id": 3826,
 																	"name": "data",
 																	"kind": 32,
 																	"kindString": "Variable",
@@ -47576,7 +47519,7 @@
 																	}
 																},
 																{
-																	"id": 3818,
+																	"id": 3825,
 																	"name": "name",
 																	"kind": 32,
 																	"kindString": "Variable",
@@ -47601,8 +47544,8 @@
 																	"title": "Variables",
 																	"kind": 32,
 																	"children": [
-																		3819,
-																		3818
+																		3826,
+																		3825
 																	]
 																}
 															],
@@ -47644,20 +47587,20 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3781,
-								3782
+								3788,
+								3789
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								3783,
-								3789,
-								3795,
-								3803,
-								3807,
-								3810
+								3790,
+								3796,
+								3802,
+								3810,
+								3814,
+								3817
 							]
 						}
 					],
@@ -47672,7 +47615,7 @@
 						{
 							"type": "reference",
 							"name": "BaseExecutor",
-							"id": 3820
+							"id": 3827
 						},
 						{
 							"type": "reference",
@@ -47682,12 +47625,12 @@
 						{
 							"type": "reference",
 							"name": "Node",
-							"id": 2600
+							"id": 2607
 						}
 					]
 				},
 				{
-					"id": 4001,
+					"id": 4008,
 					"name": "ExecutorEvent",
 					"kind": 256,
 					"kindString": "Interface",
@@ -47697,7 +47640,7 @@
 					},
 					"children": [
 						{
-							"id": 4003,
+							"id": 4010,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -47718,7 +47661,7 @@
 							}
 						},
 						{
-							"id": 4002,
+							"id": 4009,
 							"name": "name",
 							"kind": 1024,
 							"kindString": "Property",
@@ -47748,8 +47691,8 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4003,
-								4002
+								4010,
+								4009
 							]
 						}
 					],
@@ -47762,7 +47705,7 @@
 					]
 				},
 				{
-					"id": 3985,
+					"id": 3992,
 					"name": "InternEvent",
 					"kind": 256,
 					"kindString": "Interface",
@@ -47772,7 +47715,7 @@
 					},
 					"typeParameter": [
 						{
-							"id": 3986,
+							"id": 3993,
 							"name": "E",
 							"kind": 131072,
 							"kindString": "Type parameter",
@@ -47780,13 +47723,13 @@
 							"type": {
 								"type": "reference",
 								"name": "Events",
-								"id": 4004
+								"id": 4011
 							}
 						}
 					],
 					"children": [
 						{
-							"id": 3988,
+							"id": 3995,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -47808,7 +47751,7 @@
 							}
 						},
 						{
-							"id": 3987,
+							"id": 3994,
 							"name": "eventName",
 							"kind": 1024,
 							"kindString": "Property",
@@ -47832,7 +47775,7 @@
 									"constraint": {
 										"type": "reference",
 										"name": "Events",
-										"id": 4004
+										"id": 4011
 									}
 								}
 							}
@@ -47843,8 +47786,8 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3988,
-								3987
+								3995,
+								3994
 							]
 						}
 					],
@@ -47857,7 +47800,7 @@
 					]
 				},
 				{
-					"id": 3989,
+					"id": 3996,
 					"name": "Listener",
 					"kind": 256,
 					"kindString": "Interface",
@@ -47870,7 +47813,7 @@
 					},
 					"typeParameter": [
 						{
-							"id": 3990,
+							"id": 3997,
 							"name": "T",
 							"kind": 131072,
 							"kindString": "Type parameter",
@@ -47879,7 +47822,7 @@
 					],
 					"signatures": [
 						{
-							"id": 3991,
+							"id": 3998,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -47889,7 +47832,7 @@
 							},
 							"parameters": [
 								{
-									"id": 3992,
+									"id": 3999,
 									"name": "arg",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -47930,7 +47873,7 @@
 					]
 				},
 				{
-					"id": 4023,
+					"id": 4030,
 					"name": "Loader",
 					"kind": 256,
 					"kindString": "Interface",
@@ -47943,7 +47886,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4024,
+							"id": 4031,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -47953,7 +47896,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4025,
+									"id": 4032,
 									"name": "modules",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -47988,7 +47931,7 @@
 					]
 				},
 				{
-					"id": 4026,
+					"id": 4033,
 					"name": "LoaderInit",
 					"kind": 256,
 					"kindString": "Interface",
@@ -48001,7 +47944,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4027,
+							"id": 4034,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -48011,7 +47954,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4028,
+									"id": 4035,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -48019,21 +47962,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 4029,
+											"id": 4036,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 4030,
+													"id": 4037,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 4031,
+															"id": 4038,
 															"name": "key",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -48071,14 +48014,14 @@
 											{
 												"type": "reference",
 												"name": "Loader",
-												"id": 4023
+												"id": 4030
 											}
 										]
 									},
 									{
 										"type": "reference",
 										"name": "Loader",
-										"id": 4023
+										"id": 4030
 									}
 								]
 							}
@@ -48093,7 +48036,7 @@
 					]
 				},
 				{
-					"id": 4032,
+					"id": 4039,
 					"name": "PluginInitializer",
 					"kind": 256,
 					"kindString": "Interface",
@@ -48103,7 +48046,7 @@
 					},
 					"typeParameter": [
 						{
-							"id": 4033,
+							"id": 4040,
 							"name": "T",
 							"kind": 131072,
 							"kindString": "Type parameter",
@@ -48116,14 +48059,14 @@
 					],
 					"signatures": [
 						{
-							"id": 4034,
+							"id": 4041,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 4035,
+									"id": 4042,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -48140,21 +48083,21 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 4036,
+													"id": 4043,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"indexSignature": [
 														{
-															"id": 4037,
+															"id": 4044,
 															"name": "__index",
 															"kind": 8192,
 															"kindString": "Index signature",
 															"flags": {},
 															"parameters": [
 																{
-																	"id": 4038,
+																	"id": 4045,
 																	"name": "key",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -48215,7 +48158,7 @@
 					]
 				},
 				{
-					"id": 4021,
+					"id": 4028,
 					"name": "Plugins",
 					"kind": 256,
 					"kindString": "Interface",
@@ -48228,7 +48171,7 @@
 					},
 					"children": [
 						{
-							"id": 4022,
+							"id": 4029,
 							"name": "reporter",
 							"kind": 1024,
 							"kindString": "Property",
@@ -48246,7 +48189,7 @@
 							"type": {
 								"type": "reference",
 								"name": "ReporterInitializer",
-								"id": 4039
+								"id": 4046
 							}
 						}
 					],
@@ -48255,7 +48198,7 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4022
+								4029
 							]
 						}
 					],
@@ -48270,12 +48213,12 @@
 						{
 							"type": "reference",
 							"name": "NodePlugins",
-							"id": 2810
+							"id": 2817
 						}
 					]
 				},
 				{
-					"id": 4042,
+					"id": 4049,
 					"name": "Reporter",
 					"kind": 256,
 					"kindString": "Interface",
@@ -48295,7 +48238,7 @@
 					]
 				},
 				{
-					"id": 4039,
+					"id": 4046,
 					"name": "ReporterInitializer",
 					"kind": 256,
 					"kindString": "Interface",
@@ -48305,14 +48248,14 @@
 					},
 					"signatures": [
 						{
-							"id": 4040,
+							"id": 4047,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 4041,
+									"id": 4048,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -48328,7 +48271,7 @@
 							"type": {
 								"type": "reference",
 								"name": "Reporter",
-								"id": 4042
+								"id": 4049
 							}
 						}
 					],
@@ -48341,7 +48284,7 @@
 					]
 				},
 				{
-					"id": 4043,
+					"id": 4050,
 					"name": "NoDataEvents",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -48387,33 +48330,33 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						3820
+						3827
 					]
 				},
 				{
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						3993,
-						3997,
+						4000,
 						4004,
-						3780,
-						4001,
-						3985,
-						3989,
-						4023,
-						4026,
-						4032,
-						4021,
-						4042,
-						4039
+						4011,
+						3787,
+						4008,
+						3992,
+						3996,
+						4030,
+						4033,
+						4039,
+						4028,
+						4049,
+						4046
 					]
 				},
 				{
 					"title": "Type aliases",
 					"kind": 4194304,
 					"children": [
-						4043
+						4050
 					]
 				}
 			],
@@ -48426,7 +48369,7 @@
 			]
 		},
 		{
-			"id": 2599,
+			"id": 2606,
 			"name": "\"lib/executors/Node\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -48437,7 +48380,7 @@
 			"originalName": "src/lib/executors/Node.ts",
 			"children": [
 				{
-					"id": 3279,
+					"id": 3286,
 					"name": "FunctionQueue",
 					"kind": 128,
 					"kindString": "Class",
@@ -48449,7 +48392,7 @@
 					},
 					"children": [
 						{
-							"id": 3284,
+							"id": 3291,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -48458,14 +48401,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3285,
+									"id": 3292,
 									"name": "new FunctionQueue",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3286,
+											"id": 3293,
 											"name": "maxConcurrency",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -48479,7 +48422,7 @@
 									"type": {
 										"type": "reference",
 										"name": "FunctionQueue",
-										"id": 3279
+										"id": 3286
 									}
 								}
 							],
@@ -48492,7 +48435,7 @@
 							]
 						},
 						{
-							"id": 3282,
+							"id": 3289,
 							"name": "activeTasks",
 							"kind": 1024,
 							"kindString": "Property",
@@ -48521,7 +48464,7 @@
 							}
 						},
 						{
-							"id": 3283,
+							"id": 3290,
 							"name": "funcTasks",
 							"kind": 1024,
 							"kindString": "Property",
@@ -48550,7 +48493,7 @@
 							}
 						},
 						{
-							"id": 3280,
+							"id": 3287,
 							"name": "maxConcurrency",
 							"kind": 1024,
 							"kindString": "Property",
@@ -48570,7 +48513,7 @@
 							}
 						},
 						{
-							"id": 3281,
+							"id": 3288,
 							"name": "queue",
 							"kind": 1024,
 							"kindString": "Property",
@@ -48589,12 +48532,12 @@
 								"elementType": {
 									"type": "reference",
 									"name": "QueueEntry",
-									"id": 3296
+									"id": 3303
 								}
 							}
 						},
 						{
-							"id": 3292,
+							"id": 3299,
 							"name": "clear",
 							"kind": 2048,
 							"kindString": "Method",
@@ -48603,7 +48546,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3293,
+									"id": 3300,
 									"name": "clear",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -48623,7 +48566,7 @@
 							]
 						},
 						{
-							"id": 3287,
+							"id": 3294,
 							"name": "enqueue",
 							"kind": 2048,
 							"kindString": "Method",
@@ -48632,14 +48575,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3288,
+									"id": 3295,
 									"name": "enqueue",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3289,
+											"id": 3296,
 											"name": "func",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -48647,14 +48590,14 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 3290,
+													"id": 3297,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"signatures": [
 														{
-															"id": 3291,
+															"id": 3298,
 															"name": "__call",
 															"kind": 4096,
 															"kindString": "Call signature",
@@ -48703,7 +48646,7 @@
 							]
 						},
 						{
-							"id": 3294,
+							"id": 3301,
 							"name": "next",
 							"kind": 2048,
 							"kindString": "Method",
@@ -48712,7 +48655,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3295,
+									"id": 3302,
 									"name": "next",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -48737,26 +48680,26 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								3284
+								3291
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3282,
-								3283,
-								3280,
-								3281
+								3289,
+								3290,
+								3287,
+								3288
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								3292,
-								3287,
-								3294
+								3299,
+								3294,
+								3301
 							]
 						}
 					],
@@ -48769,7 +48712,7 @@
 					]
 				},
 				{
-					"id": 2600,
+					"id": 2607,
 					"name": "Node",
 					"kind": 128,
 					"kindString": "Class",
@@ -48779,7 +48722,7 @@
 					},
 					"children": [
 						{
-							"id": 2614,
+							"id": 2621,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -48789,14 +48732,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2615,
+									"id": 2622,
 									"name": "new Node",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2616,
+											"id": 2623,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -48813,7 +48756,7 @@
 													{
 														"type": "reflection",
 														"declaration": {
-															"id": 2617,
+															"id": 2624,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
@@ -48827,12 +48770,12 @@
 									"type": {
 										"type": "reference",
 										"name": "Node",
-										"id": 2600
+										"id": 2607
 									},
 									"overwrites": {
 										"type": "reference",
 										"name": "BaseExecutor.__constructor",
-										"id": 3850
+										"id": 3857
 									}
 								}
 							],
@@ -48846,11 +48789,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "BaseExecutor.__constructor",
-								"id": 3850
+								"id": 3857
 							}
 						},
 						{
-							"id": 2676,
+							"id": 2683,
 							"name": "_config",
 							"kind": 1024,
 							"kindString": "Property",
@@ -48869,16 +48812,16 @@
 							"type": {
 								"type": "reference",
 								"name": "Config",
-								"id": 4098
+								"id": 4105
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._config",
-								"id": 3824
+								"id": 3831
 							}
 						},
 						{
-							"id": 2604,
+							"id": 2611,
 							"name": "_coverageFiles",
 							"kind": 1024,
 							"kindString": "Property",
@@ -48912,7 +48855,7 @@
 							}
 						},
 						{
-							"id": 2603,
+							"id": 2610,
 							"name": "_coverageMap",
 							"kind": 1024,
 							"kindString": "Property",
@@ -48934,7 +48877,7 @@
 							}
 						},
 						{
-							"id": 2679,
+							"id": 2686,
 							"name": "_errorFormatter",
 							"kind": 1024,
 							"kindString": "Property",
@@ -48967,11 +48910,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._errorFormatter",
-								"id": 3827
+								"id": 3834
 							}
 						},
 						{
-							"id": 2678,
+							"id": 2685,
 							"name": "_events",
 							"kind": 1024,
 							"kindString": "Property",
@@ -48992,12 +48935,12 @@
 								"elementType": {
 									"type": "reference",
 									"name": "InternEvent",
-									"id": 3985,
+									"id": 3992,
 									"typeArguments": [
 										{
 											"type": "reference",
 											"name": "NodeEvents",
-											"id": 3256
+											"id": 3263
 										}
 									]
 								}
@@ -49005,11 +48948,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._events",
-								"id": 3826
+								"id": 3833
 							}
 						},
 						{
-							"id": 2682,
+							"id": 2689,
 							"name": "_hasEmittedErrors",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49033,11 +48976,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._hasEmittedErrors",
-								"id": 3830
+								"id": 3837
 							}
 						},
 						{
-							"id": 2680,
+							"id": 2687,
 							"name": "_hasSuiteErrors",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49061,11 +49004,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._hasSuiteErrors",
-								"id": 3828
+								"id": 3835
 							}
 						},
 						{
-							"id": 2681,
+							"id": 2688,
 							"name": "_hasTestErrors",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49089,11 +49032,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._hasTestErrors",
-								"id": 3829
+								"id": 3836
 							}
 						},
 						{
-							"id": 2606,
+							"id": 2613,
 							"name": "_instrumentBasePath",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49124,7 +49067,7 @@
 							}
 						},
 						{
-							"id": 2609,
+							"id": 2616,
 							"name": "_instrumentedMaps",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49146,7 +49089,7 @@
 							}
 						},
 						{
-							"id": 2607,
+							"id": 2614,
 							"name": "_instrumenter",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49177,7 +49120,7 @@
 							}
 						},
 						{
-							"id": 2691,
+							"id": 2698,
 							"name": "_listeners",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49196,21 +49139,21 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 2692,
+									"id": 2699,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"indexSignature": [
 										{
-											"id": 2693,
+											"id": 2700,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2694,
+													"id": 2701,
 													"name": "event",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -49226,7 +49169,7 @@
 												"elementType": {
 													"type": "reference",
 													"name": "Listener",
-													"id": 3989,
+													"id": 3996,
 													"typeArguments": [
 														{
 															"type": "intrinsic",
@@ -49249,11 +49192,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._listeners",
-								"id": 3839
+								"id": 3846
 							}
 						},
 						{
-							"id": 2683,
+							"id": 2690,
 							"name": "_loader",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49272,16 +49215,16 @@
 							"type": {
 								"type": "reference",
 								"name": "Loader",
-								"id": 4023
+								"id": 4030
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loader",
-								"id": 3831
+								"id": 3838
 							}
 						},
 						{
-							"id": 2685,
+							"id": 2692,
 							"name": "_loaderInit",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49307,7 +49250,7 @@
 											{
 												"type": "reference",
 												"name": "Loader",
-												"id": 4023
+												"id": 4030
 											}
 										]
 									},
@@ -49320,11 +49263,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loaderInit",
-								"id": 3833
+								"id": 3840
 							}
 						},
 						{
-							"id": 2684,
+							"id": 2691,
 							"name": "_loaderOptions",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49347,11 +49290,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loaderOptions",
-								"id": 3832
+								"id": 3839
 							}
 						},
 						{
-							"id": 2605,
+							"id": 2612,
 							"name": "_loadingFunctionalSuites",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49382,7 +49325,7 @@
 							}
 						},
 						{
-							"id": 2690,
+							"id": 2697,
 							"name": "_loadingPluginOptions",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49414,11 +49357,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loadingPluginOptions",
-								"id": 3838
+								"id": 3845
 							}
 						},
 						{
-							"id": 2686,
+							"id": 2693,
 							"name": "_loadingPlugins",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49439,14 +49382,14 @@
 								"elementType": {
 									"type": "reflection",
 									"declaration": {
-										"id": 2687,
+										"id": 2694,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
 										"flags": {},
 										"children": [
 											{
-												"id": 2689,
+												"id": 2696,
 												"name": "init",
 												"kind": 32,
 												"kindString": "Variable",
@@ -49472,7 +49415,7 @@
 												}
 											},
 											{
-												"id": 2688,
+												"id": 2695,
 												"name": "name",
 												"kind": 32,
 												"kindString": "Variable",
@@ -49497,8 +49440,8 @@
 												"title": "Variables",
 												"kind": 32,
 												"children": [
-													2689,
-													2688
+													2696,
+													2695
 												]
 											}
 										],
@@ -49515,11 +49458,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loadingPlugins",
-								"id": 3834
+								"id": 3841
 							}
 						},
 						{
-							"id": 2695,
+							"id": 2702,
 							"name": "_plugins",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49538,21 +49481,21 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 2696,
+									"id": 2703,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"indexSignature": [
 										{
-											"id": 2697,
+											"id": 2704,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2698,
+													"id": 2705,
 													"name": "name",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -49581,11 +49524,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._plugins",
-								"id": 3843
+								"id": 3850
 							}
 						},
 						{
-							"id": 2699,
+							"id": 2706,
 							"name": "_reporters",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49606,17 +49549,17 @@
 								"elementType": {
 									"type": "reference",
 									"name": "Reporter",
-									"id": 4042
+									"id": 4049
 								}
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._reporters",
-								"id": 3847
+								"id": 3854
 							}
 						},
 						{
-							"id": 2701,
+							"id": 2708,
 							"name": "_reportersInitialized",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49639,11 +49582,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._reportersInitialized",
-								"id": 3849
+								"id": 3856
 							}
 						},
 						{
-							"id": 2677,
+							"id": 2684,
 							"name": "_rootSuite",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49662,16 +49605,16 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._rootSuite",
-								"id": 3825
+								"id": 3832
 							}
 						},
 						{
-							"id": 2700,
+							"id": 2707,
 							"name": "_runTask",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49709,11 +49652,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._runTask",
-								"id": 3848
+								"id": 3855
 							}
 						},
 						{
-							"id": 2613,
+							"id": 2620,
 							"name": "_sessionSuites",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49737,7 +49680,7 @@
 										"elementType": {
 											"type": "reference",
 											"name": "Suite",
-											"id": 3400
+											"id": 3407
 										}
 									},
 									{
@@ -49748,7 +49691,7 @@
 							}
 						},
 						{
-							"id": 2608,
+							"id": 2615,
 							"name": "_sourceMaps",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49770,7 +49713,7 @@
 							}
 						},
 						{
-							"id": 2610,
+							"id": 2617,
 							"name": "_unhookRequire",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49792,14 +49735,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 2611,
+											"id": 2618,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 2612,
+													"id": 2619,
 													"name": "__call",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -49827,7 +49770,7 @@
 							}
 						},
 						{
-							"id": 2601,
+							"id": 2608,
 							"name": "server",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49858,7 +49801,7 @@
 							}
 						},
 						{
-							"id": 2602,
+							"id": 2609,
 							"name": "tunnel",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49888,7 +49831,7 @@
 							}
 						},
 						{
-							"id": 2702,
+							"id": 2709,
 							"name": "config",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -49901,7 +49844,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2703,
+									"id": 2710,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -49916,7 +49859,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.config",
-										"id": 3856
+										"id": 3863
 									}
 								}
 							],
@@ -49930,16 +49873,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.config",
-								"id": 3856
+								"id": 3863
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.config",
-								"id": 3781
+								"id": 3788
 							}
 						},
 						{
-							"id": 2618,
+							"id": 2625,
 							"name": "coverageMap",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -49949,7 +49892,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2619,
+									"id": 2626,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -49969,7 +49912,7 @@
 							]
 						},
 						{
-							"id": 2620,
+							"id": 2627,
 							"name": "environment",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -49979,7 +49922,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2621,
+									"id": 2628,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -49992,7 +49935,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "BaseExecutor.environment",
-										"id": 3854
+										"id": 3861
 									}
 								}
 							],
@@ -50006,11 +49949,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "BaseExecutor.environment",
-								"id": 3854
+								"id": 3861
 							}
 						},
 						{
-							"id": 2626,
+							"id": 2633,
 							"name": "hasCoveredFiles",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -50020,7 +49963,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2627,
+									"id": 2634,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -50053,7 +49996,7 @@
 							]
 						},
 						{
-							"id": 2622,
+							"id": 2629,
 							"name": "instrumentedMapStore",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -50063,7 +50006,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2623,
+									"id": 2630,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -50083,7 +50026,7 @@
 							]
 						},
 						{
-							"id": 2624,
+							"id": 2631,
 							"name": "sourceMapStore",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -50093,7 +50036,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2625,
+									"id": 2632,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -50113,7 +50056,7 @@
 							]
 						},
 						{
-							"id": 2628,
+							"id": 2635,
 							"name": "suites",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -50126,7 +50069,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2629,
+									"id": 2636,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -50139,13 +50082,13 @@
 										"elementType": {
 											"type": "reference",
 											"name": "Suite",
-											"id": 3400
+											"id": 3407
 										}
 									},
 									"overwrites": {
 										"type": "reference",
 										"name": "BaseExecutor.suites",
-										"id": 3858
+										"id": 3865
 									}
 								}
 							],
@@ -50159,16 +50102,16 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "BaseExecutor.suites",
-								"id": 3858
+								"id": 3865
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.suites",
-								"id": 3782
+								"id": 3789
 							}
 						},
 						{
-							"id": 2654,
+							"id": 2661,
 							"name": "_afterRun",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50179,7 +50122,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2655,
+									"id": 2662,
 									"name": "_afterRun",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -50197,7 +50140,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "BaseExecutor._afterRun",
-										"id": 3947
+										"id": 3954
 									}
 								}
 							],
@@ -50211,11 +50154,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "BaseExecutor._afterRun",
-								"id": 3947
+								"id": 3954
 							}
 						},
 						{
-							"id": 2782,
+							"id": 2789,
 							"name": "_assignPlugin",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50226,7 +50169,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2783,
+									"id": 2790,
 									"name": "_assignPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -50236,7 +50179,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2784,
+											"id": 2791,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -50247,7 +50190,7 @@
 											}
 										},
 										{
-											"id": 2785,
+											"id": 2792,
 											"name": "plugin",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -50265,7 +50208,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._assignPlugin",
-										"id": 3949
+										"id": 3956
 									}
 								}
 							],
@@ -50279,11 +50222,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._assignPlugin",
-								"id": 3949
+								"id": 3956
 							}
 						},
 						{
-							"id": 2656,
+							"id": 2663,
 							"name": "_beforeRun",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50294,7 +50237,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2657,
+									"id": 2664,
 									"name": "_beforeRun",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -50312,7 +50255,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "BaseExecutor._beforeRun",
-										"id": 3953
+										"id": 3960
 									}
 								}
 							],
@@ -50326,11 +50269,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "BaseExecutor._beforeRun",
-								"id": 3953
+								"id": 3960
 							}
 						},
 						{
-							"id": 2658,
+							"id": 2665,
 							"name": "_createSessionSuites",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50341,7 +50284,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2659,
+									"id": 2666,
 									"name": "_createSessionSuites",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -50370,7 +50313,7 @@
 							]
 						},
 						{
-							"id": 2788,
+							"id": 2795,
 							"name": "_drainEventQueue",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50381,7 +50324,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2789,
+									"id": 2796,
 									"name": "_drainEventQueue",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -50402,7 +50345,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._drainEventQueue",
-										"id": 3957
+										"id": 3964
 									}
 								}
 							],
@@ -50416,11 +50359,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._drainEventQueue",
-								"id": 3957
+								"id": 3964
 							}
 						},
 						{
-							"id": 2790,
+							"id": 2797,
 							"name": "_emitCoverage",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50431,14 +50374,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2791,
+									"id": 2798,
 									"name": "_emitCoverage",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2792,
+											"id": 2799,
 											"name": "source",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -50482,7 +50425,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._emitCoverage",
-										"id": 3959
+										"id": 3966
 									}
 								}
 							],
@@ -50496,11 +50439,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._emitCoverage",
-								"id": 3959
+								"id": 3966
 							}
 						},
 						{
-							"id": 2666,
+							"id": 2673,
 							"name": "_getSeleniumDriverNames",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50511,7 +50454,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2667,
+									"id": 2674,
 									"name": "_getSeleniumDriverNames",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -50537,7 +50480,7 @@
 							]
 						},
 						{
-							"id": 2786,
+							"id": 2793,
 							"name": "_initReporters",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50548,7 +50491,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2787,
+									"id": 2794,
 									"name": "_initReporters",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -50569,7 +50512,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._initReporters",
-										"id": 3955
+										"id": 3962
 									}
 								}
 							],
@@ -50583,11 +50526,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._initReporters",
-								"id": 3955
+								"id": 3962
 							}
 						},
 						{
-							"id": 2660,
+							"id": 2667,
 							"name": "_loadFunctionalSuites",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50598,7 +50541,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2661,
+									"id": 2668,
 									"name": "_loadFunctionalSuites",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -50627,7 +50570,7 @@
 							]
 						},
 						{
-							"id": 2793,
+							"id": 2800,
 							"name": "_loadLoader",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50638,7 +50581,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2794,
+									"id": 2801,
 									"name": "_loadLoader",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -50659,7 +50602,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._loadLoader",
-										"id": 3962
+										"id": 3969
 									}
 								}
 							],
@@ -50673,11 +50616,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loadLoader",
-								"id": 3962
+								"id": 3969
 							}
 						},
 						{
-							"id": 2797,
+							"id": 2804,
 							"name": "_loadPlugins",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50688,7 +50631,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2798,
+									"id": 2805,
 									"name": "_loadPlugins",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -50709,7 +50652,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._loadPlugins",
-										"id": 3966
+										"id": 3973
 									}
 								}
 							],
@@ -50723,11 +50666,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loadPlugins",
-								"id": 3966
+								"id": 3973
 							}
 						},
 						{
-							"id": 2795,
+							"id": 2802,
 							"name": "_loadPluginsWithLoader",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50738,7 +50681,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2796,
+									"id": 2803,
 									"name": "_loadPluginsWithLoader",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -50759,7 +50702,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._loadPluginsWithLoader",
-										"id": 3964
+										"id": 3971
 									}
 								}
 							],
@@ -50773,11 +50716,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loadPluginsWithLoader",
-								"id": 3964
+								"id": 3971
 							}
 						},
 						{
-							"id": 2799,
+							"id": 2806,
 							"name": "_loadScripts",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50788,7 +50731,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2800,
+									"id": 2807,
 									"name": "_loadScripts",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -50798,7 +50741,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2801,
+											"id": 2808,
 											"name": "scripts",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -50808,12 +50751,12 @@
 												"elementType": {
 													"type": "reference",
 													"name": "PluginDescriptor",
-													"id": 4163
+													"id": 4170
 												}
 											}
 										},
 										{
-											"id": 2802,
+											"id": 2809,
 											"name": "loader",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -50821,21 +50764,21 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 2803,
+													"id": 2810,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"signatures": [
 														{
-															"id": 2804,
+															"id": 2811,
 															"name": "__call",
 															"kind": 4096,
 															"kindString": "Call signature",
 															"flags": {},
 															"parameters": [
 																{
-																	"id": 2805,
+																	"id": 2812,
 																	"name": "script",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -50882,7 +50825,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._loadScripts",
-										"id": 3968
+										"id": 3975
 									}
 								}
 							],
@@ -50896,11 +50839,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._loadScripts",
-								"id": 3968
+								"id": 3975
 							}
 						},
 						{
-							"id": 2662,
+							"id": 2669,
 							"name": "_loadSuites",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50911,7 +50854,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2663,
+									"id": 2670,
 									"name": "_loadSuites",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -50932,7 +50875,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "BaseExecutor._loadSuites",
-										"id": 3975
+										"id": 3982
 									}
 								}
 							],
@@ -50946,11 +50889,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "BaseExecutor._loadSuites",
-								"id": 3975
+								"id": 3982
 							}
 						},
 						{
-							"id": 2806,
+							"id": 2813,
 							"name": "_processOption",
 							"kind": 2048,
 							"kindString": "Method",
@@ -50961,7 +50904,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2807,
+									"id": 2814,
 									"name": "_processOption",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -50971,7 +50914,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2808,
+											"id": 2815,
 											"name": "key",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -50986,7 +50929,7 @@
 											}
 										},
 										{
-											"id": 2809,
+											"id": 2816,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51004,7 +50947,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor._processOption",
-										"id": 3977
+										"id": 3984
 									}
 								}
 							],
@@ -51018,11 +50961,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor._processOption",
-								"id": 3977
+								"id": 3984
 							}
 						},
 						{
-							"id": 2674,
+							"id": 2681,
 							"name": "_removeInstrumentationHooks",
 							"kind": 2048,
 							"kindString": "Method",
@@ -51033,7 +50976,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2675,
+									"id": 2682,
 									"name": "_removeInstrumentationHooks",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -51056,7 +50999,7 @@
 							]
 						},
 						{
-							"id": 2664,
+							"id": 2671,
 							"name": "_resolveConfig",
 							"kind": 2048,
 							"kindString": "Method",
@@ -51067,7 +51010,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2665,
+									"id": 2672,
 									"name": "_resolveConfig",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -51085,7 +51028,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "BaseExecutor._resolveConfig",
-										"id": 3981
+										"id": 3988
 									}
 								}
 							],
@@ -51099,11 +51042,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "BaseExecutor._resolveConfig",
-								"id": 3981
+								"id": 3988
 							}
 						},
 						{
-							"id": 2670,
+							"id": 2677,
 							"name": "_runRemoteTests",
 							"kind": 2048,
 							"kindString": "Method",
@@ -51114,7 +51057,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2671,
+									"id": 2678,
 									"name": "_runRemoteTests",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -51140,7 +51083,7 @@
 							]
 						},
 						{
-							"id": 2668,
+							"id": 2675,
 							"name": "_runTests",
 							"kind": 2048,
 							"kindString": "Method",
@@ -51151,7 +51094,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2669,
+									"id": 2676,
 									"name": "_runTests",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -51169,7 +51112,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "BaseExecutor._runTests",
-										"id": 3983
+										"id": 3990
 									}
 								}
 							],
@@ -51183,11 +51126,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "BaseExecutor._runTests",
-								"id": 3983
+								"id": 3990
 							}
 						},
 						{
-							"id": 2672,
+							"id": 2679,
 							"name": "_setInstrumentationHooks",
 							"kind": 2048,
 							"kindString": "Method",
@@ -51198,7 +51141,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2673,
+									"id": 2680,
 									"name": "_setInstrumentationHooks",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -51221,7 +51164,7 @@
 							]
 						},
 						{
-							"id": 2630,
+							"id": 2637,
 							"name": "addSuite",
 							"kind": 2048,
 							"kindString": "Method",
@@ -51231,7 +51174,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2631,
+									"id": 2638,
 									"name": "addSuite",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -51241,7 +51184,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2632,
+											"id": 2639,
 											"name": "factory",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51249,21 +51192,21 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 2633,
+													"id": 2640,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"signatures": [
 														{
-															"id": 2634,
+															"id": 2641,
 															"name": "__call",
 															"kind": 4096,
 															"kindString": "Call signature",
 															"flags": {},
 															"parameters": [
 																{
-																	"id": 2635,
+																	"id": 2642,
 																	"name": "parentSuite",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -51271,7 +51214,7 @@
 																	"type": {
 																		"type": "reference",
 																		"name": "Suite",
-																		"id": 3400
+																		"id": 3407
 																	}
 																}
 															],
@@ -51299,7 +51242,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "BaseExecutor.addSuite",
-										"id": 3867
+										"id": 3874
 									}
 								}
 							],
@@ -51313,16 +51256,16 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "BaseExecutor.addSuite",
-								"id": 3867
+								"id": 3874
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.addSuite",
-								"id": 3783
+								"id": 3790
 							}
 						},
 						{
-							"id": 2708,
+							"id": 2715,
 							"name": "configure",
 							"kind": 2048,
 							"kindString": "Method",
@@ -51332,7 +51275,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2709,
+									"id": 2716,
 									"name": "configure",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -51342,7 +51285,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2710,
+											"id": 2717,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51350,7 +51293,7 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 2711,
+													"id": 2718,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
@@ -51373,7 +51316,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.configure",
-										"id": 3873
+										"id": 3880
 									}
 								}
 							],
@@ -51387,16 +51330,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.configure",
-								"id": 3873
+								"id": 3880
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.configure",
-								"id": 3789
+								"id": 3796
 							}
 						},
 						{
-							"id": 2712,
+							"id": 2719,
 							"name": "emit",
 							"kind": 2048,
 							"kindString": "Method",
@@ -51406,7 +51349,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2713,
+									"id": 2720,
 									"name": "emit",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -51418,7 +51361,7 @@
 									},
 									"typeParameter": [
 										{
-											"id": 2714,
+											"id": 2721,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -51426,13 +51369,13 @@
 											"type": {
 												"type": "reference",
 												"name": "NoDataEvents",
-												"id": 4043
+												"id": 4050
 											}
 										}
 									],
 									"parameters": [
 										{
-											"id": 2715,
+											"id": 2722,
 											"name": "eventName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51446,7 +51389,7 @@
 												"constraint": {
 													"type": "reference",
 													"name": "NoDataEvents",
-													"id": 4043
+													"id": 4050
 												}
 											}
 										}
@@ -51464,23 +51407,23 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.emit",
-										"id": 3877
+										"id": 3884
 									},
 									"implementationOf": {
 										"type": "reference",
 										"name": "Executor.emit",
-										"id": 3796
+										"id": 3803
 									}
 								},
 								{
-									"id": 2716,
+									"id": 2723,
 									"name": "emit",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2717,
+											"id": 2724,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -51497,7 +51440,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2718,
+											"id": 2725,
 											"name": "eventName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51516,7 +51459,7 @@
 											}
 										},
 										{
-											"id": 2719,
+											"id": 2726,
 											"name": "data",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51540,7 +51483,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.emit",
-										"id": 3877
+										"id": 3884
 									}
 								}
 							],
@@ -51564,16 +51507,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.emit",
-								"id": 3877
+								"id": 3884
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.emit",
-								"id": 3795
+								"id": 3802
 							}
 						},
 						{
-							"id": 2704,
+							"id": 2711,
 							"name": "formatError",
 							"kind": 2048,
 							"kindString": "Method",
@@ -51583,7 +51526,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2705,
+									"id": 2712,
 									"name": "formatError",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -51593,7 +51536,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2706,
+											"id": 2713,
 											"name": "error",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51604,7 +51547,7 @@
 											}
 										},
 										{
-											"id": 2707,
+											"id": 2714,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51625,12 +51568,12 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.formatError",
-										"id": 3860
+										"id": 3867
 									},
 									"implementationOf": {
 										"type": "reference",
 										"name": "Executor.formatError",
-										"id": 3804
+										"id": 3811
 									}
 								}
 							],
@@ -51644,16 +51587,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.formatError",
-								"id": 3860
+								"id": 3867
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.formatError",
-								"id": 3803
+								"id": 3810
 							}
 						},
 						{
-							"id": 2720,
+							"id": 2727,
 							"name": "getInterface",
 							"kind": 2048,
 							"kindString": "Method",
@@ -51663,7 +51606,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2721,
+									"id": 2728,
 									"name": "getInterface",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -51675,7 +51618,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2722,
+											"id": 2729,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51692,23 +51635,23 @@
 									"type": {
 										"type": "reference",
 										"name": "ObjectInterface",
-										"id": 3504
+										"id": 3511
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getInterface",
-										"id": 3885
+										"id": 3892
 									}
 								},
 								{
-									"id": 2723,
+									"id": 2730,
 									"name": "getInterface",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2724,
+											"id": 2731,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51722,23 +51665,23 @@
 									"type": {
 										"type": "reference",
 										"name": "TddInterface",
-										"id": 3551
+										"id": 3558
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getInterface",
-										"id": 3885
+										"id": 3892
 									}
 								},
 								{
-									"id": 2725,
+									"id": 2732,
 									"name": "getInterface",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2726,
+											"id": 2733,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51752,23 +51695,23 @@
 									"type": {
 										"type": "reference",
 										"name": "BddInterface",
-										"id": 3628
+										"id": 3635
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getInterface",
-										"id": 3885
+										"id": 3892
 									}
 								},
 								{
-									"id": 2727,
+									"id": 2734,
 									"name": "getInterface",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2728,
+											"id": 2735,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51782,12 +51725,12 @@
 									"type": {
 										"type": "reference",
 										"name": "BenchmarkInterface",
-										"id": 3743
+										"id": 3750
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getInterface",
-										"id": 3885
+										"id": 3892
 									}
 								}
 							],
@@ -51821,11 +51764,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.getInterface",
-								"id": 3885
+								"id": 3892
 							}
 						},
 						{
-							"id": 2729,
+							"id": 2736,
 							"name": "getPlugin",
 							"kind": 2048,
 							"kindString": "Method",
@@ -51835,7 +51778,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2730,
+									"id": 2737,
 									"name": "getPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -51846,7 +51789,7 @@
 									},
 									"typeParameter": [
 										{
-											"id": 2731,
+											"id": 2738,
 											"name": "Y",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -51863,7 +51806,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2732,
+											"id": 2739,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51885,7 +51828,7 @@
 											}
 										},
 										{
-											"id": 2733,
+											"id": 2740,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51906,18 +51849,18 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getPlugin",
-										"id": 3894
+										"id": 3901
 									}
 								},
 								{
-									"id": 2734,
+									"id": 2741,
 									"name": "getPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2735,
+											"id": 2742,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51935,18 +51878,18 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getPlugin",
-										"id": 3894
+										"id": 3901
 									}
 								},
 								{
-									"id": 2736,
+									"id": 2743,
 									"name": "getPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2737,
+											"id": 2744,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51960,23 +51903,23 @@
 									"type": {
 										"type": "reference",
 										"name": "ObjectInterface",
-										"id": 3504
+										"id": 3511
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getPlugin",
-										"id": 3894
+										"id": 3901
 									}
 								},
 								{
-									"id": 2738,
+									"id": 2745,
 									"name": "getPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2739,
+											"id": 2746,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -51990,23 +51933,23 @@
 									"type": {
 										"type": "reference",
 										"name": "TddInterface",
-										"id": 3551
+										"id": 3558
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getPlugin",
-										"id": 3894
+										"id": 3901
 									}
 								},
 								{
-									"id": 2740,
+									"id": 2747,
 									"name": "getPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2741,
+											"id": 2748,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52020,23 +51963,23 @@
 									"type": {
 										"type": "reference",
 										"name": "BddInterface",
-										"id": 3628
+										"id": 3635
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getPlugin",
-										"id": 3894
+										"id": 3901
 									}
 								},
 								{
-									"id": 2742,
+									"id": 2749,
 									"name": "getPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2743,
+											"id": 2750,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52050,23 +51993,23 @@
 									"type": {
 										"type": "reference",
 										"name": "BenchmarkInterface",
-										"id": 3743
+										"id": 3750
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getPlugin",
-										"id": 3894
+										"id": 3901
 									}
 								},
 								{
-									"id": 2744,
+									"id": 2751,
 									"name": "getPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2745,
+											"id": 2752,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -52075,7 +52018,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2746,
+											"id": 2753,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52093,7 +52036,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.getPlugin",
-										"id": 3894
+										"id": 3901
 									}
 								}
 							],
@@ -52142,11 +52085,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.getPlugin",
-								"id": 3894
+								"id": 3901
 							}
 						},
 						{
-							"id": 2636,
+							"id": 2643,
 							"name": "getTunnel",
 							"kind": 2048,
 							"kindString": "Method",
@@ -52156,7 +52099,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2637,
+									"id": 2644,
 									"name": "getTunnel",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -52166,7 +52109,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2638,
+											"id": 2645,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52192,7 +52135,7 @@
 							]
 						},
 						{
-							"id": 2639,
+							"id": 2646,
 							"name": "instrumentCode",
 							"kind": 2048,
 							"kindString": "Method",
@@ -52202,7 +52145,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2640,
+									"id": 2647,
 									"name": "instrumentCode",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -52212,7 +52155,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2641,
+											"id": 2648,
 											"name": "code",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52223,7 +52166,7 @@
 											}
 										},
 										{
-											"id": 2642,
+											"id": 2649,
 											"name": "filename",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52234,7 +52177,7 @@
 											}
 										},
 										{
-											"id": 2643,
+											"id": 2650,
 											"name": "shouldCompile",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52275,7 +52218,7 @@
 							]
 						},
 						{
-							"id": 2644,
+							"id": 2651,
 							"name": "loadScript",
 							"kind": 2048,
 							"kindString": "Method",
@@ -52285,7 +52228,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2645,
+									"id": 2652,
 									"name": "loadScript",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -52295,7 +52238,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2646,
+											"id": 2653,
 											"name": "script",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52331,7 +52274,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "BaseExecutor.loadScript",
-										"id": 3864
+										"id": 3871
 									}
 								}
 							],
@@ -52345,11 +52288,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "BaseExecutor.loadScript",
-								"id": 3864
+								"id": 3871
 							}
 						},
 						{
-							"id": 2747,
+							"id": 2754,
 							"name": "log",
 							"kind": 2048,
 							"kindString": "Method",
@@ -52359,7 +52302,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2748,
+									"id": 2755,
 									"name": "log",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -52371,7 +52314,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2749,
+											"id": 2756,
 											"name": "args",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52403,12 +52346,12 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.log",
-										"id": 3912
+										"id": 3919
 									},
 									"implementationOf": {
 										"type": "reference",
 										"name": "Executor.log",
-										"id": 3808
+										"id": 3815
 									}
 								}
 							],
@@ -52422,16 +52365,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.log",
-								"id": 3912
+								"id": 3919
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.log",
-								"id": 3807
+								"id": 3814
 							}
 						},
 						{
-							"id": 2750,
+							"id": 2757,
 							"name": "on",
 							"kind": 2048,
 							"kindString": "Method",
@@ -52441,7 +52384,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2751,
+									"id": 2758,
 									"name": "on",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -52453,7 +52396,7 @@
 									},
 									"typeParameter": [
 										{
-											"id": 2752,
+											"id": 2759,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -52470,7 +52413,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2753,
+											"id": 2760,
 											"name": "eventName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52492,7 +52435,7 @@
 											}
 										},
 										{
-											"id": 2754,
+											"id": 2761,
 											"name": "listener",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52503,7 +52446,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Listener",
-												"id": 3989,
+												"id": 3996,
 												"typeArguments": [
 													{
 														"type": "unknown",
@@ -52520,23 +52463,23 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.on",
-										"id": 3915
+										"id": 3922
 									},
 									"implementationOf": {
 										"type": "reference",
 										"name": "Executor.on",
-										"id": 3811
+										"id": 3818
 									}
 								},
 								{
-									"id": 2755,
+									"id": 2762,
 									"name": "on",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2756,
+											"id": 2763,
 											"name": "listener",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52544,19 +52487,19 @@
 											"type": {
 												"type": "reference",
 												"name": "Listener",
-												"id": 3989,
+												"id": 3996,
 												"typeArguments": [
 													{
 														"type": "reflection",
 														"declaration": {
-															"id": 2757,
+															"id": 2764,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 2759,
+																	"id": 2766,
 																	"name": "data",
 																	"kind": 32,
 																	"kindString": "Variable",
@@ -52577,7 +52520,7 @@
 																	}
 																},
 																{
-																	"id": 2758,
+																	"id": 2765,
 																	"name": "name",
 																	"kind": 32,
 																	"kindString": "Variable",
@@ -52602,8 +52545,8 @@
 																	"title": "Variables",
 																	"kind": 32,
 																	"children": [
-																		2759,
-																		2758
+																		2766,
+																		2765
 																	]
 																}
 															],
@@ -52627,12 +52570,12 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.on",
-										"id": 3915
+										"id": 3922
 									},
 									"implementationOf": {
 										"type": "reference",
 										"name": "Executor.on",
-										"id": 3815
+										"id": 3822
 									}
 								}
 							],
@@ -52656,16 +52599,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.on",
-								"id": 3915
+								"id": 3922
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "Executor.on",
-								"id": 3810
+								"id": 3817
 							}
 						},
 						{
-							"id": 2760,
+							"id": 2767,
 							"name": "registerInterface",
 							"kind": 2048,
 							"kindString": "Method",
@@ -52675,7 +52618,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2761,
+									"id": 2768,
 									"name": "registerInterface",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -52686,7 +52629,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2762,
+											"id": 2769,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52697,7 +52640,7 @@
 											}
 										},
 										{
-											"id": 2763,
+											"id": 2770,
 											"name": "iface",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52715,7 +52658,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.registerInterface",
-										"id": 3925
+										"id": 3932
 									}
 								}
 							],
@@ -52729,11 +52672,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.registerInterface",
-								"id": 3925
+								"id": 3932
 							}
 						},
 						{
-							"id": 2764,
+							"id": 2771,
 							"name": "registerLoader",
 							"kind": 2048,
 							"kindString": "Method",
@@ -52743,7 +52686,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2765,
+									"id": 2772,
 									"name": "registerLoader",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -52754,7 +52697,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2766,
+											"id": 2773,
 											"name": "init",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52765,7 +52708,7 @@
 											"type": {
 												"type": "reference",
 												"name": "LoaderInit",
-												"id": 4026
+												"id": 4033
 											}
 										}
 									],
@@ -52776,7 +52719,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.registerLoader",
-										"id": 3929
+										"id": 3936
 									}
 								}
 							],
@@ -52790,11 +52733,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.registerLoader",
-								"id": 3929
+								"id": 3936
 							}
 						},
 						{
-							"id": 2767,
+							"id": 2774,
 							"name": "registerPlugin",
 							"kind": 2048,
 							"kindString": "Method",
@@ -52804,7 +52747,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2768,
+									"id": 2775,
 									"name": "registerPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -52815,7 +52758,7 @@
 									},
 									"typeParameter": [
 										{
-											"id": 2769,
+											"id": 2776,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -52832,7 +52775,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2770,
+											"id": 2777,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52851,7 +52794,7 @@
 											}
 										},
 										{
-											"id": 2771,
+											"id": 2778,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52865,7 +52808,7 @@
 											}
 										},
 										{
-											"id": 2772,
+											"id": 2779,
 											"name": "init",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52876,7 +52819,7 @@
 											"type": {
 												"type": "reference",
 												"name": "PluginInitializer",
-												"id": 4032,
+												"id": 4039,
 												"typeArguments": [
 													{
 														"type": "unknown",
@@ -52893,18 +52836,18 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.registerPlugin",
-										"id": 3932
+										"id": 3939
 									}
 								},
 								{
-									"id": 2773,
+									"id": 2780,
 									"name": "registerPlugin",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2774,
+											"id": 2781,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52915,7 +52858,7 @@
 											}
 										},
 										{
-											"id": 2775,
+											"id": 2782,
 											"name": "init",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52923,7 +52866,7 @@
 											"type": {
 												"type": "reference",
 												"name": "PluginInitializer",
-												"id": 4032
+												"id": 4039
 											}
 										}
 									],
@@ -52934,7 +52877,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.registerPlugin",
-										"id": 3932
+										"id": 3939
 									}
 								}
 							],
@@ -52958,11 +52901,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.registerPlugin",
-								"id": 3932
+								"id": 3939
 							}
 						},
 						{
-							"id": 2776,
+							"id": 2783,
 							"name": "registerReporter",
 							"kind": 2048,
 							"kindString": "Method",
@@ -52972,7 +52915,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2777,
+									"id": 2784,
 									"name": "registerReporter",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -52983,7 +52926,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2778,
+											"id": 2785,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -52997,7 +52940,7 @@
 											}
 										},
 										{
-											"id": 2779,
+											"id": 2786,
 											"name": "init",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -53005,7 +52948,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterInitializer",
-												"id": 4039
+												"id": 4046
 											}
 										}
 									],
@@ -53016,7 +52959,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.registerReporter",
-										"id": 3941
+										"id": 3948
 									}
 								}
 							],
@@ -53030,11 +52973,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.registerReporter",
-								"id": 3941
+								"id": 3948
 							}
 						},
 						{
-							"id": 2647,
+							"id": 2654,
 							"name": "registerTunnel",
 							"kind": 2048,
 							"kindString": "Method",
@@ -53044,7 +52987,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2648,
+									"id": 2655,
 									"name": "registerTunnel",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -53054,7 +52997,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2649,
+											"id": 2656,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -53065,7 +53008,7 @@
 											}
 										},
 										{
-											"id": 2650,
+											"id": 2657,
 											"name": "Ctor",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -53091,7 +53034,7 @@
 							]
 						},
 						{
-							"id": 2780,
+							"id": 2787,
 							"name": "run",
 							"kind": 2048,
 							"kindString": "Method",
@@ -53101,7 +53044,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2781,
+									"id": 2788,
 									"name": "run",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -53123,7 +53066,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "BaseExecutor.run",
-										"id": 3945
+										"id": 3952
 									}
 								}
 							],
@@ -53137,11 +53080,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "BaseExecutor.run",
-								"id": 3945
+								"id": 3952
 							}
 						},
 						{
-							"id": 2651,
+							"id": 2658,
 							"name": "shouldInstrumentFile",
 							"kind": 2048,
 							"kindString": "Method",
@@ -53151,7 +53094,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2652,
+									"id": 2659,
 									"name": "shouldInstrumentFile",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -53161,7 +53104,7 @@
 									},
 									"parameters": [
 										{
-											"id": 2653,
+											"id": 2660,
 											"name": "filename",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -53192,98 +53135,98 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								2614
+								2621
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2676,
-								2604,
-								2603,
-								2679,
-								2678,
-								2682,
-								2680,
-								2681,
-								2606,
-								2609,
-								2607,
-								2691,
 								2683,
-								2685,
-								2684,
-								2605,
-								2690,
-								2686,
-								2695,
-								2699,
-								2701,
-								2677,
-								2700,
-								2613,
-								2608,
+								2611,
 								2610,
-								2601,
-								2602
+								2686,
+								2685,
+								2689,
+								2687,
+								2688,
+								2613,
+								2616,
+								2614,
+								2698,
+								2690,
+								2692,
+								2691,
+								2612,
+								2697,
+								2693,
+								2702,
+								2706,
+								2708,
+								2684,
+								2707,
+								2620,
+								2615,
+								2617,
+								2608,
+								2609
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								2702,
-								2618,
-								2620,
-								2626,
-								2622,
-								2624,
-								2628
+								2709,
+								2625,
+								2627,
+								2633,
+								2629,
+								2631,
+								2635
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								2654,
-								2782,
-								2656,
-								2658,
-								2788,
-								2790,
-								2666,
-								2786,
-								2660,
-								2793,
-								2797,
+								2661,
+								2789,
+								2663,
+								2665,
 								2795,
-								2799,
-								2662,
+								2797,
+								2673,
+								2793,
+								2667,
+								2800,
+								2804,
+								2802,
 								2806,
-								2674,
-								2664,
-								2670,
-								2668,
-								2672,
-								2630,
-								2708,
-								2712,
-								2704,
-								2720,
-								2729,
-								2636,
-								2639,
-								2644,
-								2747,
-								2750,
-								2760,
-								2764,
+								2669,
+								2813,
+								2681,
+								2671,
+								2677,
+								2675,
+								2679,
+								2637,
+								2715,
+								2719,
+								2711,
+								2727,
+								2736,
+								2643,
+								2646,
+								2651,
+								2754,
+								2757,
 								2767,
-								2776,
-								2647,
-								2780,
-								2651
+								2771,
+								2774,
+								2783,
+								2654,
+								2787,
+								2658
 							]
 						}
 					],
@@ -53298,22 +53241,22 @@
 						{
 							"type": "reference",
 							"name": "BaseExecutor",
-							"id": 3820,
+							"id": 3827,
 							"typeArguments": [
 								{
 									"type": "reference",
 									"name": "NodeEvents",
-									"id": 3256
+									"id": 3263
 								},
 								{
 									"type": "reference",
 									"name": "Config",
-									"id": 4098
+									"id": 4105
 								},
 								{
 									"type": "reference",
 									"name": "NodePlugins",
-									"id": 2810
+									"id": 2817
 								}
 							]
 						}
@@ -53322,12 +53265,12 @@
 						{
 							"type": "reference",
 							"name": "Executor",
-							"id": 3780
+							"id": 3787
 						}
 					]
 				},
 				{
-					"id": 3256,
+					"id": 3263,
 					"name": "NodeEvents",
 					"kind": 256,
 					"kindString": "Interface",
@@ -53337,7 +53280,7 @@
 					},
 					"children": [
 						{
-							"id": 3263,
+							"id": 3270,
 							"name": "*",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53358,16 +53301,16 @@
 							"type": {
 								"type": "reference",
 								"name": "ExecutorEvent",
-								"id": 4001
+								"id": 4008
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.'*'",
-								"id": 4005
+								"id": 4012
 							}
 						},
 						{
-							"id": 3264,
+							"id": 3271,
 							"name": "afterRun",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53392,11 +53335,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.afterRun",
-								"id": 4006
+								"id": 4013
 							}
 						},
 						{
-							"id": 3265,
+							"id": 3272,
 							"name": "beforeRun",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53421,11 +53364,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.beforeRun",
-								"id": 4007
+								"id": 4014
 							}
 						},
 						{
-							"id": 3266,
+							"id": 3273,
 							"name": "coverage",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53446,16 +53389,16 @@
 							"type": {
 								"type": "reference",
 								"name": "CoverageMessage",
-								"id": 3993
+								"id": 4000
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.coverage",
-								"id": 4008
+								"id": 4015
 							}
 						},
 						{
-							"id": 3267,
+							"id": 3274,
 							"name": "deprecated",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53476,16 +53419,16 @@
 							"type": {
 								"type": "reference",
 								"name": "DeprecationMessage",
-								"id": 3997
+								"id": 4004
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.deprecated",
-								"id": 4009
+								"id": 4016
 							}
 						},
 						{
-							"id": 3268,
+							"id": 3275,
 							"name": "error",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53510,11 +53453,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.error",
-								"id": 4010
+								"id": 4017
 							}
 						},
 						{
-							"id": 3269,
+							"id": 3276,
 							"name": "log",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53539,11 +53482,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.log",
-								"id": 4011
+								"id": 4018
 							}
 						},
 						{
-							"id": 3270,
+							"id": 3277,
 							"name": "runEnd",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53568,11 +53511,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.runEnd",
-								"id": 4012
+								"id": 4019
 							}
 						},
 						{
-							"id": 3271,
+							"id": 3278,
 							"name": "runStart",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53597,11 +53540,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.runStart",
-								"id": 4013
+								"id": 4020
 							}
 						},
 						{
-							"id": 3257,
+							"id": 3264,
 							"name": "serverEnd",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53626,7 +53569,7 @@
 							}
 						},
 						{
-							"id": 3258,
+							"id": 3265,
 							"name": "serverStart",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53651,7 +53594,7 @@
 							}
 						},
 						{
-							"id": 3272,
+							"id": 3279,
 							"name": "suiteAdd",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53672,16 +53615,16 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.suiteAdd",
-								"id": 4014
+								"id": 4021
 							}
 						},
 						{
-							"id": 3273,
+							"id": 3280,
 							"name": "suiteEnd",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53702,16 +53645,16 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.suiteEnd",
-								"id": 4015
+								"id": 4022
 							}
 						},
 						{
-							"id": 3274,
+							"id": 3281,
 							"name": "suiteStart",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53732,16 +53675,16 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.suiteStart",
-								"id": 4016
+								"id": 4023
 							}
 						},
 						{
-							"id": 3275,
+							"id": 3282,
 							"name": "testAdd",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53762,16 +53705,16 @@
 							"type": {
 								"type": "reference",
 								"name": "Test",
-								"id": 3317
+								"id": 3324
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.testAdd",
-								"id": 4017
+								"id": 4024
 							}
 						},
 						{
-							"id": 3276,
+							"id": 3283,
 							"name": "testEnd",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53792,16 +53735,16 @@
 							"type": {
 								"type": "reference",
 								"name": "Test",
-								"id": 3317
+								"id": 3324
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.testEnd",
-								"id": 4018
+								"id": 4025
 							}
 						},
 						{
-							"id": 3277,
+							"id": 3284,
 							"name": "testStart",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53822,16 +53765,16 @@
 							"type": {
 								"type": "reference",
 								"name": "Test",
-								"id": 3317
+								"id": 3324
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.testStart",
-								"id": 4019
+								"id": 4026
 							}
 						},
 						{
-							"id": 3259,
+							"id": 3266,
 							"name": "tunnelDownloadProgress",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53852,11 +53795,11 @@
 							"type": {
 								"type": "reference",
 								"name": "TunnelMessage",
-								"id": 3252
+								"id": 3259
 							}
 						},
 						{
-							"id": 3260,
+							"id": 3267,
 							"name": "tunnelStart",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53877,11 +53820,11 @@
 							"type": {
 								"type": "reference",
 								"name": "TunnelMessage",
-								"id": 3252
+								"id": 3259
 							}
 						},
 						{
-							"id": 3261,
+							"id": 3268,
 							"name": "tunnelStatus",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53902,11 +53845,11 @@
 							"type": {
 								"type": "reference",
 								"name": "TunnelMessage",
-								"id": 3252
+								"id": 3259
 							}
 						},
 						{
-							"id": 3262,
+							"id": 3269,
 							"name": "tunnelStop",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53927,11 +53870,11 @@
 							"type": {
 								"type": "reference",
 								"name": "TunnelMessage",
-								"id": 3252
+								"id": 3259
 							}
 						},
 						{
-							"id": 3278,
+							"id": 3285,
 							"name": "warning",
 							"kind": 1024,
 							"kindString": "Property",
@@ -53956,7 +53899,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Events.warning",
-								"id": 4020
+								"id": 4027
 							}
 						}
 					],
@@ -53965,28 +53908,28 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3263,
-								3264,
-								3265,
-								3266,
-								3267,
-								3268,
-								3269,
 								3270,
 								3271,
-								3257,
-								3258,
 								3272,
 								3273,
 								3274,
 								3275,
 								3276,
 								3277,
-								3259,
-								3260,
-								3261,
-								3262,
-								3278
+								3278,
+								3264,
+								3265,
+								3279,
+								3280,
+								3281,
+								3282,
+								3283,
+								3284,
+								3266,
+								3267,
+								3268,
+								3269,
+								3285
 							]
 						}
 					],
@@ -54001,7 +53944,7 @@
 						{
 							"type": "reference",
 							"name": "Events",
-							"id": 4004
+							"id": 4011
 						}
 					],
 					"extendedBy": [
@@ -54013,7 +53956,7 @@
 					]
 				},
 				{
-					"id": 2810,
+					"id": 2817,
 					"name": "NodePlugins",
 					"kind": 256,
 					"kindString": "Interface",
@@ -54023,7 +53966,7 @@
 					},
 					"children": [
 						{
-							"id": 2812,
+							"id": 2819,
 							"name": "reporter",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54041,16 +53984,16 @@
 							"type": {
 								"type": "reference",
 								"name": "ReporterInitializer",
-								"id": 4039
+								"id": 4046
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Plugins.reporter",
-								"id": 4022
+								"id": 4029
 							}
 						},
 						{
-							"id": 2811,
+							"id": 2818,
 							"name": "tunnel",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54076,8 +54019,8 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2812,
-								2811
+								2819,
+								2818
 							]
 						}
 					],
@@ -54092,12 +54035,12 @@
 						{
 							"type": "reference",
 							"name": "Plugins",
-							"id": 4021
+							"id": 4028
 						}
 					]
 				},
 				{
-					"id": 3296,
+					"id": 3303,
 					"name": "QueueEntry",
 					"kind": 256,
 					"kindString": "Interface",
@@ -54106,7 +54049,7 @@
 					},
 					"children": [
 						{
-							"id": 3297,
+							"id": 3304,
 							"name": "func",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54123,14 +54066,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3298,
+									"id": 3305,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"signatures": [
 										{
-											"id": 3299,
+											"id": 3306,
 											"name": "__call",
 											"kind": 4096,
 											"kindString": "Call signature",
@@ -54158,7 +54101,7 @@
 							}
 						},
 						{
-							"id": 3303,
+							"id": 3310,
 							"name": "reject",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54175,14 +54118,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3304,
+									"id": 3311,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"signatures": [
 										{
-											"id": 3305,
+											"id": 3312,
 											"name": "__call",
 											"kind": 4096,
 											"kindString": "Call signature",
@@ -54204,7 +54147,7 @@
 							}
 						},
 						{
-							"id": 3300,
+							"id": 3307,
 							"name": "resolve",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54221,14 +54164,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3301,
+									"id": 3308,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"signatures": [
 										{
-											"id": 3302,
+											"id": 3309,
 											"name": "__call",
 											"kind": 4096,
 											"kindString": "Call signature",
@@ -54255,9 +54198,9 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3297,
-								3303,
-								3300
+								3304,
+								3310,
+								3307
 							]
 						}
 					],
@@ -54270,7 +54213,7 @@
 					]
 				},
 				{
-					"id": 2813,
+					"id": 2820,
 					"name": "Remote",
 					"kind": 256,
 					"kindString": "Interface",
@@ -54280,14 +54223,14 @@
 					},
 					"typeParameter": [
 						{
-							"id": 2819,
+							"id": 2826,
 							"name": "P",
 							"kind": 131072,
 							"kindString": "Type parameter",
 							"flags": {}
 						},
 						{
-							"id": 2820,
+							"id": 2827,
 							"name": "StringResult",
 							"kind": 131072,
 							"kindString": "Type parameter",
@@ -54312,7 +54255,7 @@
 					],
 					"children": [
 						{
-							"id": 2836,
+							"id": 2843,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -54322,14 +54265,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2837,
+									"id": 2844,
 									"name": "new Remote",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2838,
+											"id": 2845,
 											"name": "parentOrSession",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -54383,7 +54326,7 @@
 											}
 										},
 										{
-											"id": 2839,
+											"id": 2846,
 											"name": "initialiser",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -54400,21 +54343,21 @@
 													{
 														"type": "reflection",
 														"declaration": {
-															"id": 2840,
+															"id": 2847,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"signatures": [
 																{
-																	"id": 2841,
+																	"id": 2848,
 																	"name": "__call",
 																	"kind": 4096,
 																	"kindString": "Call signature",
 																	"flags": {},
 																	"parameters": [
 																		{
-																			"id": 2842,
+																			"id": 2849,
 																			"name": "this",
 																			"kind": 32768,
 																			"kindString": "Parameter",
@@ -54455,7 +54398,7 @@
 																			}
 																		},
 																		{
-																			"id": 2843,
+																			"id": 2850,
 																			"name": "setContext",
 																			"kind": 32768,
 																			"kindString": "Parameter",
@@ -54466,7 +54409,7 @@
 																			}
 																		},
 																		{
-																			"id": 2844,
+																			"id": 2851,
 																			"name": "value",
 																			"kind": 32768,
 																			"kindString": "Parameter",
@@ -54504,7 +54447,7 @@
 											}
 										},
 										{
-											"id": 2845,
+											"id": 2852,
 											"name": "errback",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -54521,21 +54464,21 @@
 													{
 														"type": "reflection",
 														"declaration": {
-															"id": 2846,
+															"id": 2853,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"signatures": [
 																{
-																	"id": 2847,
+																	"id": 2854,
 																	"name": "__call",
 																	"kind": 4096,
 																	"kindString": "Call signature",
 																	"flags": {},
 																	"parameters": [
 																		{
-																			"id": 2848,
+																			"id": 2855,
 																			"name": "this",
 																			"kind": 32768,
 																			"kindString": "Parameter",
@@ -54576,7 +54519,7 @@
 																			}
 																		},
 																		{
-																			"id": 2849,
+																			"id": 2856,
 																			"name": "setContext",
 																			"kind": 32768,
 																			"kindString": "Parameter",
@@ -54587,7 +54530,7 @@
 																			}
 																		},
 																		{
-																			"id": 2850,
+																			"id": 2857,
 																			"name": "error",
 																			"kind": 32768,
 																			"kindString": "Parameter",
@@ -54628,7 +54571,7 @@
 									"type": {
 										"type": "reference",
 										"name": "Remote",
-										"id": 2813
+										"id": 2820
 									},
 									"inheritedFrom": {
 										"type": "reference",
@@ -54649,7 +54592,7 @@
 							}
 						},
 						{
-							"id": 2853,
+							"id": 2860,
 							"name": "context",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54674,7 +54617,7 @@
 							}
 						},
 						{
-							"id": 2814,
+							"id": 2821,
 							"name": "environmentType",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54697,7 +54640,7 @@
 							}
 						},
 						{
-							"id": 2851,
+							"id": 2858,
 							"name": "parent",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54752,7 +54695,7 @@
 							}
 						},
 						{
-							"id": 2854,
+							"id": 2861,
 							"name": "promise",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54783,7 +54726,7 @@
 							}
 						},
 						{
-							"id": 2815,
+							"id": 2822,
 							"name": "requestedEnvironment",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54806,7 +54749,7 @@
 							}
 						},
 						{
-							"id": 2852,
+							"id": 2859,
 							"name": "session",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54831,7 +54774,7 @@
 							}
 						},
 						{
-							"id": 3018,
+							"id": 3025,
 							"name": "acceptAlert",
 							"kind": 2048,
 							"kindString": "Method",
@@ -54841,7 +54784,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3019,
+									"id": 3026,
 									"name": "acceptAlert",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -54899,7 +54842,7 @@
 							}
 						},
 						{
-							"id": 2945,
+							"id": 2952,
 							"name": "activateIme",
 							"kind": 2048,
 							"kindString": "Method",
@@ -54909,14 +54852,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2946,
+									"id": 2953,
 									"name": "activateIme",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2947,
+											"id": 2954,
 											"name": "engine",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -54980,7 +54923,7 @@
 							}
 						},
 						{
-							"id": 2889,
+							"id": 2896,
 							"name": "cancel",
 							"kind": 2048,
 							"kindString": "Method",
@@ -54990,7 +54933,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2890,
+									"id": 2897,
 									"name": "cancel",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -55018,7 +54961,7 @@
 							}
 						},
 						{
-							"id": 2876,
+							"id": 2883,
 							"name": "catch",
 							"kind": 2048,
 							"kindString": "Method",
@@ -55028,14 +54971,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2877,
+									"id": 2884,
 									"name": "catch",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2878,
+											"id": 2885,
 											"name": "R",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -55044,7 +54987,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2879,
+											"id": 2886,
 											"name": "errback",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -55052,21 +54995,21 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 2880,
+													"id": 2887,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"signatures": [
 														{
-															"id": 2881,
+															"id": 2888,
 															"name": "__call",
 															"kind": 4096,
 															"kindString": "Call signature",
 															"flags": {},
 															"parameters": [
 																{
-																	"id": 2882,
+																	"id": 2889,
 																	"name": "this",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -55107,7 +55050,7 @@
 																	}
 																},
 																{
-																	"id": 2883,
+																	"id": 2890,
 																	"name": "reason",
 																	"kind": 32768,
 																	"kindString": "Parameter",
@@ -55212,7 +55155,7 @@
 							}
 						},
 						{
-							"id": 2994,
+							"id": 3001,
 							"name": "clearCookies",
 							"kind": 2048,
 							"kindString": "Method",
@@ -55222,7 +55165,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2995,
+									"id": 3002,
 									"name": "clearCookies",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -55280,7 +55223,7 @@
 							}
 						},
 						{
-							"id": 3124,
+							"id": 3131,
 							"name": "clearValue",
 							"kind": 2048,
 							"kindString": "Method",
@@ -55290,7 +55233,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3125,
+									"id": 3132,
 									"name": "clearValue",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -55348,7 +55291,7 @@
 							}
 						},
 						{
-							"id": 3113,
+							"id": 3120,
 							"name": "click",
 							"kind": 2048,
 							"kindString": "Method",
@@ -55358,7 +55301,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3114,
+									"id": 3121,
 									"name": "click",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -55416,7 +55359,7 @@
 							}
 						},
 						{
-							"id": 3030,
+							"id": 3037,
 							"name": "clickMouseButton",
 							"kind": 2048,
 							"kindString": "Method",
@@ -55426,14 +55369,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3031,
+									"id": 3038,
 									"name": "clickMouseButton",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3032,
+											"id": 3039,
 											"name": "button",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -55508,7 +55451,7 @@
 							}
 						},
 						{
-							"id": 2956,
+							"id": 2963,
 							"name": "closeCurrentWindow",
 							"kind": 2048,
 							"kindString": "Method",
@@ -55518,7 +55461,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2957,
+									"id": 2964,
 									"name": "closeCurrentWindow",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -55576,7 +55519,7 @@
 							}
 						},
 						{
-							"id": 2943,
+							"id": 2950,
 							"name": "deactivateIme",
 							"kind": 2048,
 							"kindString": "Method",
@@ -55586,7 +55529,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2944,
+									"id": 2951,
 									"name": "deactivateIme",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -55644,7 +55587,7 @@
 							}
 						},
 						{
-							"id": 2996,
+							"id": 3003,
 							"name": "deleteCookie",
 							"kind": 2048,
 							"kindString": "Method",
@@ -55654,14 +55597,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2997,
+									"id": 3004,
 									"name": "deleteCookie",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2998,
+											"id": 3005,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -55725,7 +55668,7 @@
 							}
 						},
 						{
-							"id": 3020,
+							"id": 3027,
 							"name": "dismissAlert",
 							"kind": 2048,
 							"kindString": "Method",
@@ -55735,7 +55678,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3021,
+									"id": 3028,
 									"name": "dismissAlert",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -55793,7 +55736,7 @@
 							}
 						},
 						{
-							"id": 3039,
+							"id": 3046,
 							"name": "doubleClick",
 							"kind": 2048,
 							"kindString": "Method",
@@ -55803,7 +55746,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3040,
+									"id": 3047,
 									"name": "doubleClick",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -55861,7 +55804,7 @@
 							}
 						},
 						{
-							"id": 3064,
+							"id": 3071,
 							"name": "doubleTap",
 							"kind": 2048,
 							"kindString": "Method",
@@ -55871,14 +55814,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3065,
+									"id": 3072,
 									"name": "doubleTap",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3066,
+											"id": 3073,
 											"name": "element",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -55944,7 +55887,7 @@
 							}
 						},
 						{
-							"id": 2858,
+							"id": 2865,
 							"name": "end",
 							"kind": 2048,
 							"kindString": "Method",
@@ -55954,14 +55897,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2859,
+									"id": 2866,
 									"name": "end",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2860,
+											"id": 2867,
 											"name": "numCommandsToPop",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56036,7 +55979,7 @@
 							}
 						},
 						{
-							"id": 3141,
+							"id": 3148,
 							"name": "equals",
 							"kind": 2048,
 							"kindString": "Method",
@@ -56046,14 +55989,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3142,
+									"id": 3149,
 									"name": "equals",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3143,
+											"id": 3150,
 											"name": "other",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56117,7 +56060,7 @@
 							}
 						},
 						{
-							"id": 2925,
+							"id": 2932,
 							"name": "execute",
 							"kind": 2048,
 							"kindString": "Method",
@@ -56127,14 +56070,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2926,
+									"id": 2933,
 									"name": "execute",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2927,
+											"id": 2934,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -56143,7 +56086,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2928,
+											"id": 2935,
 											"name": "script",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56163,7 +56106,7 @@
 											}
 										},
 										{
-											"id": 2929,
+											"id": 2936,
 											"name": "args",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56232,7 +56175,7 @@
 							}
 						},
 						{
-							"id": 2930,
+							"id": 2937,
 							"name": "executeAsync",
 							"kind": 2048,
 							"kindString": "Method",
@@ -56242,14 +56185,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2931,
+									"id": 2938,
 									"name": "executeAsync",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2932,
+											"id": 2939,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -56258,7 +56201,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2933,
+											"id": 2940,
 											"name": "script",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56278,7 +56221,7 @@
 											}
 										},
 										{
-											"id": 2934,
+											"id": 2941,
 											"name": "args",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56347,7 +56290,7 @@
 							}
 						},
 						{
-							"id": 2884,
+							"id": 2891,
 							"name": "finally",
 							"kind": 2048,
 							"kindString": "Method",
@@ -56357,14 +56300,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2885,
+									"id": 2892,
 									"name": "finally",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2886,
+											"id": 2893,
 											"name": "callback",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56372,14 +56315,14 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 2887,
+													"id": 2894,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"signatures": [
 														{
-															"id": 2888,
+															"id": 2895,
 															"name": "__call",
 															"kind": 4096,
 															"kindString": "Call signature",
@@ -56424,7 +56367,7 @@
 							}
 						},
 						{
-							"id": 2891,
+							"id": 2898,
 							"name": "find",
 							"kind": 2048,
 							"kindString": "Method",
@@ -56434,14 +56377,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2892,
+									"id": 2899,
 									"name": "find",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2893,
+											"id": 2900,
 											"name": "strategy",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56452,7 +56395,7 @@
 											}
 										},
 										{
-											"id": 2894,
+											"id": 2901,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56508,7 +56451,7 @@
 							}
 						},
 						{
-							"id": 2895,
+							"id": 2902,
 							"name": "findAll",
 							"kind": 2048,
 							"kindString": "Method",
@@ -56518,14 +56461,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2896,
+									"id": 2903,
 									"name": "findAll",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2897,
+											"id": 2904,
 											"name": "strategy",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56536,7 +56479,7 @@
 											}
 										},
 										{
-											"id": 2898,
+											"id": 2905,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56598,7 +56541,7 @@
 							}
 						},
 						{
-							"id": 3183,
+							"id": 3190,
 							"name": "findAllByClassName",
 							"kind": 2048,
 							"kindString": "Method",
@@ -56608,14 +56551,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3184,
+									"id": 3191,
 									"name": "findAllByClassName",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3185,
+											"id": 3192,
 											"name": "className",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56669,7 +56612,7 @@
 							}
 						},
 						{
-							"id": 3186,
+							"id": 3193,
 							"name": "findAllByCssSelector",
 							"kind": 2048,
 							"kindString": "Method",
@@ -56679,14 +56622,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3187,
+									"id": 3194,
 									"name": "findAllByCssSelector",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3188,
+											"id": 3195,
 											"name": "selector",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56740,7 +56683,7 @@
 							}
 						},
 						{
-							"id": 3192,
+							"id": 3199,
 							"name": "findAllByLinkText",
 							"kind": 2048,
 							"kindString": "Method",
@@ -56750,14 +56693,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3193,
+									"id": 3200,
 									"name": "findAllByLinkText",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3194,
+											"id": 3201,
 											"name": "text",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56811,7 +56754,7 @@
 							}
 						},
 						{
-							"id": 3189,
+							"id": 3196,
 							"name": "findAllByName",
 							"kind": 2048,
 							"kindString": "Method",
@@ -56821,14 +56764,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3190,
+									"id": 3197,
 									"name": "findAllByName",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3191,
+											"id": 3198,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56882,7 +56825,7 @@
 							}
 						},
 						{
-							"id": 3195,
+							"id": 3202,
 							"name": "findAllByPartialLinkText",
 							"kind": 2048,
 							"kindString": "Method",
@@ -56892,14 +56835,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3196,
+									"id": 3203,
 									"name": "findAllByPartialLinkText",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3197,
+											"id": 3204,
 											"name": "text",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -56953,7 +56896,7 @@
 							}
 						},
 						{
-							"id": 3198,
+							"id": 3205,
 							"name": "findAllByTagName",
 							"kind": 2048,
 							"kindString": "Method",
@@ -56963,14 +56906,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3199,
+									"id": 3206,
 									"name": "findAllByTagName",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3200,
+											"id": 3207,
 											"name": "tagName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57024,7 +56967,7 @@
 							}
 						},
 						{
-							"id": 3201,
+							"id": 3208,
 							"name": "findAllByXpath",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57034,14 +56977,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3202,
+									"id": 3209,
 									"name": "findAllByXpath",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3203,
+											"id": 3210,
 											"name": "path",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57095,7 +57038,7 @@
 							}
 						},
 						{
-							"id": 3159,
+							"id": 3166,
 							"name": "findByClassName",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57105,14 +57048,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3160,
+									"id": 3167,
 									"name": "findByClassName",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3161,
+											"id": 3168,
 											"name": "className",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57160,7 +57103,7 @@
 							}
 						},
 						{
-							"id": 3162,
+							"id": 3169,
 							"name": "findByCssSelector",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57170,14 +57113,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3163,
+									"id": 3170,
 									"name": "findByCssSelector",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3164,
+											"id": 3171,
 											"name": "selector",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57225,7 +57168,7 @@
 							}
 						},
 						{
-							"id": 3165,
+							"id": 3172,
 							"name": "findById",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57235,14 +57178,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3166,
+									"id": 3173,
 									"name": "findById",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3167,
+											"id": 3174,
 											"name": "id",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57290,7 +57233,7 @@
 							}
 						},
 						{
-							"id": 3171,
+							"id": 3178,
 							"name": "findByLinkText",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57300,14 +57243,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3172,
+									"id": 3179,
 									"name": "findByLinkText",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3173,
+											"id": 3180,
 											"name": "text",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57355,7 +57298,7 @@
 							}
 						},
 						{
-							"id": 3168,
+							"id": 3175,
 							"name": "findByName",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57365,14 +57308,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3169,
+									"id": 3176,
 									"name": "findByName",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3170,
+											"id": 3177,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57420,7 +57363,7 @@
 							}
 						},
 						{
-							"id": 3174,
+							"id": 3181,
 							"name": "findByPartialLinkText",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57430,14 +57373,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3175,
+									"id": 3182,
 									"name": "findByPartialLinkText",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3176,
+											"id": 3183,
 											"name": "text",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57485,7 +57428,7 @@
 							}
 						},
 						{
-							"id": 3177,
+							"id": 3184,
 							"name": "findByTagName",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57495,14 +57438,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3178,
+									"id": 3185,
 									"name": "findByTagName",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3179,
+											"id": 3186,
 											"name": "tagName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57550,7 +57493,7 @@
 							}
 						},
 						{
-							"id": 3180,
+							"id": 3187,
 							"name": "findByXpath",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57560,14 +57503,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3181,
+									"id": 3188,
 									"name": "findByXpath",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3182,
+											"id": 3189,
 											"name": "path",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57615,7 +57558,7 @@
 							}
 						},
 						{
-							"id": 2899,
+							"id": 2906,
 							"name": "findDisplayed",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57625,14 +57568,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2900,
+									"id": 2907,
 									"name": "findDisplayed",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2901,
+											"id": 2908,
 											"name": "strategy",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57643,7 +57586,7 @@
 											}
 										},
 										{
-											"id": 2902,
+											"id": 2909,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57699,7 +57642,7 @@
 							}
 						},
 						{
-							"id": 3204,
+							"id": 3211,
 							"name": "findDisplayedByClassName",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57709,14 +57652,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3205,
+									"id": 3212,
 									"name": "findDisplayedByClassName",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3206,
+											"id": 3213,
 											"name": "className",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57764,7 +57707,7 @@
 							}
 						},
 						{
-							"id": 3207,
+							"id": 3214,
 							"name": "findDisplayedByCssSelector",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57774,14 +57717,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3208,
+									"id": 3215,
 									"name": "findDisplayedByCssSelector",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3209,
+											"id": 3216,
 											"name": "selector",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57829,7 +57772,7 @@
 							}
 						},
 						{
-							"id": 3210,
+							"id": 3217,
 							"name": "findDisplayedById",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57839,14 +57782,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3211,
+									"id": 3218,
 									"name": "findDisplayedById",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3212,
+											"id": 3219,
 											"name": "id",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57894,7 +57837,7 @@
 							}
 						},
 						{
-							"id": 3216,
+							"id": 3223,
 							"name": "findDisplayedByLinkText",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57904,14 +57847,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3217,
+									"id": 3224,
 									"name": "findDisplayedByLinkText",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3218,
+											"id": 3225,
 											"name": "text",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -57959,7 +57902,7 @@
 							}
 						},
 						{
-							"id": 3213,
+							"id": 3220,
 							"name": "findDisplayedByName",
 							"kind": 2048,
 							"kindString": "Method",
@@ -57969,14 +57912,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3214,
+									"id": 3221,
 									"name": "findDisplayedByName",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3215,
+											"id": 3222,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -58024,7 +57967,7 @@
 							}
 						},
 						{
-							"id": 3219,
+							"id": 3226,
 							"name": "findDisplayedByPartialLinkText",
 							"kind": 2048,
 							"kindString": "Method",
@@ -58034,14 +57977,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3220,
+									"id": 3227,
 									"name": "findDisplayedByPartialLinkText",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3221,
+											"id": 3228,
 											"name": "text",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -58089,7 +58032,7 @@
 							}
 						},
 						{
-							"id": 3222,
+							"id": 3229,
 							"name": "findDisplayedByTagName",
 							"kind": 2048,
 							"kindString": "Method",
@@ -58099,14 +58042,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3223,
+									"id": 3230,
 									"name": "findDisplayedByTagName",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3224,
+											"id": 3231,
 											"name": "tagName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -58154,7 +58097,7 @@
 							}
 						},
 						{
-							"id": 3225,
+							"id": 3232,
 							"name": "findDisplayedByXpath",
 							"kind": 2048,
 							"kindString": "Method",
@@ -58164,14 +58107,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3226,
+									"id": 3233,
 									"name": "findDisplayedByXpath",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3227,
+											"id": 3234,
 											"name": "path",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -58219,7 +58162,7 @@
 							}
 						},
 						{
-							"id": 3070,
+							"id": 3077,
 							"name": "flickFinger",
 							"kind": 2048,
 							"kindString": "Method",
@@ -58229,14 +58172,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3071,
+									"id": 3078,
 									"name": "flickFinger",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3072,
+											"id": 3079,
 											"name": "element",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -58247,7 +58190,7 @@
 											}
 										},
 										{
-											"id": 3073,
+											"id": 3080,
 											"name": "xOffset",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -58258,7 +58201,7 @@
 											}
 										},
 										{
-											"id": 3074,
+											"id": 3081,
 											"name": "yOffset",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -58269,7 +58212,7 @@
 											}
 										},
 										{
-											"id": 3075,
+											"id": 3082,
 											"name": "speed",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -58331,14 +58274,14 @@
 									}
 								},
 								{
-									"id": 3076,
+									"id": 3083,
 									"name": "flickFinger",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3077,
+											"id": 3084,
 											"name": "xOffset",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -58349,7 +58292,7 @@
 											}
 										},
 										{
-											"id": 3078,
+											"id": 3085,
 											"name": "yOffset",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -58360,7 +58303,7 @@
 											}
 										},
 										{
-											"id": 3079,
+											"id": 3086,
 											"name": "speed",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -58440,7 +58383,7 @@
 							}
 						},
 						{
-							"id": 2916,
+							"id": 2923,
 							"name": "get",
 							"kind": 2048,
 							"kindString": "Method",
@@ -58450,14 +58393,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2917,
+									"id": 2924,
 									"name": "get",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2918,
+											"id": 2925,
 											"name": "url",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -58521,7 +58464,7 @@
 							}
 						},
 						{
-							"id": 3003,
+							"id": 3010,
 							"name": "getActiveElement",
 							"kind": 2048,
 							"kindString": "Method",
@@ -58531,7 +58474,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3004,
+									"id": 3011,
 									"name": "getActiveElement",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -58589,7 +58532,7 @@
 							}
 						},
 						{
-							"id": 2939,
+							"id": 2946,
 							"name": "getActiveImeEngine",
 							"kind": 2048,
 							"kindString": "Method",
@@ -58599,7 +58542,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2940,
+									"id": 2947,
 									"name": "getActiveImeEngine",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -58657,7 +58600,7 @@
 							}
 						},
 						{
-							"id": 3013,
+							"id": 3020,
 							"name": "getAlertText",
 							"kind": 2048,
 							"kindString": "Method",
@@ -58667,7 +58610,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3014,
+									"id": 3021,
 									"name": "getAlertText",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -58725,7 +58668,7 @@
 							}
 						},
 						{
-							"id": 2912,
+							"id": 2919,
 							"name": "getAllWindowHandles",
 							"kind": 2048,
 							"kindString": "Method",
@@ -58735,7 +58678,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2913,
+									"id": 2920,
 									"name": "getAllWindowHandles",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -58796,7 +58739,7 @@
 							}
 						},
 						{
-							"id": 3090,
+							"id": 3097,
 							"name": "getApplicationCacheStatus",
 							"kind": 2048,
 							"kindString": "Method",
@@ -58806,7 +58749,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3091,
+									"id": 3098,
 									"name": "getApplicationCacheStatus",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -58864,7 +58807,7 @@
 							}
 						},
 						{
-							"id": 3133,
+							"id": 3140,
 							"name": "getAttribute",
 							"kind": 2048,
 							"kindString": "Method",
@@ -58874,14 +58817,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3134,
+									"id": 3141,
 									"name": "getAttribute",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 3135,
+											"id": 3142,
 											"name": "S",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -58890,7 +58833,7 @@
 									],
 									"parameters": [
 										{
-											"id": 3136,
+											"id": 3143,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -58954,7 +58897,7 @@
 							}
 						},
 						{
-							"id": 2937,
+							"id": 2944,
 							"name": "getAvailableImeEngines",
 							"kind": 2048,
 							"kindString": "Method",
@@ -58964,7 +58907,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2938,
+									"id": 2945,
 									"name": "getAvailableImeEngines",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -59025,7 +58968,7 @@
 							}
 						},
 						{
-							"id": 3088,
+							"id": 3095,
 							"name": "getAvailableLogTypes",
 							"kind": 2048,
 							"kindString": "Method",
@@ -59035,7 +58978,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3089,
+									"id": 3096,
 									"name": "getAvailableLogTypes",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -59096,7 +59039,7 @@
 							}
 						},
 						{
-							"id": 3156,
+							"id": 3163,
 							"name": "getComputedStyle",
 							"kind": 2048,
 							"kindString": "Method",
@@ -59106,14 +59049,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3157,
+									"id": 3164,
 									"name": "getComputedStyle",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3158,
+											"id": 3165,
 											"name": "propertyName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -59193,7 +59136,7 @@
 							}
 						},
 						{
-							"id": 2989,
+							"id": 2996,
 							"name": "getCookies",
 							"kind": 2048,
 							"kindString": "Method",
@@ -59203,7 +59146,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2990,
+									"id": 2997,
 									"name": "getCookies",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -59264,7 +59207,7 @@
 							}
 						},
 						{
-							"id": 2914,
+							"id": 2921,
 							"name": "getCurrentUrl",
 							"kind": 2048,
 							"kindString": "Method",
@@ -59274,7 +59217,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2915,
+									"id": 2922,
 									"name": "getCurrentUrl",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -59332,7 +59275,7 @@
 							}
 						},
 						{
-							"id": 2910,
+							"id": 2917,
 							"name": "getCurrentWindowHandle",
 							"kind": 2048,
 							"kindString": "Method",
@@ -59342,7 +59285,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2911,
+									"id": 2918,
 									"name": "getCurrentWindowHandle",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -59400,7 +59343,7 @@
 							}
 						},
 						{
-							"id": 3098,
+							"id": 3105,
 							"name": "getExecuteAsyncTimeout",
 							"kind": 2048,
 							"kindString": "Method",
@@ -59410,7 +59353,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3099,
+									"id": 3106,
 									"name": "getExecuteAsyncTimeout",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -59468,7 +59411,7 @@
 							}
 						},
 						{
-							"id": 3103,
+							"id": 3110,
 							"name": "getFindTimeout",
 							"kind": 2048,
 							"kindString": "Method",
@@ -59478,7 +59421,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3104,
+									"id": 3111,
 									"name": "getFindTimeout",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -59536,7 +59479,7 @@
 							}
 						},
 						{
-							"id": 3080,
+							"id": 3087,
 							"name": "getGeolocation",
 							"kind": 2048,
 							"kindString": "Method",
@@ -59546,7 +59489,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3081,
+									"id": 3088,
 									"name": "getGeolocation",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -59604,7 +59547,7 @@
 							}
 						},
 						{
-							"id": 3085,
+							"id": 3092,
 							"name": "getLogsFor",
 							"kind": 2048,
 							"kindString": "Method",
@@ -59614,14 +59557,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3086,
+									"id": 3093,
 									"name": "getLogsFor",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3087,
+											"id": 3094,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -59688,7 +59631,7 @@
 							}
 						},
 						{
-							"id": 3008,
+							"id": 3015,
 							"name": "getOrientation",
 							"kind": 2048,
 							"kindString": "Method",
@@ -59698,7 +59641,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3009,
+									"id": 3016,
 									"name": "getOrientation",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -59765,7 +59708,7 @@
 							}
 						},
 						{
-							"id": 3108,
+							"id": 3115,
 							"name": "getPageLoadTimeout",
 							"kind": 2048,
 							"kindString": "Method",
@@ -59775,7 +59718,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3109,
+									"id": 3116,
 									"name": "getPageLoadTimeout",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -59833,7 +59776,7 @@
 							}
 						},
 						{
-							"id": 2999,
+							"id": 3006,
 							"name": "getPageSource",
 							"kind": 2048,
 							"kindString": "Method",
@@ -59843,7 +59786,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3000,
+									"id": 3007,
 									"name": "getPageSource",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -59901,7 +59844,7 @@
 							}
 						},
 						{
-							"id": 3001,
+							"id": 3008,
 							"name": "getPageTitle",
 							"kind": 2048,
 							"kindString": "Method",
@@ -59911,7 +59854,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3002,
+									"id": 3009,
 									"name": "getPageTitle",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -59969,7 +59912,7 @@
 							}
 						},
 						{
-							"id": 3146,
+							"id": 3153,
 							"name": "getPosition",
 							"kind": 2048,
 							"kindString": "Method",
@@ -59979,7 +59922,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3147,
+									"id": 3154,
 									"name": "getPosition",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -59991,14 +59934,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 3148,
+													"id": 3155,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 3149,
+															"id": 3156,
 															"name": "x",
 															"kind": 32,
 															"kindString": "Variable",
@@ -60018,7 +59961,7 @@
 															}
 														},
 														{
-															"id": 3150,
+															"id": 3157,
 															"name": "y",
 															"kind": 32,
 															"kindString": "Variable",
@@ -60043,8 +59986,8 @@
 															"title": "Variables",
 															"kind": 32,
 															"children": [
-																3149,
-																3150
+																3156,
+																3157
 															]
 														}
 													],
@@ -60102,7 +60045,7 @@
 							}
 						},
 						{
-							"id": 3137,
+							"id": 3144,
 							"name": "getProperty",
 							"kind": 2048,
 							"kindString": "Method",
@@ -60112,14 +60055,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3138,
+									"id": 3145,
 									"name": "getProperty",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 3139,
+											"id": 3146,
 											"name": "T",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -60128,7 +60071,7 @@
 									],
 									"parameters": [
 										{
-											"id": 3140,
+											"id": 3147,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -60192,7 +60135,7 @@
 							}
 						},
 						{
-							"id": 3151,
+							"id": 3158,
 							"name": "getSize",
 							"kind": 2048,
 							"kindString": "Method",
@@ -60202,7 +60145,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3152,
+									"id": 3159,
 									"name": "getSize",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -60214,14 +60157,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 3153,
+													"id": 3160,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 3155,
+															"id": 3162,
 															"name": "height",
 															"kind": 32,
 															"kindString": "Variable",
@@ -60241,7 +60184,7 @@
 															}
 														},
 														{
-															"id": 3154,
+															"id": 3161,
 															"name": "width",
 															"kind": 32,
 															"kindString": "Variable",
@@ -60266,8 +60209,8 @@
 															"title": "Variables",
 															"kind": 32,
 															"children": [
-																3155,
-																3154
+																3162,
+																3161
 															]
 														}
 													],
@@ -60325,7 +60268,7 @@
 							}
 						},
 						{
-							"id": 3130,
+							"id": 3137,
 							"name": "getSpecAttribute",
 							"kind": 2048,
 							"kindString": "Method",
@@ -60335,14 +60278,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3131,
+									"id": 3138,
 									"name": "getSpecAttribute",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3132,
+											"id": 3139,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -60422,7 +60365,7 @@
 							}
 						},
 						{
-							"id": 3122,
+							"id": 3129,
 							"name": "getTagName",
 							"kind": 2048,
 							"kindString": "Method",
@@ -60432,7 +60375,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3123,
+									"id": 3130,
 									"name": "getTagName",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -60506,7 +60449,7 @@
 							}
 						},
 						{
-							"id": 2903,
+							"id": 2910,
 							"name": "getTimeout",
 							"kind": 2048,
 							"kindString": "Method",
@@ -60516,14 +60459,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2904,
+									"id": 2911,
 									"name": "getTimeout",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2905,
+											"id": 2912,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -60587,7 +60530,7 @@
 							}
 						},
 						{
-							"id": 3117,
+							"id": 3124,
 							"name": "getVisibleText",
 							"kind": 2048,
 							"kindString": "Method",
@@ -60597,7 +60540,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3118,
+									"id": 3125,
 									"name": "getVisibleText",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -60671,7 +60614,7 @@
 							}
 						},
 						{
-							"id": 2980,
+							"id": 2987,
 							"name": "getWindowPosition",
 							"kind": 2048,
 							"kindString": "Method",
@@ -60681,14 +60624,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2981,
+									"id": 2988,
 									"name": "getWindowPosition",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2982,
+											"id": 2989,
 											"name": "windowHandle",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -60717,14 +60660,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 2983,
+													"id": 2990,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 2984,
+															"id": 2991,
 															"name": "x",
 															"kind": 32,
 															"kindString": "Variable",
@@ -60744,7 +60687,7 @@
 															}
 														},
 														{
-															"id": 2985,
+															"id": 2992,
 															"name": "y",
 															"kind": 32,
 															"kindString": "Variable",
@@ -60769,8 +60712,8 @@
 															"title": "Variables",
 															"kind": 32,
 															"children": [
-																2984,
-																2985
+																2991,
+																2992
 															]
 														}
 													],
@@ -60828,7 +60771,7 @@
 							}
 						},
 						{
-							"id": 2966,
+							"id": 2973,
 							"name": "getWindowSize",
 							"kind": 2048,
 							"kindString": "Method",
@@ -60838,14 +60781,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2967,
+									"id": 2974,
 									"name": "getWindowSize",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2968,
+											"id": 2975,
 											"name": "_windowHandle",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -60874,14 +60817,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 2969,
+													"id": 2976,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 2971,
+															"id": 2978,
 															"name": "height",
 															"kind": 32,
 															"kindString": "Variable",
@@ -60901,7 +60844,7 @@
 															}
 														},
 														{
-															"id": 2970,
+															"id": 2977,
 															"name": "width",
 															"kind": 32,
 															"kindString": "Variable",
@@ -60926,8 +60869,8 @@
 															"title": "Variables",
 															"kind": 32,
 															"children": [
-																2971,
-																2970
+																2978,
+																2977
 															]
 														}
 													],
@@ -60985,7 +60928,7 @@
 							}
 						},
 						{
-							"id": 2921,
+							"id": 2928,
 							"name": "goBack",
 							"kind": 2048,
 							"kindString": "Method",
@@ -60995,7 +60938,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2922,
+									"id": 2929,
 									"name": "goBack",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -61053,7 +60996,7 @@
 							}
 						},
 						{
-							"id": 2919,
+							"id": 2926,
 							"name": "goForward",
 							"kind": 2048,
 							"kindString": "Method",
@@ -61063,7 +61006,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2920,
+									"id": 2927,
 									"name": "goForward",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -61121,7 +61064,7 @@
 							}
 						},
 						{
-							"id": 3144,
+							"id": 3151,
 							"name": "isDisplayed",
 							"kind": 2048,
 							"kindString": "Method",
@@ -61131,7 +61074,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3145,
+									"id": 3152,
 									"name": "isDisplayed",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -61189,7 +61132,7 @@
 							}
 						},
 						{
-							"id": 3128,
+							"id": 3135,
 							"name": "isEnabled",
 							"kind": 2048,
 							"kindString": "Method",
@@ -61199,7 +61142,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3129,
+									"id": 3136,
 									"name": "isEnabled",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -61257,7 +61200,7 @@
 							}
 						},
 						{
-							"id": 2941,
+							"id": 2948,
 							"name": "isImeActivated",
 							"kind": 2048,
 							"kindString": "Method",
@@ -61267,7 +61210,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2942,
+									"id": 2949,
 									"name": "isImeActivated",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -61325,7 +61268,7 @@
 							}
 						},
 						{
-							"id": 3126,
+							"id": 3133,
 							"name": "isSelected",
 							"kind": 2048,
 							"kindString": "Method",
@@ -61335,7 +61278,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3127,
+									"id": 3134,
 									"name": "isSelected",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -61393,7 +61336,7 @@
 							}
 						},
 						{
-							"id": 3067,
+							"id": 3074,
 							"name": "longTap",
 							"kind": 2048,
 							"kindString": "Method",
@@ -61403,14 +61346,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3068,
+									"id": 3075,
 									"name": "longTap",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3069,
+											"id": 3076,
 											"name": "element",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -61476,7 +61419,7 @@
 							}
 						},
 						{
-							"id": 2986,
+							"id": 2993,
 							"name": "maximizeWindow",
 							"kind": 2048,
 							"kindString": "Method",
@@ -61486,14 +61429,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2987,
+									"id": 2994,
 									"name": "maximizeWindow",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2988,
+											"id": 2995,
 											"name": "windowHandle",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -61568,7 +61511,7 @@
 							}
 						},
 						{
-							"id": 3052,
+							"id": 3059,
 							"name": "moveFinger",
 							"kind": 2048,
 							"kindString": "Method",
@@ -61578,14 +61521,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3053,
+									"id": 3060,
 									"name": "moveFinger",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3054,
+											"id": 3061,
 											"name": "x",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -61596,7 +61539,7 @@
 											}
 										},
 										{
-											"id": 3055,
+											"id": 3062,
 											"name": "y",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -61660,7 +61603,7 @@
 							}
 						},
 						{
-							"id": 3022,
+							"id": 3029,
 							"name": "moveMouseTo",
 							"kind": 2048,
 							"kindString": "Method",
@@ -61670,14 +61613,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3023,
+									"id": 3030,
 									"name": "moveMouseTo",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3024,
+											"id": 3031,
 											"name": "element",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -61690,7 +61633,7 @@
 											}
 										},
 										{
-											"id": 3025,
+											"id": 3032,
 											"name": "xOffset",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -61712,7 +61655,7 @@
 											}
 										},
 										{
-											"id": 3026,
+											"id": 3033,
 											"name": "yOffset",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -61774,14 +61717,14 @@
 									}
 								},
 								{
-									"id": 3027,
+									"id": 3034,
 									"name": "moveMouseTo",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3028,
+											"id": 3035,
 											"name": "xOffset",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -61803,7 +61746,7 @@
 											}
 										},
 										{
-											"id": 3029,
+											"id": 3036,
 											"name": "yOffset",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -61883,7 +61826,7 @@
 							}
 						},
 						{
-							"id": 3044,
+							"id": 3051,
 							"name": "pressFinger",
 							"kind": 2048,
 							"kindString": "Method",
@@ -61893,14 +61836,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3045,
+									"id": 3052,
 									"name": "pressFinger",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3046,
+											"id": 3053,
 											"name": "x",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -61911,7 +61854,7 @@
 											}
 										},
 										{
-											"id": 3047,
+											"id": 3054,
 											"name": "y",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -61975,7 +61918,7 @@
 							}
 						},
 						{
-							"id": 3005,
+							"id": 3012,
 							"name": "pressKeys",
 							"kind": 2048,
 							"kindString": "Method",
@@ -61985,14 +61928,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3006,
+									"id": 3013,
 									"name": "pressKeys",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3007,
+											"id": 3014,
 											"name": "keys",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -62068,7 +62011,7 @@
 							}
 						},
 						{
-							"id": 3033,
+							"id": 3040,
 							"name": "pressMouseButton",
 							"kind": 2048,
 							"kindString": "Method",
@@ -62078,14 +62021,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3034,
+									"id": 3041,
 									"name": "pressMouseButton",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3035,
+											"id": 3042,
 											"name": "button",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -62160,7 +62103,7 @@
 							}
 						},
 						{
-							"id": 3092,
+							"id": 3099,
 							"name": "quit",
 							"kind": 2048,
 							"kindString": "Method",
@@ -62170,7 +62113,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3093,
+									"id": 3100,
 									"name": "quit",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -62228,7 +62171,7 @@
 							}
 						},
 						{
-							"id": 2923,
+							"id": 2930,
 							"name": "refresh",
 							"kind": 2048,
 							"kindString": "Method",
@@ -62238,7 +62181,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2924,
+									"id": 2931,
 									"name": "refresh",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -62296,7 +62239,7 @@
 							}
 						},
 						{
-							"id": 3048,
+							"id": 3055,
 							"name": "releaseFinger",
 							"kind": 2048,
 							"kindString": "Method",
@@ -62306,14 +62249,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3049,
+									"id": 3056,
 									"name": "releaseFinger",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3050,
+											"id": 3057,
 											"name": "x",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -62324,7 +62267,7 @@
 											}
 										},
 										{
-											"id": 3051,
+											"id": 3058,
 											"name": "y",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -62388,7 +62331,7 @@
 							}
 						},
 						{
-							"id": 3036,
+							"id": 3043,
 							"name": "releaseMouseButton",
 							"kind": 2048,
 							"kindString": "Method",
@@ -62398,14 +62341,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3037,
+									"id": 3044,
 									"name": "releaseMouseButton",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3038,
+											"id": 3045,
 											"name": "button",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -62480,7 +62423,7 @@
 							}
 						},
 						{
-							"id": 2991,
+							"id": 2998,
 							"name": "setCookie",
 							"kind": 2048,
 							"kindString": "Method",
@@ -62490,14 +62433,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2992,
+									"id": 2999,
 									"name": "setCookie",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2993,
+											"id": 3000,
 											"name": "cookie",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -62561,7 +62504,7 @@
 							}
 						},
 						{
-							"id": 3100,
+							"id": 3107,
 							"name": "setExecuteAsyncTimeout",
 							"kind": 2048,
 							"kindString": "Method",
@@ -62571,14 +62514,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3101,
+									"id": 3108,
 									"name": "setExecuteAsyncTimeout",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3102,
+											"id": 3109,
 											"name": "ms",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -62642,7 +62585,7 @@
 							}
 						},
 						{
-							"id": 3105,
+							"id": 3112,
 							"name": "setFindTimeout",
 							"kind": 2048,
 							"kindString": "Method",
@@ -62652,14 +62595,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3106,
+									"id": 3113,
 									"name": "setFindTimeout",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3107,
+											"id": 3114,
 											"name": "ms",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -62723,7 +62666,7 @@
 							}
 						},
 						{
-							"id": 3082,
+							"id": 3089,
 							"name": "setGeolocation",
 							"kind": 2048,
 							"kindString": "Method",
@@ -62733,14 +62676,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3083,
+									"id": 3090,
 									"name": "setGeolocation",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3084,
+											"id": 3091,
 											"name": "location",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -62804,7 +62747,7 @@
 							}
 						},
 						{
-							"id": 2816,
+							"id": 2823,
 							"name": "setHeartbeatInterval",
 							"kind": 2048,
 							"kindString": "Method",
@@ -62814,14 +62757,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2817,
+									"id": 2824,
 									"name": "setHeartbeatInterval",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2818,
+											"id": 2825,
 											"name": "delay",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -62853,7 +62796,7 @@
 							]
 						},
 						{
-							"id": 3010,
+							"id": 3017,
 							"name": "setOrientation",
 							"kind": 2048,
 							"kindString": "Method",
@@ -62863,14 +62806,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3011,
+									"id": 3018,
 									"name": "setOrientation",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3012,
+											"id": 3019,
 											"name": "orientation",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -62943,7 +62886,7 @@
 							}
 						},
 						{
-							"id": 3110,
+							"id": 3117,
 							"name": "setPageLoadTimeout",
 							"kind": 2048,
 							"kindString": "Method",
@@ -62953,14 +62896,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3111,
+									"id": 3118,
 									"name": "setPageLoadTimeout",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3112,
+											"id": 3119,
 											"name": "ms",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63024,7 +62967,7 @@
 							}
 						},
 						{
-							"id": 2906,
+							"id": 2913,
 							"name": "setTimeout",
 							"kind": 2048,
 							"kindString": "Method",
@@ -63034,14 +62977,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2907,
+									"id": 2914,
 									"name": "setTimeout",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2908,
+											"id": 2915,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63052,7 +62995,7 @@
 											}
 										},
 										{
-											"id": 2909,
+											"id": 2916,
 											"name": "ms",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63116,7 +63059,7 @@
 							}
 						},
 						{
-							"id": 2972,
+							"id": 2979,
 							"name": "setWindowPosition",
 							"kind": 2048,
 							"kindString": "Method",
@@ -63126,14 +63069,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2973,
+									"id": 2980,
 									"name": "setWindowPosition",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2974,
+											"id": 2981,
 											"name": "x",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63144,7 +63087,7 @@
 											}
 										},
 										{
-											"id": 2975,
+											"id": 2982,
 											"name": "y",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63195,14 +63138,14 @@
 									}
 								},
 								{
-									"id": 2976,
+									"id": 2983,
 									"name": "setWindowPosition",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2977,
+											"id": 2984,
 											"name": "windowHandle",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63213,7 +63156,7 @@
 											}
 										},
 										{
-											"id": 2978,
+											"id": 2985,
 											"name": "x",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63224,7 +63167,7 @@
 											}
 										},
 										{
-											"id": 2979,
+											"id": 2986,
 											"name": "y",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63293,7 +63236,7 @@
 							}
 						},
 						{
-							"id": 2958,
+							"id": 2965,
 							"name": "setWindowSize",
 							"kind": 2048,
 							"kindString": "Method",
@@ -63303,14 +63246,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2959,
+									"id": 2966,
 									"name": "setWindowSize",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2960,
+											"id": 2967,
 											"name": "width",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63321,7 +63264,7 @@
 											}
 										},
 										{
-											"id": 2961,
+											"id": 2968,
 											"name": "height",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63372,14 +63315,14 @@
 									}
 								},
 								{
-									"id": 2962,
+									"id": 2969,
 									"name": "setWindowSize",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2963,
+											"id": 2970,
 											"name": "windowHandle",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63390,7 +63333,7 @@
 											}
 										},
 										{
-											"id": 2964,
+											"id": 2971,
 											"name": "width",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63401,7 +63344,7 @@
 											}
 										},
 										{
-											"id": 2965,
+											"id": 2972,
 											"name": "height",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63470,7 +63413,7 @@
 							}
 						},
 						{
-							"id": 2855,
+							"id": 2862,
 							"name": "sleep",
 							"kind": 2048,
 							"kindString": "Method",
@@ -63480,14 +63423,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2856,
+									"id": 2863,
 									"name": "sleep",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2857,
+											"id": 2864,
 											"name": "ms",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63551,7 +63494,7 @@
 							}
 						},
 						{
-							"id": 3115,
+							"id": 3122,
 							"name": "submit",
 							"kind": 2048,
 							"kindString": "Method",
@@ -63561,7 +63504,7 @@
 							},
 							"signatures": [
 								{
-									"id": 3116,
+									"id": 3123,
 									"name": "submit",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -63619,7 +63562,7 @@
 							}
 						},
 						{
-							"id": 2948,
+							"id": 2955,
 							"name": "switchToFrame",
 							"kind": 2048,
 							"kindString": "Method",
@@ -63629,14 +63572,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2949,
+									"id": 2956,
 									"name": "switchToFrame",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2950,
+											"id": 2957,
 											"name": "id",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63717,7 +63660,7 @@
 							}
 						},
 						{
-							"id": 2954,
+							"id": 2961,
 							"name": "switchToParentFrame",
 							"kind": 2048,
 							"kindString": "Method",
@@ -63727,7 +63670,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2955,
+									"id": 2962,
 									"name": "switchToParentFrame",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -63785,7 +63728,7 @@
 							}
 						},
 						{
-							"id": 2951,
+							"id": 2958,
 							"name": "switchToWindow",
 							"kind": 2048,
 							"kindString": "Method",
@@ -63795,14 +63738,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2952,
+									"id": 2959,
 									"name": "switchToWindow",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2953,
+											"id": 2960,
 											"name": "handle",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -63866,7 +63809,7 @@
 							}
 						},
 						{
-							"id": 2935,
+							"id": 2942,
 							"name": "takeScreenshot",
 							"kind": 2048,
 							"kindString": "Method",
@@ -63876,7 +63819,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2936,
+									"id": 2943,
 									"name": "takeScreenshot",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -63934,7 +63877,7 @@
 							}
 						},
 						{
-							"id": 3041,
+							"id": 3048,
 							"name": "tap",
 							"kind": 2048,
 							"kindString": "Method",
@@ -63944,14 +63887,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3042,
+									"id": 3049,
 									"name": "tap",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3043,
+											"id": 3050,
 											"name": "element",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -64015,7 +63958,7 @@
 							}
 						},
 						{
-							"id": 2861,
+							"id": 2868,
 							"name": "then",
 							"kind": 2048,
 							"kindString": "Method",
@@ -64025,21 +63968,21 @@
 							},
 							"signatures": [
 								{
-									"id": 2862,
+									"id": 2869,
 									"name": "then",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2863,
+											"id": 2870,
 											"name": "U",
 											"kind": 131072,
 											"kindString": "Type parameter",
 											"flags": {}
 										},
 										{
-											"id": 2864,
+											"id": 2871,
 											"name": "R",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -64048,7 +63991,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2865,
+											"id": 2872,
 											"name": "callback",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -64061,21 +64004,21 @@
 													{
 														"type": "reflection",
 														"declaration": {
-															"id": 2866,
+															"id": 2873,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"signatures": [
 																{
-																	"id": 2867,
+																	"id": 2874,
 																	"name": "__call",
 																	"kind": 4096,
 																	"kindString": "Call signature",
 																	"flags": {},
 																	"parameters": [
 																		{
-																			"id": 2868,
+																			"id": 2875,
 																			"name": "this",
 																			"kind": 32768,
 																			"kindString": "Parameter",
@@ -64116,7 +64059,7 @@
 																			}
 																		},
 																		{
-																			"id": 2869,
+																			"id": 2876,
 																			"name": "value",
 																			"kind": 32768,
 																			"kindString": "Parameter",
@@ -64127,7 +64070,7 @@
 																			}
 																		},
 																		{
-																			"id": 2870,
+																			"id": 2877,
 																			"name": "setContext",
 																			"kind": 32768,
 																			"kindString": "Parameter",
@@ -64180,7 +64123,7 @@
 											}
 										},
 										{
-											"id": 2871,
+											"id": 2878,
 											"name": "errback",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -64193,21 +64136,21 @@
 													{
 														"type": "reflection",
 														"declaration": {
-															"id": 2872,
+															"id": 2879,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"signatures": [
 																{
-																	"id": 2873,
+																	"id": 2880,
 																	"name": "__call",
 																	"kind": 4096,
 																	"kindString": "Call signature",
 																	"flags": {},
 																	"parameters": [
 																		{
-																			"id": 2874,
+																			"id": 2881,
 																			"name": "this",
 																			"kind": 32768,
 																			"kindString": "Parameter",
@@ -64248,7 +64191,7 @@
 																			}
 																		},
 																		{
-																			"id": 2875,
+																			"id": 2882,
 																			"name": "error",
 																			"kind": 32768,
 																			"kindString": "Parameter",
@@ -64363,7 +64306,7 @@
 							}
 						},
 						{
-							"id": 3056,
+							"id": 3063,
 							"name": "touchScroll",
 							"kind": 2048,
 							"kindString": "Method",
@@ -64373,14 +64316,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3057,
+									"id": 3064,
 									"name": "touchScroll",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3058,
+											"id": 3065,
 											"name": "xOffset",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -64391,7 +64334,7 @@
 											}
 										},
 										{
-											"id": 3059,
+											"id": 3066,
 											"name": "yOffset",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -64442,14 +64385,14 @@
 									}
 								},
 								{
-									"id": 3060,
+									"id": 3067,
 									"name": "touchScroll",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3061,
+											"id": 3068,
 											"name": "element",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -64462,7 +64405,7 @@
 											}
 										},
 										{
-											"id": 3062,
+											"id": 3069,
 											"name": "xOffset",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -64484,7 +64427,7 @@
 											}
 										},
 										{
-											"id": 3063,
+											"id": 3070,
 											"name": "yOffset",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -64564,7 +64507,7 @@
 							}
 						},
 						{
-							"id": 3119,
+							"id": 3126,
 							"name": "type",
 							"kind": 2048,
 							"kindString": "Method",
@@ -64574,14 +64517,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3120,
+									"id": 3127,
 									"name": "type",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3121,
+											"id": 3128,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -64657,7 +64600,7 @@
 							}
 						},
 						{
-							"id": 3015,
+							"id": 3022,
 							"name": "typeInPrompt",
 							"kind": 2048,
 							"kindString": "Method",
@@ -64667,14 +64610,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3016,
+									"id": 3023,
 									"name": "typeInPrompt",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3017,
+											"id": 3024,
 											"name": "text",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -64750,7 +64693,7 @@
 							}
 						},
 						{
-							"id": 3094,
+							"id": 3101,
 							"name": "waitForDeleted",
 							"kind": 2048,
 							"kindString": "Method",
@@ -64760,14 +64703,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3095,
+									"id": 3102,
 									"name": "waitForDeleted",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3096,
+											"id": 3103,
 											"name": "using",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -64778,7 +64721,7 @@
 											}
 										},
 										{
-											"id": 3097,
+											"id": 3104,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -64850,7 +64793,7 @@
 							}
 						},
 						{
-							"id": 3228,
+							"id": 3235,
 							"name": "waitForDeletedByClassName",
 							"kind": 2048,
 							"kindString": "Method",
@@ -64860,14 +64803,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3229,
+									"id": 3236,
 									"name": "waitForDeletedByClassName",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3230,
+											"id": 3237,
 											"name": "className",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -64931,7 +64874,7 @@
 							}
 						},
 						{
-							"id": 3231,
+							"id": 3238,
 							"name": "waitForDeletedByCssSelector",
 							"kind": 2048,
 							"kindString": "Method",
@@ -64941,14 +64884,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3232,
+									"id": 3239,
 									"name": "waitForDeletedByCssSelector",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3233,
+											"id": 3240,
 											"name": "selector",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -65012,7 +64955,7 @@
 							}
 						},
 						{
-							"id": 3234,
+							"id": 3241,
 							"name": "waitForDeletedById",
 							"kind": 2048,
 							"kindString": "Method",
@@ -65022,14 +64965,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3235,
+									"id": 3242,
 									"name": "waitForDeletedById",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3236,
+											"id": 3243,
 											"name": "id",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -65093,7 +65036,7 @@
 							}
 						},
 						{
-							"id": 3240,
+							"id": 3247,
 							"name": "waitForDeletedByLinkText",
 							"kind": 2048,
 							"kindString": "Method",
@@ -65103,14 +65046,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3241,
+									"id": 3248,
 									"name": "waitForDeletedByLinkText",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3242,
+											"id": 3249,
 											"name": "text",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -65174,7 +65117,7 @@
 							}
 						},
 						{
-							"id": 3237,
+							"id": 3244,
 							"name": "waitForDeletedByName",
 							"kind": 2048,
 							"kindString": "Method",
@@ -65184,14 +65127,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3238,
+									"id": 3245,
 									"name": "waitForDeletedByName",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3239,
+											"id": 3246,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -65255,7 +65198,7 @@
 							}
 						},
 						{
-							"id": 3243,
+							"id": 3250,
 							"name": "waitForDeletedByPartialLinkText",
 							"kind": 2048,
 							"kindString": "Method",
@@ -65265,14 +65208,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3244,
+									"id": 3251,
 									"name": "waitForDeletedByPartialLinkText",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3245,
+											"id": 3252,
 											"name": "text",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -65336,7 +65279,7 @@
 							}
 						},
 						{
-							"id": 3246,
+							"id": 3253,
 							"name": "waitForDeletedByTagName",
 							"kind": 2048,
 							"kindString": "Method",
@@ -65346,14 +65289,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3247,
+									"id": 3254,
 									"name": "waitForDeletedByTagName",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3248,
+											"id": 3255,
 											"name": "tagName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -65417,7 +65360,7 @@
 							}
 						},
 						{
-							"id": 3249,
+							"id": 3256,
 							"name": "waitForDeletedByXpath",
 							"kind": 2048,
 							"kindString": "Method",
@@ -65427,14 +65370,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3250,
+									"id": 3257,
 									"name": "waitForDeletedByXpath",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3251,
+											"id": 3258,
 											"name": "path",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -65498,7 +65441,7 @@
 							}
 						},
 						{
-							"id": 2829,
+							"id": 2836,
 							"name": "addElementMethod",
 							"kind": 2048,
 							"kindString": "Method",
@@ -65509,28 +65452,28 @@
 							},
 							"signatures": [
 								{
-									"id": 2830,
+									"id": 2837,
 									"name": "addElementMethod",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2831,
+											"id": 2838,
 											"name": "Us",
 											"kind": 131072,
 											"kindString": "Type parameter",
 											"flags": {}
 										},
 										{
-											"id": 2832,
+											"id": 2839,
 											"name": "Ps",
 											"kind": 131072,
 											"kindString": "Type parameter",
 											"flags": {}
 										},
 										{
-											"id": 2833,
+											"id": 2840,
 											"name": "Ss",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -65555,7 +65498,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2834,
+											"id": 2841,
 											"name": "target",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -65596,7 +65539,7 @@
 											}
 										},
 										{
-											"id": 2835,
+											"id": 2842,
 											"name": "key",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -65630,7 +65573,7 @@
 							}
 						},
 						{
-							"id": 2821,
+							"id": 2828,
 							"name": "addSessionMethod",
 							"kind": 2048,
 							"kindString": "Method",
@@ -65641,28 +65584,28 @@
 							},
 							"signatures": [
 								{
-									"id": 2822,
+									"id": 2829,
 									"name": "addSessionMethod",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"typeParameter": [
 										{
-											"id": 2823,
+											"id": 2830,
 											"name": "Us",
 											"kind": 131072,
 											"kindString": "Type parameter",
 											"flags": {}
 										},
 										{
-											"id": 2824,
+											"id": 2831,
 											"name": "Ps",
 											"kind": 131072,
 											"kindString": "Type parameter",
 											"flags": {}
 										},
 										{
-											"id": 2825,
+											"id": 2832,
 											"name": "Ss",
 											"kind": 131072,
 											"kindString": "Type parameter",
@@ -65687,7 +65630,7 @@
 									],
 									"parameters": [
 										{
-											"id": 2826,
+											"id": 2833,
 											"name": "target",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -65728,7 +65671,7 @@
 											}
 										},
 										{
-											"id": 2827,
+											"id": 2834,
 											"name": "key",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -65739,7 +65682,7 @@
 											}
 										},
 										{
-											"id": 2828,
+											"id": 2835,
 											"name": "originalFn",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -65778,150 +65721,150 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								2836
+								2843
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2853,
-								2814,
-								2851,
-								2854,
-								2815,
-								2852
+								2860,
+								2821,
+								2858,
+								2861,
+								2822,
+								2859
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								3018,
-								2945,
-								2889,
-								2876,
-								2994,
-								3124,
-								3113,
-								3030,
-								2956,
-								2943,
-								2996,
-								3020,
-								3039,
-								3064,
-								2858,
-								3141,
-								2925,
-								2930,
-								2884,
-								2891,
-								2895,
-								3183,
-								3186,
-								3192,
-								3189,
-								3195,
-								3198,
-								3201,
-								3159,
-								3162,
-								3165,
-								3171,
-								3168,
-								3174,
-								3177,
-								3180,
-								2899,
-								3204,
-								3207,
-								3210,
-								3216,
-								3213,
-								3219,
-								3222,
-								3225,
-								3070,
-								2916,
-								3003,
-								2939,
-								3013,
-								2912,
-								3090,
-								3133,
-								2937,
-								3088,
-								3156,
-								2989,
-								2914,
-								2910,
-								3098,
-								3103,
-								3080,
-								3085,
-								3008,
-								3108,
-								2999,
+								3025,
+								2952,
+								2896,
+								2883,
 								3001,
-								3146,
-								3137,
-								3151,
-								3130,
-								3122,
-								2903,
-								3117,
-								2980,
-								2966,
-								2921,
-								2919,
-								3144,
-								3128,
-								2941,
-								3126,
-								3067,
-								2986,
-								3052,
-								3022,
-								3044,
-								3005,
-								3033,
-								3092,
-								2923,
-								3048,
-								3036,
-								2991,
-								3100,
-								3105,
-								3082,
-								2816,
-								3010,
-								3110,
+								3131,
+								3120,
+								3037,
+								2963,
+								2950,
+								3003,
+								3027,
+								3046,
+								3071,
+								2865,
+								3148,
+								2932,
+								2937,
+								2891,
+								2898,
+								2902,
+								3190,
+								3193,
+								3199,
+								3196,
+								3202,
+								3205,
+								3208,
+								3166,
+								3169,
+								3172,
+								3178,
+								3175,
+								3181,
+								3184,
+								3187,
 								2906,
-								2972,
-								2958,
-								2855,
-								3115,
-								2948,
-								2954,
-								2951,
-								2935,
-								3041,
-								2861,
-								3056,
-								3119,
+								3211,
+								3214,
+								3217,
+								3223,
+								3220,
+								3226,
+								3229,
+								3232,
+								3077,
+								2923,
+								3010,
+								2946,
+								3020,
+								2919,
+								3097,
+								3140,
+								2944,
+								3095,
+								3163,
+								2996,
+								2921,
+								2917,
+								3105,
+								3110,
+								3087,
+								3092,
 								3015,
-								3094,
-								3228,
-								3231,
-								3234,
-								3240,
-								3237,
-								3243,
-								3246,
-								3249,
-								2829,
-								2821
+								3115,
+								3006,
+								3008,
+								3153,
+								3144,
+								3158,
+								3137,
+								3129,
+								2910,
+								3124,
+								2987,
+								2973,
+								2928,
+								2926,
+								3151,
+								3135,
+								2948,
+								3133,
+								3074,
+								2993,
+								3059,
+								3029,
+								3051,
+								3012,
+								3040,
+								3099,
+								2930,
+								3055,
+								3043,
+								2998,
+								3107,
+								3112,
+								3089,
+								2823,
+								3017,
+								3117,
+								2913,
+								2979,
+								2965,
+								2862,
+								3122,
+								2955,
+								2961,
+								2958,
+								2942,
+								3048,
+								2868,
+								3063,
+								3126,
+								3022,
+								3101,
+								3235,
+								3238,
+								3241,
+								3247,
+								3244,
+								3250,
+								3253,
+								3256,
+								2836,
+								2828
 							]
 						}
 					],
@@ -65958,7 +65901,7 @@
 					]
 				},
 				{
-					"id": 3252,
+					"id": 3259,
 					"name": "TunnelMessage",
 					"kind": 256,
 					"kindString": "Interface",
@@ -65968,7 +65911,7 @@
 					},
 					"children": [
 						{
-							"id": 3254,
+							"id": 3261,
 							"name": "progress",
 							"kind": 1024,
 							"kindString": "Property",
@@ -65990,7 +65933,7 @@
 							}
 						},
 						{
-							"id": 3255,
+							"id": 3262,
 							"name": "status",
 							"kind": 1024,
 							"kindString": "Property",
@@ -66021,7 +65964,7 @@
 							}
 						},
 						{
-							"id": 3253,
+							"id": 3260,
 							"name": "tunnel",
 							"kind": 1024,
 							"kindString": "Property",
@@ -66047,9 +65990,9 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3254,
-								3255,
-								3253
+								3261,
+								3262,
+								3260
 							]
 						}
 					],
@@ -66062,7 +66005,7 @@
 					]
 				},
 				{
-					"id": 3306,
+					"id": 3313,
 					"name": "process",
 					"kind": 32,
 					"kindString": "Variable",
@@ -66084,7 +66027,7 @@
 					"defaultValue": " global.process"
 				},
 				{
-					"id": 3313,
+					"id": 3320,
 					"name": "getNormalizedBrowserName",
 					"kind": 64,
 					"kindString": "Function",
@@ -66093,14 +66036,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3314,
+							"id": 3321,
 							"name": "getNormalizedBrowserName",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3315,
+									"id": 3322,
 									"name": "name",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -66144,7 +66087,7 @@
 					]
 				},
 				{
-					"id": 3310,
+					"id": 3317,
 					"name": "isLocalEnvironment",
 					"kind": 64,
 					"kindString": "Function",
@@ -66153,14 +66096,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3311,
+							"id": 3318,
 							"name": "isLocalEnvironment",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3312,
+									"id": 3319,
 									"name": "environment",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -66168,7 +66111,7 @@
 									"type": {
 										"type": "reference",
 										"name": "EnvironmentSpec",
-										"id": 4189
+										"id": 4196
 									}
 								}
 							],
@@ -66187,7 +66130,7 @@
 					]
 				},
 				{
-					"id": 3307,
+					"id": 3314,
 					"name": "isRemoteEnvironment",
 					"kind": 64,
 					"kindString": "Function",
@@ -66196,14 +66139,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3308,
+							"id": 3315,
 							"name": "isRemoteEnvironment",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3309,
+									"id": 3316,
 									"name": "environment",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -66211,7 +66154,7 @@
 									"type": {
 										"type": "reference",
 										"name": "EnvironmentSpec",
-										"id": 4189
+										"id": 4196
 									}
 								}
 							],
@@ -66235,35 +66178,35 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						3279,
-						2600
+						3286,
+						2607
 					]
 				},
 				{
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						3256,
-						2810,
-						3296,
-						2813,
-						3252
+						3263,
+						2817,
+						3303,
+						2820,
+						3259
 					]
 				},
 				{
 					"title": "Variables",
 					"kind": 32,
 					"children": [
-						3306
+						3313
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						3313,
-						3310,
-						3307
+						3320,
+						3317,
+						3314
 					]
 				}
 			],
@@ -66276,7 +66219,7 @@
 			]
 		},
 		{
-			"id": 3627,
+			"id": 3634,
 			"name": "\"lib/interfaces/bdd\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -66287,7 +66230,7 @@
 			"originalName": "src/lib/interfaces/bdd.ts",
 			"children": [
 				{
-					"id": 3628,
+					"id": 3635,
 					"name": "BddInterface",
 					"kind": 256,
 					"kindString": "Interface",
@@ -66297,7 +66240,7 @@
 					},
 					"children": [
 						{
-							"id": 3640,
+							"id": 3647,
 							"name": "after",
 							"kind": 2048,
 							"kindString": "Method",
@@ -66307,14 +66250,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3641,
+									"id": 3648,
 									"name": "after",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3642,
+											"id": 3649,
 											"name": "fn",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -66329,7 +66272,7 @@
 													{
 														"type": "reference",
 														"name": "SuiteLifecycleFunction",
-														"id": 3470
+														"id": 3477
 													}
 												]
 											}
@@ -66342,7 +66285,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "TddLifecycleInterface.after",
-										"id": 3576
+										"id": 3583
 									}
 								}
 							],
@@ -66356,11 +66299,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "TddLifecycleInterface.after",
-								"id": 3576
+								"id": 3583
 							}
 						},
 						{
-							"id": 3646,
+							"id": 3653,
 							"name": "afterEach",
 							"kind": 2048,
 							"kindString": "Method",
@@ -66370,14 +66313,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3647,
+									"id": 3654,
 									"name": "afterEach",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3648,
+											"id": 3655,
 											"name": "fn",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -66392,7 +66335,7 @@
 													{
 														"type": "reference",
 														"name": "TestLifecycleFunction",
-														"id": 3474
+														"id": 3481
 													}
 												]
 											}
@@ -66405,7 +66348,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "TddLifecycleInterface.afterEach",
-										"id": 3582
+										"id": 3589
 									}
 								}
 							],
@@ -66419,11 +66362,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "TddLifecycleInterface.afterEach",
-								"id": 3582
+								"id": 3589
 							}
 						},
 						{
-							"id": 3637,
+							"id": 3644,
 							"name": "before",
 							"kind": 2048,
 							"kindString": "Method",
@@ -66433,14 +66376,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3638,
+									"id": 3645,
 									"name": "before",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3639,
+											"id": 3646,
 											"name": "fn",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -66455,7 +66398,7 @@
 													{
 														"type": "reference",
 														"name": "SuiteLifecycleFunction",
-														"id": 3470
+														"id": 3477
 													}
 												]
 											}
@@ -66468,7 +66411,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "TddLifecycleInterface.before",
-										"id": 3573
+										"id": 3580
 									}
 								}
 							],
@@ -66482,11 +66425,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "TddLifecycleInterface.before",
-								"id": 3573
+								"id": 3580
 							}
 						},
 						{
-							"id": 3643,
+							"id": 3650,
 							"name": "beforeEach",
 							"kind": 2048,
 							"kindString": "Method",
@@ -66496,14 +66439,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3644,
+									"id": 3651,
 									"name": "beforeEach",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3645,
+											"id": 3652,
 											"name": "fn",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -66518,7 +66461,7 @@
 													{
 														"type": "reference",
 														"name": "TestLifecycleFunction",
-														"id": 3474
+														"id": 3481
 													}
 												]
 											}
@@ -66531,7 +66474,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "TddLifecycleInterface.beforeEach",
-										"id": 3579
+										"id": 3586
 									}
 								}
 							],
@@ -66545,11 +66488,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "TddLifecycleInterface.beforeEach",
-								"id": 3579
+								"id": 3586
 							}
 						},
 						{
-							"id": 3629,
+							"id": 3636,
 							"name": "describe",
 							"kind": 2048,
 							"kindString": "Method",
@@ -66559,14 +66502,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3630,
+									"id": 3637,
 									"name": "describe",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3631,
+											"id": 3638,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -66577,7 +66520,7 @@
 											}
 										},
 										{
-											"id": 3632,
+											"id": 3639,
 											"name": "factory",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -66585,7 +66528,7 @@
 											"type": {
 												"type": "reference",
 												"name": "TddSuiteFactory",
-												"id": 3585
+												"id": 3592
 											}
 										}
 									],
@@ -66604,7 +66547,7 @@
 							]
 						},
 						{
-							"id": 3633,
+							"id": 3640,
 							"name": "it",
 							"kind": 2048,
 							"kindString": "Method",
@@ -66614,14 +66557,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3634,
+									"id": 3641,
 									"name": "it",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3635,
+											"id": 3642,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -66632,7 +66575,7 @@
 											}
 										},
 										{
-											"id": 3636,
+											"id": 3643,
 											"name": "test",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -66640,7 +66583,7 @@
 											"type": {
 												"type": "reference",
 												"name": "TestFunction",
-												"id": 3374
+												"id": 3381
 											}
 										}
 									],
@@ -66664,12 +66607,12 @@
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								3640,
-								3646,
-								3637,
-								3643,
-								3629,
-								3633
+								3647,
+								3653,
+								3644,
+								3650,
+								3636,
+								3640
 							]
 						}
 					],
@@ -66684,12 +66627,12 @@
 						{
 							"type": "reference",
 							"name": "TddLifecycleInterface",
-							"id": 3572
+							"id": 3579
 						}
 					]
 				},
 				{
-					"id": 3649,
+					"id": 3656,
 					"name": "getInterface",
 					"kind": 64,
 					"kindString": "Function",
@@ -66699,14 +66642,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3650,
+							"id": 3657,
 							"name": "getInterface",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3651,
+									"id": 3658,
 									"name": "executor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -66714,14 +66657,14 @@
 									"type": {
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
 								"name": "BddInterface",
-								"id": 3628
+								"id": 3635
 							}
 						}
 					],
@@ -66739,14 +66682,14 @@
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						3628
+						3635
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						3649
+						3656
 					]
 				}
 			],
@@ -66759,7 +66702,7 @@
 			]
 		},
 		{
-			"id": 3742,
+			"id": 3749,
 			"name": "\"lib/interfaces/benchmark\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -66773,7 +66716,7 @@
 			},
 			"children": [
 				{
-					"id": 3743,
+					"id": 3750,
 					"name": "BenchmarkInterface",
 					"kind": 256,
 					"kindString": "Interface",
@@ -66783,7 +66726,7 @@
 					},
 					"children": [
 						{
-							"id": 3748,
+							"id": 3755,
 							"name": "async",
 							"kind": 1024,
 							"kindString": "Property",
@@ -66801,21 +66744,21 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3749,
+									"id": 3756,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"signatures": [
 										{
-											"id": 3750,
+											"id": 3757,
 											"name": "__call",
 											"kind": 4096,
 											"kindString": "Call signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 3751,
+													"id": 3758,
 													"name": "testFunction",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -66823,11 +66766,11 @@
 													"type": {
 														"type": "reference",
 														"name": "BenchmarkDeferredTestFunction",
-														"id": 2052
+														"id": 2059
 													}
 												},
 												{
-													"id": 3752,
+													"id": 3759,
 													"name": "numCallsUntilResolution",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -66852,7 +66795,7 @@
 											"type": {
 												"type": "reference",
 												"name": "BenchmarkTestFunction",
-												"id": 2045
+												"id": 2052
 											}
 										}
 									],
@@ -66867,7 +66810,7 @@
 							}
 						},
 						{
-							"id": 3744,
+							"id": 3751,
 							"name": "registerSuite",
 							"kind": 2048,
 							"kindString": "Method",
@@ -66877,14 +66820,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3745,
+									"id": 3752,
 									"name": "registerSuite",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3746,
+											"id": 3753,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -66895,7 +66838,7 @@
 											}
 										},
 										{
-											"id": 3747,
+											"id": 3754,
 											"name": "descriptor",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -66906,17 +66849,17 @@
 													{
 														"type": "reference",
 														"name": "BenchmarkSuiteDescriptor",
-														"id": 3756
+														"id": 3763
 													},
 													{
 														"type": "reference",
 														"name": "BenchmarkSuiteFactory",
-														"id": 3759
+														"id": 3766
 													},
 													{
 														"type": "reference",
 														"name": "BenchmarkTests",
-														"id": 3753
+														"id": 3760
 													}
 												]
 											}
@@ -66942,14 +66885,14 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3748
+								3755
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								3744
+								3751
 							]
 						}
 					],
@@ -66962,7 +66905,7 @@
 					]
 				},
 				{
-					"id": 3756,
+					"id": 3763,
 					"name": "BenchmarkSuiteDescriptor",
 					"kind": 256,
 					"kindString": "Interface",
@@ -66972,7 +66915,7 @@
 					},
 					"children": [
 						{
-							"id": 3757,
+							"id": 3764,
 							"name": "tests",
 							"kind": 1024,
 							"kindString": "Property",
@@ -66990,7 +66933,7 @@
 							"type": {
 								"type": "reference",
 								"name": "BenchmarkTests",
-								"id": 3753
+								"id": 3760
 							}
 						}
 					],
@@ -66999,7 +66942,7 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3757
+								3764
 							]
 						}
 					],
@@ -67014,7 +66957,7 @@
 						{
 							"type": "reflection",
 							"declaration": {
-								"id": 3758,
+								"id": 3765,
 								"name": "__type",
 								"kind": 65536,
 								"kindString": "Type literal",
@@ -67031,7 +66974,7 @@
 					]
 				},
 				{
-					"id": 3759,
+					"id": 3766,
 					"name": "BenchmarkSuiteFactory",
 					"kind": 256,
 					"kindString": "Interface",
@@ -67041,7 +66984,7 @@
 					},
 					"signatures": [
 						{
-							"id": 3760,
+							"id": 3767,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -67052,12 +66995,12 @@
 									{
 										"type": "reference",
 										"name": "BenchmarkSuiteDescriptor",
-										"id": 3756
+										"id": 3763
 									},
 									{
 										"type": "reference",
 										"name": "BenchmarkTests",
-										"id": 3753
+										"id": 3760
 									}
 								]
 							}
@@ -67072,7 +67015,7 @@
 					]
 				},
 				{
-					"id": 3753,
+					"id": 3760,
 					"name": "BenchmarkTests",
 					"kind": 256,
 					"kindString": "Interface",
@@ -67082,14 +67025,14 @@
 					},
 					"indexSignature": [
 						{
-							"id": 3754,
+							"id": 3761,
 							"name": "__index",
 							"kind": 8192,
 							"kindString": "Index signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3755,
+									"id": 3762,
 									"name": "name",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67106,17 +67049,17 @@
 									{
 										"type": "reference",
 										"name": "BenchmarkSuiteDescriptor",
-										"id": 3756
+										"id": 3763
 									},
 									{
 										"type": "reference",
 										"name": "BenchmarkTestFunction",
-										"id": 2045
+										"id": 2052
 									},
 									{
 										"type": "reference",
 										"name": "BenchmarkTests",
-										"id": 3753
+										"id": 3760
 									}
 								]
 							}
@@ -67131,7 +67074,7 @@
 					]
 				},
 				{
-					"id": 3774,
+					"id": 3781,
 					"name": "_registerSuite",
 					"kind": 64,
 					"kindString": "Function",
@@ -67140,14 +67083,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3775,
+							"id": 3782,
 							"name": "_registerSuite",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3776,
+									"id": 3783,
 									"name": "executor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67155,11 +67098,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									}
 								},
 								{
-									"id": 3777,
+									"id": 3784,
 									"name": "name",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67170,7 +67113,7 @@
 									}
 								},
 								{
-									"id": 3778,
+									"id": 3785,
 									"name": "descriptorOrFactory",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67181,17 +67124,17 @@
 											{
 												"type": "reference",
 												"name": "BenchmarkSuiteDescriptor",
-												"id": 3756
+												"id": 3763
 											},
 											{
 												"type": "reference",
 												"name": "BenchmarkSuiteFactory",
-												"id": 3759
+												"id": 3766
 											},
 											{
 												"type": "reference",
 												"name": "BenchmarkTests",
-												"id": 3753
+												"id": 3760
 											}
 										]
 									}
@@ -67212,7 +67155,7 @@
 					]
 				},
 				{
-					"id": 3765,
+					"id": 3772,
 					"name": "getInterface",
 					"kind": 64,
 					"kindString": "Function",
@@ -67222,7 +67165,7 @@
 					},
 					"signatures": [
 						{
-							"id": 3766,
+							"id": 3773,
 							"name": "getInterface",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -67232,7 +67175,7 @@
 							},
 							"parameters": [
 								{
-									"id": 3767,
+									"id": 3774,
 									"name": "executor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67240,21 +67183,21 @@
 									"type": {
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									}
 								}
 							],
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3768,
+									"id": 3775,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 3773,
+											"id": 3780,
 											"name": "async",
 											"kind": 32,
 											"kindString": "Variable",
@@ -67271,12 +67214,12 @@
 											"type": {
 												"type": "reference",
 												"name": "async",
-												"id": 2005
+												"id": 2012
 											},
 											"defaultValue": " BenchmarkTest.async"
 										},
 										{
-											"id": 3769,
+											"id": 3776,
 											"name": "registerSuite",
 											"kind": 64,
 											"kindString": "Function",
@@ -67285,14 +67228,14 @@
 											},
 											"signatures": [
 												{
-													"id": 3770,
+													"id": 3777,
 													"name": "registerSuite",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 3771,
+															"id": 3778,
 															"name": "name",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -67303,7 +67246,7 @@
 															}
 														},
 														{
-															"id": 3772,
+															"id": 3779,
 															"name": "descriptorOrFactory",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -67314,17 +67257,17 @@
 																	{
 																		"type": "reference",
 																		"name": "BenchmarkSuiteDescriptor",
-																		"id": 3756
+																		"id": 3763
 																	},
 																	{
 																		"type": "reference",
 																		"name": "BenchmarkSuiteFactory",
-																		"id": 3759
+																		"id": 3766
 																	},
 																	{
 																		"type": "reference",
 																		"name": "BenchmarkTests",
-																		"id": 3753
+																		"id": 3760
 																	}
 																]
 															}
@@ -67350,14 +67293,14 @@
 											"title": "Variables",
 											"kind": 32,
 											"children": [
-												3773
+												3780
 											]
 										},
 										{
 											"title": "Functions",
 											"kind": 64,
 											"children": [
-												3769
+												3776
 											]
 										}
 									]
@@ -67374,7 +67317,7 @@
 					]
 				},
 				{
-					"id": 3761,
+					"id": 3768,
 					"name": "registerSuite",
 					"kind": 64,
 					"kindString": "Function",
@@ -67384,7 +67327,7 @@
 					},
 					"signatures": [
 						{
-							"id": 3762,
+							"id": 3769,
 							"name": "registerSuite",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -67394,7 +67337,7 @@
 							},
 							"parameters": [
 								{
-									"id": 3763,
+									"id": 3770,
 									"name": "name",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67405,7 +67348,7 @@
 									}
 								},
 								{
-									"id": 3764,
+									"id": 3771,
 									"name": "descriptorOrFactory",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67416,17 +67359,17 @@
 											{
 												"type": "reference",
 												"name": "BenchmarkSuiteDescriptor",
-												"id": 3756
+												"id": 3763
 											},
 											{
 												"type": "reference",
 												"name": "BenchmarkSuiteFactory",
-												"id": 3759
+												"id": 3766
 											},
 											{
 												"type": "reference",
 												"name": "BenchmarkTests",
-												"id": 3753
+												"id": 3760
 											}
 										]
 									}
@@ -67452,19 +67395,19 @@
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						3743,
-						3756,
-						3759,
-						3753
+						3750,
+						3763,
+						3766,
+						3760
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						3774,
-						3765,
-						3761
+						3781,
+						3772,
+						3768
 					]
 				}
 			],
@@ -67477,7 +67420,7 @@
 			]
 		},
 		{
-			"id": 3503,
+			"id": 3510,
 			"name": "\"lib/interfaces/object\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -67492,7 +67435,7 @@
 			},
 			"children": [
 				{
-					"id": 3504,
+					"id": 3511,
 					"name": "ObjectInterface",
 					"kind": 256,
 					"kindString": "Interface",
@@ -67502,7 +67445,7 @@
 					},
 					"children": [
 						{
-							"id": 3505,
+							"id": 3512,
 							"name": "registerSuite",
 							"kind": 2048,
 							"kindString": "Method",
@@ -67512,14 +67455,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3506,
+									"id": 3513,
 									"name": "registerSuite",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3507,
+											"id": 3514,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -67530,7 +67473,7 @@
 											}
 										},
 										{
-											"id": 3508,
+											"id": 3515,
 											"name": "mainDescriptor",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -67541,17 +67484,17 @@
 													{
 														"type": "reference",
 														"name": "ObjectSuiteDescriptor",
-														"id": 3512
+														"id": 3519
 													},
 													{
 														"type": "reference",
 														"name": "ObjectSuiteFactory",
-														"id": 3515
+														"id": 3522
 													},
 													{
 														"type": "reference",
 														"name": "Tests",
-														"id": 3509
+														"id": 3516
 													}
 												]
 											}
@@ -67577,7 +67520,7 @@
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								3505
+								3512
 							]
 						}
 					],
@@ -67590,7 +67533,7 @@
 					]
 				},
 				{
-					"id": 3512,
+					"id": 3519,
 					"name": "ObjectSuiteDescriptor",
 					"kind": 256,
 					"kindString": "Interface",
@@ -67600,7 +67543,7 @@
 					},
 					"children": [
 						{
-							"id": 3513,
+							"id": 3520,
 							"name": "tests",
 							"kind": 1024,
 							"kindString": "Property",
@@ -67618,7 +67561,7 @@
 							"type": {
 								"type": "reference",
 								"name": "Tests",
-								"id": 3509
+								"id": 3516
 							}
 						}
 					],
@@ -67627,7 +67570,7 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								3513
+								3520
 							]
 						}
 					],
@@ -67642,7 +67585,7 @@
 						{
 							"type": "reflection",
 							"declaration": {
-								"id": 3514,
+								"id": 3521,
 								"name": "__type",
 								"kind": 65536,
 								"kindString": "Type literal",
@@ -67659,7 +67602,7 @@
 					]
 				},
 				{
-					"id": 3515,
+					"id": 3522,
 					"name": "ObjectSuiteFactory",
 					"kind": 256,
 					"kindString": "Interface",
@@ -67669,7 +67612,7 @@
 					},
 					"signatures": [
 						{
-							"id": 3516,
+							"id": 3523,
 							"name": "__call",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -67680,12 +67623,12 @@
 									{
 										"type": "reference",
 										"name": "ObjectSuiteDescriptor",
-										"id": 3512
+										"id": 3519
 									},
 									{
 										"type": "reference",
 										"name": "Tests",
-										"id": 3509
+										"id": 3516
 									}
 								]
 							}
@@ -67700,7 +67643,7 @@
 					]
 				},
 				{
-					"id": 3509,
+					"id": 3516,
 					"name": "Tests",
 					"kind": 256,
 					"kindString": "Interface",
@@ -67710,14 +67653,14 @@
 					},
 					"indexSignature": [
 						{
-							"id": 3510,
+							"id": 3517,
 							"name": "__index",
 							"kind": 8192,
 							"kindString": "Index signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3511,
+									"id": 3518,
 									"name": "name",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67734,17 +67677,17 @@
 									{
 										"type": "reference",
 										"name": "ObjectSuiteDescriptor",
-										"id": 3512
+										"id": 3519
 									},
 									{
 										"type": "reference",
 										"name": "TestFunction",
-										"id": 3374
+										"id": 3381
 									},
 									{
 										"type": "reference",
 										"name": "Tests",
-										"id": 3509
+										"id": 3516
 									}
 								]
 							}
@@ -67759,7 +67702,7 @@
 					]
 				},
 				{
-					"id": 3545,
+					"id": 3552,
 					"name": "_registerSuite",
 					"kind": 64,
 					"kindString": "Function",
@@ -67768,14 +67711,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3546,
+							"id": 3553,
 							"name": "_registerSuite",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3547,
+									"id": 3554,
 									"name": "executor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67783,11 +67726,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									}
 								},
 								{
-									"id": 3548,
+									"id": 3555,
 									"name": "name",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67798,7 +67741,7 @@
 									}
 								},
 								{
-									"id": 3549,
+									"id": 3556,
 									"name": "descriptorOrFactory",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67809,17 +67752,17 @@
 											{
 												"type": "reference",
 												"name": "ObjectSuiteDescriptor",
-												"id": 3512
+												"id": 3519
 											},
 											{
 												"type": "reference",
 												"name": "ObjectSuiteFactory",
-												"id": 3515
+												"id": 3522
 											},
 											{
 												"type": "reference",
 												"name": "Tests",
-												"id": 3509
+												"id": 3516
 											}
 										]
 									}
@@ -67840,7 +67783,7 @@
 					]
 				},
 				{
-					"id": 3533,
+					"id": 3540,
 					"name": "createSuite",
 					"kind": 64,
 					"kindString": "Function",
@@ -67850,14 +67793,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3534,
+							"id": 3541,
 							"name": "createSuite",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"typeParameter": [
 								{
-									"id": 3535,
+									"id": 3542,
 									"name": "S",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -67865,11 +67808,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Suite",
-										"id": 3400
+										"id": 3407
 									}
 								},
 								{
-									"id": 3536,
+									"id": 3543,
 									"name": "T",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -67877,13 +67820,13 @@
 									"type": {
 										"type": "reference",
 										"name": "Test",
-										"id": 3317
+										"id": 3324
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 3537,
+									"id": 3544,
 									"name": "name",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67894,7 +67837,7 @@
 									}
 								},
 								{
-									"id": 3538,
+									"id": 3545,
 									"name": "parent",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67902,11 +67845,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Suite",
-										"id": 3400
+										"id": 3407
 									}
 								},
 								{
-									"id": 3539,
+									"id": 3546,
 									"name": "descriptor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67917,18 +67860,18 @@
 											{
 												"type": "reference",
 												"name": "ObjectSuiteDescriptor",
-												"id": 3512
+												"id": 3519
 											},
 											{
 												"type": "reference",
 												"name": "Tests",
-												"id": 3509
+												"id": 3516
 											}
 										]
 									}
 								},
 								{
-									"id": 3540,
+									"id": 3547,
 									"name": "SuiteClass",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67939,12 +67882,12 @@
 										"constraint": {
 											"type": "reference",
 											"name": "Suite",
-											"id": 3400
+											"id": 3407
 										}
 									}
 								},
 								{
-									"id": 3541,
+									"id": 3548,
 									"name": "TestClass",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -67955,7 +67898,7 @@
 										"constraint": {
 											"type": "reference",
 											"name": "Test",
-											"id": 3317
+											"id": 3324
 										}
 									}
 								}
@@ -67963,7 +67906,7 @@
 							"type": {
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							}
 						}
 					],
@@ -67976,7 +67919,7 @@
 					]
 				},
 				{
-					"id": 3521,
+					"id": 3528,
 					"name": "getInterface",
 					"kind": 64,
 					"kindString": "Function",
@@ -67986,7 +67929,7 @@
 					},
 					"signatures": [
 						{
-							"id": 3522,
+							"id": 3529,
 							"name": "getInterface",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -67996,7 +67939,7 @@
 							},
 							"parameters": [
 								{
-									"id": 3523,
+									"id": 3530,
 									"name": "executor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -68004,21 +67947,21 @@
 									"type": {
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									}
 								}
 							],
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3524,
+									"id": 3531,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 3525,
+											"id": 3532,
 											"name": "registerSuite",
 											"kind": 64,
 											"kindString": "Function",
@@ -68027,14 +67970,14 @@
 											},
 											"signatures": [
 												{
-													"id": 3526,
+													"id": 3533,
 													"name": "registerSuite",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 3527,
+															"id": 3534,
 															"name": "name",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -68045,7 +67988,7 @@
 															}
 														},
 														{
-															"id": 3528,
+															"id": 3535,
 															"name": "descriptorOrFactory",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -68056,17 +67999,17 @@
 																	{
 																		"type": "reference",
 																		"name": "ObjectSuiteDescriptor",
-																		"id": 3512
+																		"id": 3519
 																	},
 																	{
 																		"type": "reference",
 																		"name": "ObjectSuiteFactory",
-																		"id": 3515
+																		"id": 3522
 																	},
 																	{
 																		"type": "reference",
 																		"name": "Tests",
-																		"id": 3509
+																		"id": 3516
 																	}
 																]
 															}
@@ -68092,7 +68035,7 @@
 											"title": "Functions",
 											"kind": 64,
 											"children": [
-												3525
+												3532
 											]
 										}
 									]
@@ -68109,7 +68052,7 @@
 					]
 				},
 				{
-					"id": 3542,
+					"id": 3549,
 					"name": "isObjectSuiteDescriptor",
 					"kind": 64,
 					"kindString": "Function",
@@ -68118,14 +68061,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3543,
+							"id": 3550,
 							"name": "isObjectSuiteDescriptor",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3544,
+									"id": 3551,
 									"name": "value",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -68151,7 +68094,7 @@
 					]
 				},
 				{
-					"id": 3529,
+					"id": 3536,
 					"name": "isSuiteDescriptorFactory",
 					"kind": 64,
 					"kindString": "Function",
@@ -68161,14 +68104,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3530,
+							"id": 3537,
 							"name": "isSuiteDescriptorFactory",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"typeParameter": [
 								{
-									"id": 3531,
+									"id": 3538,
 									"name": "T",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -68177,7 +68120,7 @@
 							],
 							"parameters": [
 								{
-									"id": 3532,
+									"id": 3539,
 									"name": "value",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -68203,7 +68146,7 @@
 					]
 				},
 				{
-					"id": 3517,
+					"id": 3524,
 					"name": "registerSuite",
 					"kind": 64,
 					"kindString": "Function",
@@ -68213,7 +68156,7 @@
 					},
 					"signatures": [
 						{
-							"id": 3518,
+							"id": 3525,
 							"name": "registerSuite",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -68223,7 +68166,7 @@
 							},
 							"parameters": [
 								{
-									"id": 3519,
+									"id": 3526,
 									"name": "name",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -68234,7 +68177,7 @@
 									}
 								},
 								{
-									"id": 3520,
+									"id": 3527,
 									"name": "descriptorOrFactory",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -68245,17 +68188,17 @@
 											{
 												"type": "reference",
 												"name": "ObjectSuiteDescriptor",
-												"id": 3512
+												"id": 3519
 											},
 											{
 												"type": "reference",
 												"name": "ObjectSuiteFactory",
-												"id": 3515
+												"id": 3522
 											},
 											{
 												"type": "reference",
 												"name": "Tests",
-												"id": 3509
+												"id": 3516
 											}
 										]
 									}
@@ -68281,22 +68224,22 @@
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						3504,
-						3512,
-						3515,
-						3509
+						3511,
+						3519,
+						3522,
+						3516
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						3545,
-						3533,
-						3521,
-						3542,
-						3529,
-						3517
+						3552,
+						3540,
+						3528,
+						3549,
+						3536,
+						3524
 					]
 				}
 			],
@@ -68309,7 +68252,7 @@
 			]
 		},
 		{
-			"id": 3550,
+			"id": 3557,
 			"name": "\"lib/interfaces/tdd\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -68324,7 +68267,7 @@
 			},
 			"children": [
 				{
-					"id": 3551,
+					"id": 3558,
 					"name": "TddInterface",
 					"kind": 256,
 					"kindString": "Interface",
@@ -68334,7 +68277,7 @@
 					},
 					"children": [
 						{
-							"id": 3563,
+							"id": 3570,
 							"name": "after",
 							"kind": 2048,
 							"kindString": "Method",
@@ -68344,14 +68287,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3564,
+									"id": 3571,
 									"name": "after",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3565,
+											"id": 3572,
 											"name": "fn",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -68366,7 +68309,7 @@
 													{
 														"type": "reference",
 														"name": "SuiteLifecycleFunction",
-														"id": 3470
+														"id": 3477
 													}
 												]
 											}
@@ -68379,7 +68322,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "TddLifecycleInterface.after",
-										"id": 3576
+										"id": 3583
 									}
 								}
 							],
@@ -68393,11 +68336,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "TddLifecycleInterface.after",
-								"id": 3576
+								"id": 3583
 							}
 						},
 						{
-							"id": 3569,
+							"id": 3576,
 							"name": "afterEach",
 							"kind": 2048,
 							"kindString": "Method",
@@ -68407,14 +68350,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3570,
+									"id": 3577,
 									"name": "afterEach",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3571,
+											"id": 3578,
 											"name": "fn",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -68429,7 +68372,7 @@
 													{
 														"type": "reference",
 														"name": "TestLifecycleFunction",
-														"id": 3474
+														"id": 3481
 													}
 												]
 											}
@@ -68442,7 +68385,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "TddLifecycleInterface.afterEach",
-										"id": 3582
+										"id": 3589
 									}
 								}
 							],
@@ -68456,11 +68399,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "TddLifecycleInterface.afterEach",
-								"id": 3582
+								"id": 3589
 							}
 						},
 						{
-							"id": 3560,
+							"id": 3567,
 							"name": "before",
 							"kind": 2048,
 							"kindString": "Method",
@@ -68470,14 +68413,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3561,
+									"id": 3568,
 									"name": "before",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3562,
+											"id": 3569,
 											"name": "fn",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -68492,7 +68435,7 @@
 													{
 														"type": "reference",
 														"name": "SuiteLifecycleFunction",
-														"id": 3470
+														"id": 3477
 													}
 												]
 											}
@@ -68505,7 +68448,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "TddLifecycleInterface.before",
-										"id": 3573
+										"id": 3580
 									}
 								}
 							],
@@ -68519,11 +68462,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "TddLifecycleInterface.before",
-								"id": 3573
+								"id": 3580
 							}
 						},
 						{
-							"id": 3566,
+							"id": 3573,
 							"name": "beforeEach",
 							"kind": 2048,
 							"kindString": "Method",
@@ -68533,14 +68476,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3567,
+									"id": 3574,
 									"name": "beforeEach",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3568,
+											"id": 3575,
 											"name": "fn",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -68555,7 +68498,7 @@
 													{
 														"type": "reference",
 														"name": "TestLifecycleFunction",
-														"id": 3474
+														"id": 3481
 													}
 												]
 											}
@@ -68568,7 +68511,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "TddLifecycleInterface.beforeEach",
-										"id": 3579
+										"id": 3586
 									}
 								}
 							],
@@ -68582,11 +68525,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "TddLifecycleInterface.beforeEach",
-								"id": 3579
+								"id": 3586
 							}
 						},
 						{
-							"id": 3552,
+							"id": 3559,
 							"name": "suite",
 							"kind": 2048,
 							"kindString": "Method",
@@ -68596,14 +68539,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3553,
+									"id": 3560,
 									"name": "suite",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3554,
+											"id": 3561,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -68614,7 +68557,7 @@
 											}
 										},
 										{
-											"id": 3555,
+											"id": 3562,
 											"name": "factory",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -68622,7 +68565,7 @@
 											"type": {
 												"type": "reference",
 												"name": "TddSuiteFactory",
-												"id": 3585
+												"id": 3592
 											}
 										}
 									],
@@ -68641,7 +68584,7 @@
 							]
 						},
 						{
-							"id": 3556,
+							"id": 3563,
 							"name": "test",
 							"kind": 2048,
 							"kindString": "Method",
@@ -68651,14 +68594,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3557,
+									"id": 3564,
 									"name": "test",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3558,
+											"id": 3565,
 											"name": "name",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -68669,7 +68612,7 @@
 											}
 										},
 										{
-											"id": 3559,
+											"id": 3566,
 											"name": "test",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -68677,7 +68620,7 @@
 											"type": {
 												"type": "reference",
 												"name": "TestFunction",
-												"id": 3374
+												"id": 3381
 											}
 										}
 									],
@@ -68701,12 +68644,12 @@
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								3563,
-								3569,
-								3560,
-								3566,
-								3552,
-								3556
+								3570,
+								3576,
+								3567,
+								3573,
+								3559,
+								3563
 							]
 						}
 					],
@@ -68721,12 +68664,12 @@
 						{
 							"type": "reference",
 							"name": "TddLifecycleInterface",
-							"id": 3572
+							"id": 3579
 						}
 					]
 				},
 				{
-					"id": 3572,
+					"id": 3579,
 					"name": "TddLifecycleInterface",
 					"kind": 256,
 					"kindString": "Interface",
@@ -68736,7 +68679,7 @@
 					},
 					"children": [
 						{
-							"id": 3576,
+							"id": 3583,
 							"name": "after",
 							"kind": 2048,
 							"kindString": "Method",
@@ -68746,14 +68689,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3577,
+									"id": 3584,
 									"name": "after",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3578,
+											"id": 3585,
 											"name": "fn",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -68768,7 +68711,7 @@
 													{
 														"type": "reference",
 														"name": "SuiteLifecycleFunction",
-														"id": 3470
+														"id": 3477
 													}
 												]
 											}
@@ -68789,7 +68732,7 @@
 							]
 						},
 						{
-							"id": 3582,
+							"id": 3589,
 							"name": "afterEach",
 							"kind": 2048,
 							"kindString": "Method",
@@ -68799,14 +68742,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3583,
+									"id": 3590,
 									"name": "afterEach",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3584,
+											"id": 3591,
 											"name": "fn",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -68821,7 +68764,7 @@
 													{
 														"type": "reference",
 														"name": "TestLifecycleFunction",
-														"id": 3474
+														"id": 3481
 													}
 												]
 											}
@@ -68842,7 +68785,7 @@
 							]
 						},
 						{
-							"id": 3573,
+							"id": 3580,
 							"name": "before",
 							"kind": 2048,
 							"kindString": "Method",
@@ -68852,14 +68795,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3574,
+									"id": 3581,
 									"name": "before",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3575,
+											"id": 3582,
 											"name": "fn",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -68874,7 +68817,7 @@
 													{
 														"type": "reference",
 														"name": "SuiteLifecycleFunction",
-														"id": 3470
+														"id": 3477
 													}
 												]
 											}
@@ -68895,7 +68838,7 @@
 							]
 						},
 						{
-							"id": 3579,
+							"id": 3586,
 							"name": "beforeEach",
 							"kind": 2048,
 							"kindString": "Method",
@@ -68905,14 +68848,14 @@
 							},
 							"signatures": [
 								{
-									"id": 3580,
+									"id": 3587,
 									"name": "beforeEach",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3581,
+											"id": 3588,
 											"name": "fn",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -68927,7 +68870,7 @@
 													{
 														"type": "reference",
 														"name": "TestLifecycleFunction",
-														"id": 3474
+														"id": 3481
 													}
 												]
 											}
@@ -68953,10 +68896,10 @@
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								3576,
-								3582,
-								3573,
-								3579
+								3583,
+								3589,
+								3580,
+								3586
 							]
 						}
 					],
@@ -68971,17 +68914,17 @@
 						{
 							"type": "reference",
 							"name": "TddInterface",
-							"id": 3551
+							"id": 3558
 						},
 						{
 							"type": "reference",
 							"name": "BddInterface",
-							"id": 3628
+							"id": 3635
 						}
 					]
 				},
 				{
-					"id": 3585,
+					"id": 3592,
 					"name": "TddSuiteFactory",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -68999,21 +68942,21 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3586,
+							"id": 3593,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"signatures": [
 								{
-									"id": 3587,
+									"id": 3594,
 									"name": "__call",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 3588,
+											"id": 3595,
 											"name": "suite",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -69021,7 +68964,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -69042,7 +68985,7 @@
 					}
 				},
 				{
-					"id": 3612,
+					"id": 3619,
 					"name": "currentSuite",
 					"kind": 32,
 					"kindString": "Variable",
@@ -69063,7 +69006,7 @@
 							{
 								"type": "reference",
 								"name": "Suite",
-								"id": 3400
+								"id": 3407
 							},
 							{
 								"type": "intrinsic",
@@ -69073,7 +69016,7 @@
 					}
 				},
 				{
-					"id": 3617,
+					"id": 3624,
 					"name": "_suite",
 					"kind": 64,
 					"kindString": "Function",
@@ -69082,14 +69025,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3618,
+							"id": 3625,
 							"name": "_suite",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3619,
+									"id": 3626,
 									"name": "executor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69097,11 +69040,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									}
 								},
 								{
-									"id": 3620,
+									"id": 3627,
 									"name": "name",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69112,7 +69055,7 @@
 									}
 								},
 								{
-									"id": 3621,
+									"id": 3628,
 									"name": "factory",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69120,7 +69063,7 @@
 									"type": {
 										"type": "reference",
 										"name": "TddSuiteFactory",
-										"id": 3585
+										"id": 3592
 									}
 								}
 							],
@@ -69139,7 +69082,7 @@
 					]
 				},
 				{
-					"id": 3600,
+					"id": 3607,
 					"name": "after",
 					"kind": 64,
 					"kindString": "Function",
@@ -69149,14 +69092,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3601,
+							"id": 3608,
 							"name": "after",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3602,
+									"id": 3609,
 									"name": "fn",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69171,7 +69114,7 @@
 											{
 												"type": "reference",
 												"name": "SuiteLifecycleFunction",
-												"id": 3470
+												"id": 3477
 											}
 										]
 									}
@@ -69192,7 +69135,7 @@
 					]
 				},
 				{
-					"id": 3606,
+					"id": 3613,
 					"name": "afterEach",
 					"kind": 64,
 					"kindString": "Function",
@@ -69202,14 +69145,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3607,
+							"id": 3614,
 							"name": "afterEach",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3608,
+									"id": 3615,
 									"name": "fn",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69224,7 +69167,7 @@
 											{
 												"type": "reference",
 												"name": "TestLifecycleFunction",
-												"id": 3474
+												"id": 3481
 											}
 										]
 									}
@@ -69245,7 +69188,7 @@
 					]
 				},
 				{
-					"id": 3622,
+					"id": 3629,
 					"name": "aspect",
 					"kind": 64,
 					"kindString": "Function",
@@ -69254,14 +69197,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3623,
+							"id": 3630,
 							"name": "aspect",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3624,
+									"id": 3631,
 									"name": "suite",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69269,11 +69212,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Suite",
-										"id": 3400
+										"id": 3407
 									}
 								},
 								{
-									"id": 3625,
+									"id": 3632,
 									"name": "method",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69301,7 +69244,7 @@
 									}
 								},
 								{
-									"id": 3626,
+									"id": 3633,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69312,12 +69255,12 @@
 											{
 												"type": "reference",
 												"name": "SuiteLifecycleFunction",
-												"id": 3470
+												"id": 3477
 											},
 											{
 												"type": "reference",
 												"name": "TestLifecycleFunction",
-												"id": 3474
+												"id": 3481
 											}
 										]
 									}
@@ -69338,7 +69281,7 @@
 					]
 				},
 				{
-					"id": 3597,
+					"id": 3604,
 					"name": "before",
 					"kind": 64,
 					"kindString": "Function",
@@ -69348,14 +69291,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3598,
+							"id": 3605,
 							"name": "before",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3599,
+									"id": 3606,
 									"name": "fn",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69370,7 +69313,7 @@
 											{
 												"type": "reference",
 												"name": "SuiteLifecycleFunction",
-												"id": 3470
+												"id": 3477
 											}
 										]
 									}
@@ -69391,7 +69334,7 @@
 					]
 				},
 				{
-					"id": 3603,
+					"id": 3610,
 					"name": "beforeEach",
 					"kind": 64,
 					"kindString": "Function",
@@ -69401,14 +69344,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3604,
+							"id": 3611,
 							"name": "beforeEach",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3605,
+									"id": 3612,
 									"name": "fn",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69423,7 +69366,7 @@
 											{
 												"type": "reference",
 												"name": "TestLifecycleFunction",
-												"id": 3474
+												"id": 3481
 											}
 										]
 									}
@@ -69444,7 +69387,7 @@
 					]
 				},
 				{
-					"id": 3609,
+					"id": 3616,
 					"name": "getInterface",
 					"kind": 64,
 					"kindString": "Function",
@@ -69454,14 +69397,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3610,
+							"id": 3617,
 							"name": "getInterface",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3611,
+									"id": 3618,
 									"name": "executor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69469,14 +69412,14 @@
 									"type": {
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
 								"name": "TddInterface",
-								"id": 3551
+								"id": 3558
 							}
 						}
 					],
@@ -69489,7 +69432,7 @@
 					]
 				},
 				{
-					"id": 3613,
+					"id": 3620,
 					"name": "registerSuite",
 					"kind": 64,
 					"kindString": "Function",
@@ -69498,14 +69441,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3614,
+							"id": 3621,
 							"name": "registerSuite",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3615,
+									"id": 3622,
 									"name": "name",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69516,7 +69459,7 @@
 									}
 								},
 								{
-									"id": 3616,
+									"id": 3623,
 									"name": "factory",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69524,7 +69467,7 @@
 									"type": {
 										"type": "reference",
 										"name": "TddSuiteFactory",
-										"id": 3585
+										"id": 3592
 									}
 								}
 							],
@@ -69543,7 +69486,7 @@
 					]
 				},
 				{
-					"id": 3589,
+					"id": 3596,
 					"name": "suite",
 					"kind": 64,
 					"kindString": "Function",
@@ -69553,14 +69496,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3590,
+							"id": 3597,
 							"name": "suite",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3591,
+									"id": 3598,
 									"name": "name",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69571,7 +69514,7 @@
 									}
 								},
 								{
-									"id": 3592,
+									"id": 3599,
 									"name": "factory",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69579,7 +69522,7 @@
 									"type": {
 										"type": "reference",
 										"name": "TddSuiteFactory",
-										"id": 3585
+										"id": 3592
 									}
 								}
 							],
@@ -69598,7 +69541,7 @@
 					]
 				},
 				{
-					"id": 3593,
+					"id": 3600,
 					"name": "test",
 					"kind": 64,
 					"kindString": "Function",
@@ -69608,14 +69551,14 @@
 					},
 					"signatures": [
 						{
-							"id": 3594,
+							"id": 3601,
 							"name": "test",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 3595,
+									"id": 3602,
 									"name": "name",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69626,7 +69569,7 @@
 									}
 								},
 								{
-									"id": 3596,
+									"id": 3603,
 									"name": "test",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -69634,7 +69577,7 @@
 									"type": {
 										"type": "reference",
 										"name": "TestFunction",
-										"id": 3374
+										"id": 3381
 									}
 								}
 							],
@@ -69658,38 +69601,38 @@
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						3551,
-						3572
+						3558,
+						3579
 					]
 				},
 				{
 					"title": "Type aliases",
 					"kind": 4194304,
 					"children": [
-						3585
+						3592
 					]
 				},
 				{
 					"title": "Variables",
 					"kind": 32,
 					"children": [
-						3612
+						3619
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						3617,
-						3600,
-						3606,
-						3622,
-						3597,
-						3603,
-						3609,
+						3624,
+						3607,
 						3613,
-						3589,
-						3593
+						3629,
+						3604,
+						3610,
+						3616,
+						3620,
+						3596,
+						3600
 					]
 				}
 			],
@@ -70187,7 +70130,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Node",
-												"id": 2600
+												"id": 2607
 											}
 										}
 									],
@@ -70235,7 +70178,7 @@
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							},
 							"overwrites": {
 								"type": "reference",
@@ -70924,7 +70867,7 @@
 			]
 		},
 		{
-			"id": 4300,
+			"id": 4304,
 			"name": "\"lib/node/util\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -70935,7 +70878,7 @@
 			"originalName": "src/lib/node/util.ts",
 			"children": [
 				{
-					"id": 4341,
+					"id": 4345,
 					"name": "sourceMapRegEx",
 					"kind": 32,
 					"kindString": "Variable",
@@ -70946,7 +70889,7 @@
 					"sources": [
 						{
 							"fileName": "lib/node/util.ts",
-							"line": 225,
+							"line": 226,
 							"character": 20
 						}
 					],
@@ -70957,7 +70900,7 @@
 					"defaultValue": " /^(?:\\/{2}[#@]{1,2}|\\/\\*)\\s+sourceMappingURL\\s*=\\s*(data:(?:[^;]+;)+base64,)?(\\S+)/"
 				},
 				{
-					"id": 4301,
+					"id": 4305,
 					"name": "expandFiles",
 					"kind": 64,
 					"kindString": "Function",
@@ -70967,7 +70910,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4302,
+							"id": 4306,
 							"name": "expandFiles",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -70977,7 +70920,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4303,
+									"id": 4307,
 									"name": "patterns",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -71020,7 +70963,7 @@
 					]
 				},
 				{
-					"id": 4304,
+					"id": 4308,
 					"name": "getConfig",
 					"kind": 64,
 					"kindString": "Function",
@@ -71030,7 +70973,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4305,
+							"id": 4309,
 							"name": "getConfig",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -71040,7 +70983,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4306,
+									"id": 4310,
 									"name": "file",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -71072,14 +71015,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 4307,
+											"id": 4311,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 4308,
+													"id": 4312,
 													"name": "config",
 													"kind": 32,
 													"kindString": "Variable",
@@ -71099,7 +71042,7 @@
 													}
 												},
 												{
-													"id": 4309,
+													"id": 4313,
 													"name": "file",
 													"kind": 32,
 													"kindString": "Variable",
@@ -71134,8 +71077,8 @@
 													"title": "Variables",
 													"kind": 32,
 													"children": [
-														4308,
-														4309
+														4312,
+														4313
 													]
 												}
 											],
@@ -71152,14 +71095,14 @@
 							}
 						},
 						{
-							"id": 4310,
+							"id": 4314,
 							"name": "getConfig",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 4311,
+									"id": 4315,
 									"name": "argv",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -71182,14 +71125,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 4312,
+											"id": 4316,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 4313,
+													"id": 4317,
 													"name": "config",
 													"kind": 32,
 													"kindString": "Variable",
@@ -71209,7 +71152,7 @@
 													}
 												},
 												{
-													"id": 4314,
+													"id": 4318,
 													"name": "file",
 													"kind": 32,
 													"kindString": "Variable",
@@ -71244,8 +71187,8 @@
 													"title": "Variables",
 													"kind": 32,
 													"children": [
-														4313,
-														4314
+														4317,
+														4318
 													]
 												}
 											],
@@ -71262,14 +71205,14 @@
 							}
 						},
 						{
-							"id": 4315,
+							"id": 4319,
 							"name": "getConfig",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 4316,
+									"id": 4320,
 									"name": "file",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -71280,7 +71223,7 @@
 									}
 								},
 								{
-									"id": 4317,
+									"id": 4321,
 									"name": "argv",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -71303,14 +71246,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 4318,
+											"id": 4322,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 4319,
+													"id": 4323,
 													"name": "config",
 													"kind": 32,
 													"kindString": "Variable",
@@ -71330,7 +71273,7 @@
 													}
 												},
 												{
-													"id": 4320,
+													"id": 4324,
 													"name": "file",
 													"kind": 32,
 													"kindString": "Variable",
@@ -71365,8 +71308,8 @@
 													"title": "Variables",
 													"kind": 32,
 													"children": [
-														4319,
-														4320
+														4323,
+														4324
 													]
 												}
 											],
@@ -71407,7 +71350,7 @@
 					]
 				},
 				{
-					"id": 4331,
+					"id": 4335,
 					"name": "isErrnoException",
 					"kind": 64,
 					"kindString": "Function",
@@ -71417,7 +71360,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4332,
+							"id": 4336,
 							"name": "isErrnoException",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -71427,7 +71370,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4333,
+									"id": 4337,
 									"name": "value",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -71453,7 +71396,7 @@
 					]
 				},
 				{
-					"id": 4321,
+					"id": 4325,
 					"name": "loadText",
 					"kind": 64,
 					"kindString": "Function",
@@ -71463,7 +71406,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4322,
+							"id": 4326,
 							"name": "loadText",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -71473,7 +71416,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4323,
+									"id": 4327,
 									"name": "path",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -71505,7 +71448,7 @@
 					]
 				},
 				{
-					"id": 4334,
+					"id": 4338,
 					"name": "mkdirp",
 					"kind": 64,
 					"kindString": "Function",
@@ -71515,7 +71458,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4335,
+							"id": 4339,
 							"name": "mkdirp",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -71525,7 +71468,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4336,
+									"id": 4340,
 									"name": "dir",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -71551,7 +71494,7 @@
 					]
 				},
 				{
-					"id": 4324,
+					"id": 4328,
 					"name": "normalizePath",
 					"kind": 64,
 					"kindString": "Function",
@@ -71561,7 +71504,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4325,
+							"id": 4329,
 							"name": "normalizePath",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -71571,7 +71514,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4326,
+									"id": 4330,
 									"name": "path",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -71597,7 +71540,7 @@
 					]
 				},
 				{
-					"id": 4327,
+					"id": 4331,
 					"name": "readSourceMap",
 					"kind": 64,
 					"kindString": "Function",
@@ -71607,7 +71550,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4328,
+							"id": 4332,
 							"name": "readSourceMap",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -71617,7 +71560,7 @@
 							},
 							"parameters": [
 								{
-									"id": 4329,
+									"id": 4333,
 									"name": "sourceFile",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -71628,7 +71571,7 @@
 									}
 								},
 								{
-									"id": 4330,
+									"id": 4334,
 									"name": "code",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -71674,7 +71617,7 @@
 					]
 				},
 				{
-					"id": 4337,
+					"id": 4341,
 					"name": "transpileSource",
 					"kind": 64,
 					"kindString": "Function",
@@ -71684,14 +71627,14 @@
 					},
 					"signatures": [
 						{
-							"id": 4338,
+							"id": 4342,
 							"name": "transpileSource",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 4339,
+									"id": 4343,
 									"name": "filename",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -71702,7 +71645,7 @@
 									}
 								},
 								{
-									"id": 4340,
+									"id": 4344,
 									"name": "code",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -71722,7 +71665,7 @@
 					"sources": [
 						{
 							"fileName": "lib/node/util.ts",
-							"line": 211,
+							"line": 212,
 							"character": 31
 						}
 					]
@@ -71733,21 +71676,21 @@
 					"title": "Variables",
 					"kind": 32,
 					"children": [
-						4341
+						4345
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						4301,
-						4304,
+						4305,
+						4308,
+						4335,
+						4325,
+						4338,
+						4328,
 						4331,
-						4321,
-						4334,
-						4324,
-						4327,
-						4337
+						4341
 					]
 				}
 			],
@@ -71760,7 +71703,7 @@
 			]
 		},
 		{
-			"id": 2443,
+			"id": 2450,
 			"name": "\"lib/reporters/Benchmark\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -71771,7 +71714,7 @@
 			"originalName": "src/lib/reporters/Benchmark.ts",
 			"children": [
 				{
-					"id": 2444,
+					"id": 2451,
 					"name": "BenchmarkReporter",
 					"kind": 128,
 					"kindString": "Class",
@@ -71785,7 +71728,7 @@
 					},
 					"children": [
 						{
-							"id": 2453,
+							"id": 2460,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -71795,14 +71738,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2454,
+									"id": 2461,
 									"name": "new BenchmarkReporter",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2455,
+											"id": 2462,
 											"name": "executor",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -71810,11 +71753,11 @@
 											"type": {
 												"type": "reference",
 												"name": "Executor",
-												"id": 3780
+												"id": 3787
 											}
 										},
 										{
-											"id": 2456,
+											"id": 2463,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -71822,7 +71765,7 @@
 											"type": {
 												"type": "reference",
 												"name": "BenchmarkReporterOptions",
-												"id": 2545
+												"id": 2552
 											},
 											"defaultValue": " {}"
 										}
@@ -71830,12 +71773,12 @@
 									"type": {
 										"type": "reference",
 										"name": "BenchmarkReporter",
-										"id": 2444
+										"id": 2451
 									},
 									"overwrites": {
 										"type": "reference",
 										"name": "Reporter.__constructor",
-										"id": 4055
+										"id": 4062
 									}
 								}
 							],
@@ -71849,11 +71792,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.__constructor",
-								"id": 4055
+								"id": 4062
 							}
 						},
 						{
-							"id": 2472,
+							"id": 2479,
 							"name": "_console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -71885,11 +71828,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
-							"id": 2476,
+							"id": 2483,
 							"name": "_eventHandlers",
 							"kind": 1024,
 							"kindString": "Property",
@@ -71914,21 +71857,21 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 2477,
+											"id": 2484,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 2478,
+													"id": 2485,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 2479,
+															"id": 2486,
 															"name": "eventName",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -71963,11 +71906,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
-							"id": 2473,
+							"id": 2480,
 							"name": "_executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -71989,7 +71932,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -72000,11 +71943,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
-							"id": 2474,
+							"id": 2481,
 							"name": "_handles",
 							"kind": 1024,
 							"kindString": "Property",
@@ -72039,11 +71982,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
-							"id": 2475,
+							"id": 2482,
 							"name": "_output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -72065,7 +72008,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -72076,11 +72019,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
-							"id": 2445,
+							"id": 2452,
 							"name": "baseline",
 							"kind": 1024,
 							"kindString": "Property",
@@ -72098,11 +72041,11 @@
 							"type": {
 								"type": "reference",
 								"name": "BenchmarkBaseline",
-								"id": 2521
+								"id": 2528
 							}
 						},
 						{
-							"id": 2471,
+							"id": 2478,
 							"name": "executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -72120,16 +72063,16 @@
 							"type": {
 								"type": "reference",
 								"name": "Executor",
-								"id": 3780
+								"id": 3787
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							}
 						},
 						{
-							"id": 2446,
+							"id": 2453,
 							"name": "filename",
 							"kind": 1024,
 							"kindString": "Property",
@@ -72151,11 +72094,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkReporterProperties.filename",
-								"id": 2539
+								"id": 2546
 							}
 						},
 						{
-							"id": 2447,
+							"id": 2454,
 							"name": "mode",
 							"kind": 1024,
 							"kindString": "Property",
@@ -72173,16 +72116,16 @@
 							"type": {
 								"type": "reference",
 								"name": "BenchmarkMode",
-								"id": 2544
+								"id": 2551
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkReporterProperties.mode",
-								"id": 2540
+								"id": 2547
 							}
 						},
 						{
-							"id": 2448,
+							"id": 2455,
 							"name": "sessions",
 							"kind": 1024,
 							"kindString": "Property",
@@ -72200,21 +72143,21 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 2449,
+									"id": 2456,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"indexSignature": [
 										{
-											"id": 2450,
+											"id": 2457,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2451,
+													"id": 2458,
 													"name": "sessionId",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -72228,7 +72171,7 @@
 											"type": {
 												"type": "reference",
 												"name": "SessionInfo",
-												"id": 2529
+												"id": 2536
 											}
 										}
 									],
@@ -72243,7 +72186,7 @@
 							}
 						},
 						{
-							"id": 2452,
+							"id": 2459,
 							"name": "thresholds",
 							"kind": 1024,
 							"kindString": "Property",
@@ -72261,16 +72204,16 @@
 							"type": {
 								"type": "reference",
 								"name": "BenchmarkThresholds",
-								"id": 2502
+								"id": 2509
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkReporterProperties.thresholds",
-								"id": 2541
+								"id": 2548
 							}
 						},
 						{
-							"id": 2480,
+							"id": 2487,
 							"name": "console",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -72280,7 +72223,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2481,
+									"id": 2488,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -72292,20 +72235,20 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 2482,
+									"id": 2489,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2483,
+											"id": 2490,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -72323,7 +72266,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -72342,16 +72285,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkReporterProperties.console",
-								"id": 2543
+								"id": 2550
 							}
 						},
 						{
-							"id": 2484,
+							"id": 2491,
 							"name": "output",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -72361,7 +72304,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2485,
+									"id": 2492,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -72369,25 +72312,25 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 2486,
+									"id": 2493,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2487,
+											"id": 2494,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -72395,7 +72338,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -72406,7 +72349,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -72425,16 +72368,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "BenchmarkReporterProperties.output",
-								"id": 2542
+								"id": 2549
 							}
 						},
 						{
-							"id": 2457,
+							"id": 2464,
 							"name": "_getSession",
 							"kind": 2048,
 							"kindString": "Method",
@@ -72444,14 +72387,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2458,
+									"id": 2465,
 									"name": "_getSession",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2459,
+											"id": 2466,
 											"name": "testOrSuite",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -72462,12 +72405,12 @@
 													{
 														"type": "reference",
 														"name": "Test",
-														"id": 3317
+														"id": 3324
 													},
 													{
 														"type": "reference",
 														"name": "Suite",
-														"id": 3400
+														"id": 3407
 													}
 												]
 											}
@@ -72476,7 +72419,7 @@
 									"type": {
 										"type": "reference",
 										"name": "SessionInfo",
-										"id": 2529
+										"id": 2536
 									}
 								}
 							],
@@ -72489,7 +72432,7 @@
 							]
 						},
 						{
-							"id": 2492,
+							"id": 2499,
 							"name": "_registerEventHandlers",
 							"kind": 2048,
 							"kindString": "Method",
@@ -72500,7 +72443,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2493,
+									"id": 2500,
 									"name": "_registerEventHandlers",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -72515,7 +72458,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -72529,11 +72472,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
-							"id": 2488,
+							"id": 2495,
 							"name": "formatError",
 							"kind": 2048,
 							"kindString": "Method",
@@ -72543,14 +72486,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2489,
+									"id": 2496,
 									"name": "formatError",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2490,
+											"id": 2497,
 											"name": "error",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -72561,7 +72504,7 @@
 											}
 										},
 										{
-											"id": 2491,
+											"id": 2498,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -72582,7 +72525,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -72596,11 +72539,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
-							"id": 2460,
+							"id": 2467,
 							"name": "runEnd",
 							"kind": 2048,
 							"kindString": "Method",
@@ -72623,7 +72566,7 @@
 							],
 							"signatures": [
 								{
-									"id": 2461,
+									"id": 2468,
 									"name": "runEnd",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -72643,7 +72586,7 @@
 							]
 						},
 						{
-							"id": 2462,
+							"id": 2469,
 							"name": "suiteEnd",
 							"kind": 2048,
 							"kindString": "Method",
@@ -72666,14 +72609,14 @@
 							],
 							"signatures": [
 								{
-									"id": 2463,
+									"id": 2470,
 									"name": "suiteEnd",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2464,
+											"id": 2471,
 											"name": "suite",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -72681,7 +72624,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -72700,7 +72643,7 @@
 							]
 						},
 						{
-							"id": 2465,
+							"id": 2472,
 							"name": "suiteStart",
 							"kind": 2048,
 							"kindString": "Method",
@@ -72723,14 +72666,14 @@
 							],
 							"signatures": [
 								{
-									"id": 2466,
+									"id": 2473,
 									"name": "suiteStart",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2467,
+											"id": 2474,
 											"name": "suite",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -72738,7 +72681,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -72757,7 +72700,7 @@
 							]
 						},
 						{
-							"id": 2468,
+							"id": 2475,
 							"name": "testEnd",
 							"kind": 2048,
 							"kindString": "Method",
@@ -72780,14 +72723,14 @@
 							],
 							"signatures": [
 								{
-									"id": 2469,
+									"id": 2476,
 									"name": "testEnd",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2470,
+											"id": 2477,
 											"name": "test",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -72795,7 +72738,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Test",
-												"id": 3317
+												"id": 3324
 											}
 										}
 									],
@@ -72819,45 +72762,45 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								2453
+								2460
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2472,
-								2476,
-								2473,
-								2474,
-								2475,
-								2445,
-								2471,
-								2446,
-								2447,
-								2448,
-								2452
+								2479,
+								2483,
+								2480,
+								2481,
+								2482,
+								2452,
+								2478,
+								2453,
+								2454,
+								2455,
+								2459
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								2480,
-								2484
+								2487,
+								2491
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								2457,
-								2492,
-								2488,
-								2460,
-								2462,
-								2465,
-								2468
+								2464,
+								2499,
+								2495,
+								2467,
+								2469,
+								2472,
+								2475
 							]
 						}
 					],
@@ -72872,24 +72815,24 @@
 						{
 							"type": "reference",
 							"name": "Reporter",
-							"id": 4045
+							"id": 4052
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						},
 						{
 							"type": "reference",
 							"name": "BenchmarkReporterProperties",
-							"id": 2538
+							"id": 2545
 						}
 					]
 				},
 				{
-					"id": 2513,
+					"id": 2520,
 					"name": "BaselineEnvironment",
 					"kind": 256,
 					"kindString": "Interface",
@@ -72899,7 +72842,7 @@
 					},
 					"children": [
 						{
-							"id": 2514,
+							"id": 2521,
 							"name": "client",
 							"kind": 1024,
 							"kindString": "Property",
@@ -72920,7 +72863,7 @@
 							}
 						},
 						{
-							"id": 2516,
+							"id": 2523,
 							"name": "platform",
 							"kind": 1024,
 							"kindString": "Property",
@@ -72941,7 +72884,7 @@
 							}
 						},
 						{
-							"id": 2517,
+							"id": 2524,
 							"name": "tests",
 							"kind": 1024,
 							"kindString": "Property",
@@ -72959,21 +72902,21 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 2518,
+									"id": 2525,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"indexSignature": [
 										{
-											"id": 2519,
+											"id": 2526,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2520,
+													"id": 2527,
 													"name": "testId",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -72987,7 +72930,7 @@
 											"type": {
 												"type": "reference",
 												"name": "BenchmarkData",
-												"id": 2494
+												"id": 2501
 											}
 										}
 									],
@@ -73002,7 +72945,7 @@
 							}
 						},
 						{
-							"id": 2515,
+							"id": 2522,
 							"name": "version",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73028,10 +72971,10 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2514,
-								2516,
-								2517,
-								2515
+								2521,
+								2523,
+								2524,
+								2522
 							]
 						}
 					],
@@ -73044,7 +72987,7 @@
 					]
 				},
 				{
-					"id": 2521,
+					"id": 2528,
 					"name": "BenchmarkBaseline",
 					"kind": 256,
 					"kindString": "Interface",
@@ -73054,14 +72997,14 @@
 					},
 					"indexSignature": [
 						{
-							"id": 2522,
+							"id": 2529,
 							"name": "__index",
 							"kind": 8192,
 							"kindString": "Index signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 2523,
+									"id": 2530,
 									"name": "key",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -73075,7 +73018,7 @@
 							"type": {
 								"type": "reference",
 								"name": "BaselineEnvironment",
-								"id": 2513
+								"id": 2520
 							}
 						}
 					],
@@ -73088,7 +73031,7 @@
 					]
 				},
 				{
-					"id": 2494,
+					"id": 2501,
 					"name": "BenchmarkData",
 					"kind": 256,
 					"kindString": "Interface",
@@ -73098,7 +73041,7 @@
 					},
 					"children": [
 						{
-							"id": 2496,
+							"id": 2503,
 							"name": "hz",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73119,7 +73062,7 @@
 							}
 						},
 						{
-							"id": 2497,
+							"id": 2504,
 							"name": "stats",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73137,14 +73080,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 2498,
+									"id": 2505,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 2501,
+											"id": 2508,
 											"name": "mean",
 											"kind": 32,
 											"kindString": "Variable",
@@ -73164,7 +73107,7 @@
 											}
 										},
 										{
-											"id": 2500,
+											"id": 2507,
 											"name": "moe",
 											"kind": 32,
 											"kindString": "Variable",
@@ -73184,7 +73127,7 @@
 											}
 										},
 										{
-											"id": 2499,
+											"id": 2506,
 											"name": "rme",
 											"kind": 32,
 											"kindString": "Variable",
@@ -73209,9 +73152,9 @@
 											"title": "Variables",
 											"kind": 32,
 											"children": [
-												2501,
-												2500,
-												2499
+												2508,
+												2507,
+												2506
 											]
 										}
 									],
@@ -73226,7 +73169,7 @@
 							}
 						},
 						{
-							"id": 2495,
+							"id": 2502,
 							"name": "times",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73252,9 +73195,9 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2496,
-								2497,
-								2495
+								2503,
+								2504,
+								2502
 							]
 						}
 					],
@@ -73267,7 +73210,7 @@
 					]
 				},
 				{
-					"id": 2538,
+					"id": 2545,
 					"name": "BenchmarkReporterProperties",
 					"kind": 256,
 					"kindString": "Interface",
@@ -73277,7 +73220,7 @@
 					},
 					"children": [
 						{
-							"id": 2543,
+							"id": 2550,
 							"name": "console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73299,11 +73242,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
-							"id": 2539,
+							"id": 2546,
 							"name": "filename",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73324,7 +73267,7 @@
 							}
 						},
 						{
-							"id": 2540,
+							"id": 2547,
 							"name": "mode",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73342,11 +73285,11 @@
 							"type": {
 								"type": "reference",
 								"name": "BenchmarkMode",
-								"id": 2544
+								"id": 2551
 							}
 						},
 						{
-							"id": 2542,
+							"id": 2549,
 							"name": "output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73364,16 +73307,16 @@
 							"type": {
 								"type": "reference",
 								"name": "ReporterOutput",
-								"id": 4076
+								"id": 4083
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						},
 						{
-							"id": 2541,
+							"id": 2548,
 							"name": "thresholds",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73391,7 +73334,7 @@
 							"type": {
 								"type": "reference",
 								"name": "BenchmarkThresholds",
-								"id": 2502
+								"id": 2509
 							}
 						}
 					],
@@ -73400,11 +73343,11 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2543,
-								2539,
-								2540,
-								2542,
-								2541
+								2550,
+								2546,
+								2547,
+								2549,
+								2548
 							]
 						}
 					],
@@ -73419,19 +73362,19 @@
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						}
 					],
 					"implementedBy": [
 						{
 							"type": "reference",
 							"name": "BenchmarkReporter",
-							"id": 2444
+							"id": 2451
 						}
 					]
 				},
 				{
-					"id": 2502,
+					"id": 2509,
 					"name": "BenchmarkThresholds",
 					"kind": 256,
 					"kindString": "Interface",
@@ -73441,7 +73384,7 @@
 					},
 					"children": [
 						{
-							"id": 2508,
+							"id": 2515,
 							"name": "fail",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73467,14 +73410,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 2509,
+											"id": 2516,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 2511,
+													"id": 2518,
 													"name": "hz",
 													"kind": 32,
 													"kindString": "Variable",
@@ -73504,7 +73447,7 @@
 													}
 												},
 												{
-													"id": 2512,
+													"id": 2519,
 													"name": "mean",
 													"kind": 32,
 													"kindString": "Variable",
@@ -73534,7 +73477,7 @@
 													}
 												},
 												{
-													"id": 2510,
+													"id": 2517,
 													"name": "rme",
 													"kind": 32,
 													"kindString": "Variable",
@@ -73569,9 +73512,9 @@
 													"title": "Variables",
 													"kind": 32,
 													"children": [
-														2511,
-														2512,
-														2510
+														2518,
+														2519,
+														2517
 													]
 												}
 											]
@@ -73581,7 +73524,7 @@
 							}
 						},
 						{
-							"id": 2503,
+							"id": 2510,
 							"name": "warn",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73607,14 +73550,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 2504,
+											"id": 2511,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 2506,
+													"id": 2513,
 													"name": "hz",
 													"kind": 32,
 													"kindString": "Variable",
@@ -73644,7 +73587,7 @@
 													}
 												},
 												{
-													"id": 2507,
+													"id": 2514,
 													"name": "mean",
 													"kind": 32,
 													"kindString": "Variable",
@@ -73674,7 +73617,7 @@
 													}
 												},
 												{
-													"id": 2505,
+													"id": 2512,
 													"name": "rme",
 													"kind": 32,
 													"kindString": "Variable",
@@ -73709,9 +73652,9 @@
 													"title": "Variables",
 													"kind": 32,
 													"children": [
-														2506,
-														2507,
-														2505
+														2513,
+														2514,
+														2512
 													]
 												}
 											]
@@ -73726,8 +73669,8 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2508,
-								2503
+								2515,
+								2510
 							]
 						}
 					],
@@ -73740,7 +73683,7 @@
 					]
 				},
 				{
-					"id": 2529,
+					"id": 2536,
 					"name": "SessionInfo",
 					"kind": 256,
 					"kindString": "Interface",
@@ -73750,7 +73693,7 @@
 					},
 					"children": [
 						{
-							"id": 2537,
+							"id": 2544,
 							"name": "environment",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73768,11 +73711,11 @@
 							"type": {
 								"type": "reference",
 								"name": "SesssionEnvironment",
-								"id": 2524
+								"id": 2531
 							}
 						},
 						{
-							"id": 2530,
+							"id": 2537,
 							"name": "suites",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73790,21 +73733,21 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 2531,
+									"id": 2538,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"indexSignature": [
 										{
-											"id": 2532,
+											"id": 2539,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2533,
+													"id": 2540,
 													"name": "suiteId",
 													"kind": 32768,
 													"kindString": "Parameter",
@@ -73818,14 +73761,14 @@
 											"type": {
 												"type": "reflection",
 												"declaration": {
-													"id": 2534,
+													"id": 2541,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 2535,
+															"id": 2542,
 															"name": "numBenchmarks",
 															"kind": 32,
 															"kindString": "Variable",
@@ -73845,7 +73788,7 @@
 															}
 														},
 														{
-															"id": 2536,
+															"id": 2543,
 															"name": "numFailedBenchmarks",
 															"kind": 32,
 															"kindString": "Variable",
@@ -73870,8 +73813,8 @@
 															"title": "Variables",
 															"kind": 32,
 															"children": [
-																2535,
-																2536
+																2542,
+																2543
 															]
 														}
 													],
@@ -73902,8 +73845,8 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2537,
-								2530
+								2544,
+								2537
 							]
 						}
 					],
@@ -73916,7 +73859,7 @@
 					]
 				},
 				{
-					"id": 2524,
+					"id": 2531,
 					"name": "SesssionEnvironment",
 					"kind": 256,
 					"kindString": "Interface",
@@ -73926,7 +73869,7 @@
 					},
 					"children": [
 						{
-							"id": 2525,
+							"id": 2532,
 							"name": "client",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73947,7 +73890,7 @@
 							}
 						},
 						{
-							"id": 2528,
+							"id": 2535,
 							"name": "id",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73968,7 +73911,7 @@
 							}
 						},
 						{
-							"id": 2527,
+							"id": 2534,
 							"name": "platform",
 							"kind": 1024,
 							"kindString": "Property",
@@ -73989,7 +73932,7 @@
 							}
 						},
 						{
-							"id": 2526,
+							"id": 2533,
 							"name": "version",
 							"kind": 1024,
 							"kindString": "Property",
@@ -74015,10 +73958,10 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2525,
-								2528,
-								2527,
-								2526
+								2532,
+								2535,
+								2534,
+								2533
 							]
 						}
 					],
@@ -74031,7 +73974,7 @@
 					]
 				},
 				{
-					"id": 2544,
+					"id": 2551,
 					"name": "BenchmarkMode",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -74061,7 +74004,7 @@
 					}
 				},
 				{
-					"id": 2545,
+					"id": 2552,
 					"name": "BenchmarkReporterOptions",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -74083,13 +74026,13 @@
 							{
 								"type": "reference",
 								"name": "BenchmarkReporterProperties",
-								"id": 2538
+								"id": 2545
 							}
 						]
 					}
 				},
 				{
-					"id": 2546,
+					"id": 2553,
 					"name": "formatSeconds",
 					"kind": 64,
 					"kindString": "Function",
@@ -74098,14 +74041,14 @@
 					},
 					"signatures": [
 						{
-							"id": 2547,
+							"id": 2554,
 							"name": "formatSeconds",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 2548,
+									"id": 2555,
 									"name": "value",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -74145,35 +74088,35 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						2444
+						2451
 					]
 				},
 				{
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						2513,
-						2521,
-						2494,
-						2538,
-						2502,
-						2529,
-						2524
+						2520,
+						2528,
+						2501,
+						2545,
+						2509,
+						2536,
+						2531
 					]
 				},
 				{
 					"title": "Type aliases",
 					"kind": 4194304,
 					"children": [
-						2544,
-						2545
+						2551,
+						2552
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						2546
+						2553
 					]
 				}
 			],
@@ -74186,7 +74129,7 @@
 			]
 		},
 		{
-			"id": 1789,
+			"id": 1796,
 			"name": "\"lib/reporters/Cobertura\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -74197,7 +74140,7 @@
 			"originalName": "src/lib/reporters/Cobertura.ts",
 			"children": [
 				{
-					"id": 1790,
+					"id": 1797,
 					"name": "Cobertura",
 					"kind": 128,
 					"kindString": "Class",
@@ -74207,7 +74150,7 @@
 					},
 					"children": [
 						{
-							"id": 1793,
+							"id": 1800,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -74217,14 +74160,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1794,
+									"id": 1801,
 									"name": "new Cobertura",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1795,
+											"id": 1802,
 											"name": "executor",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -74232,11 +74175,11 @@
 											"type": {
 												"type": "reference",
 												"name": "Node",
-												"id": 2600
+												"id": 2607
 											}
 										},
 										{
-											"id": 1796,
+											"id": 1803,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -74244,7 +74187,7 @@
 											"type": {
 												"type": "reference",
 												"name": "CoberturaCoverageOptions",
-												"id": 1841
+												"id": 1848
 											},
 											"defaultValue": " {}"
 										}
@@ -74252,12 +74195,12 @@
 									"type": {
 										"type": "reference",
 										"name": "Cobertura",
-										"id": 1790
+										"id": 1797
 									},
 									"overwrites": {
 										"type": "reference",
 										"name": "Coverage.__constructor",
-										"id": 1298
+										"id": 1304
 									}
 								}
 							],
@@ -74271,11 +74214,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.__constructor",
-								"id": 1298
+								"id": 1304
 							}
 						},
 						{
-							"id": 1812,
+							"id": 1819,
 							"name": "_console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -74307,11 +74250,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
-							"id": 1816,
+							"id": 1823,
 							"name": "_eventHandlers",
 							"kind": 1024,
 							"kindString": "Property",
@@ -74336,21 +74279,21 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1817,
+											"id": 1824,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 1818,
+													"id": 1825,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1819,
+															"id": 1826,
 															"name": "eventName",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -74385,11 +74328,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
-							"id": 1813,
+							"id": 1820,
 							"name": "_executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -74411,7 +74354,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -74422,11 +74365,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
-							"id": 1814,
+							"id": 1821,
 							"name": "_handles",
 							"kind": 1024,
 							"kindString": "Property",
@@ -74461,11 +74404,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
-							"id": 1815,
+							"id": 1822,
 							"name": "_output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -74487,7 +74430,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -74498,11 +74441,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
-							"id": 1804,
+							"id": 1811,
 							"name": "directory",
 							"kind": 1024,
 							"kindString": "Property",
@@ -74514,7 +74457,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 21,
+									"line": 34,
 									"character": 11
 								}
 							],
@@ -74534,16 +74477,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.directory",
-								"id": 1296
+								"id": 1302
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoberturaCoverageProperties.directory",
-								"id": 1837
+								"id": 1844
 							}
 						},
 						{
-							"id": 1802,
+							"id": 1809,
 							"name": "executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -74554,28 +74497,28 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 18,
+									"line": 31,
 									"character": 19
 								}
 							],
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							},
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.executor",
-								"id": 1294
+								"id": 1300
 							}
 						},
 						{
-							"id": 1803,
+							"id": 1810,
 							"name": "filename",
 							"kind": 1024,
 							"kindString": "Property",
@@ -74587,7 +74530,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 20,
+									"line": 33,
 									"character": 10
 								}
 							],
@@ -74607,16 +74550,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.filename",
-								"id": 1295
+								"id": 1301
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoberturaCoverageProperties.filename",
-								"id": 1836
+								"id": 1843
 							}
 						},
 						{
-							"id": 1792,
+							"id": 1799,
 							"name": "projectRoot",
 							"kind": 1024,
 							"kindString": "Property",
@@ -74647,11 +74590,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoberturaCoverageProperties.projectRoot",
-								"id": 1835
+								"id": 1842
 							}
 						},
 						{
-							"id": 1791,
+							"id": 1798,
 							"name": "reportType",
 							"kind": 1024,
 							"kindString": "Property",
@@ -74674,11 +74617,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.reportType",
-								"id": 1293
+								"id": 1299
 							}
 						},
 						{
-							"id": 1805,
+							"id": 1812,
 							"name": "watermarks",
 							"kind": 1024,
 							"kindString": "Property",
@@ -74690,7 +74633,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 22,
+									"line": 35,
 									"character": 12
 								}
 							],
@@ -74701,16 +74644,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.watermarks",
-								"id": 1297
+								"id": 1303
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoberturaCoverageProperties.watermarks",
-								"id": 1838
+								"id": 1845
 							}
 						},
 						{
-							"id": 1820,
+							"id": 1827,
 							"name": "console",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -74720,7 +74663,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 1821,
+									"id": 1828,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -74732,20 +74675,20 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 1822,
+									"id": 1829,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1823,
+											"id": 1830,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -74763,7 +74706,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -74782,16 +74725,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoberturaCoverageProperties.console",
-								"id": 1840
+								"id": 1847
 							}
 						},
 						{
-							"id": 1824,
+							"id": 1831,
 							"name": "output",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -74801,7 +74744,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 1825,
+									"id": 1832,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -74809,25 +74752,25 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 1826,
+									"id": 1833,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1827,
+											"id": 1834,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -74835,7 +74778,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -74846,7 +74789,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -74865,16 +74808,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoberturaCoverageProperties.output",
-								"id": 1839
+								"id": 1846
 							}
 						},
 						{
-							"id": 1832,
+							"id": 1839,
 							"name": "_registerEventHandlers",
 							"kind": 2048,
 							"kindString": "Method",
@@ -74885,7 +74828,7 @@
 							},
 							"signatures": [
 								{
-									"id": 1833,
+									"id": 1840,
 									"name": "_registerEventHandlers",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -74900,7 +74843,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -74914,11 +74857,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
-							"id": 1806,
+							"id": 1813,
 							"name": "createCoverageReport",
 							"kind": 2048,
 							"kindString": "Method",
@@ -74928,14 +74871,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1807,
+									"id": 1814,
 									"name": "createCoverageReport",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1808,
+											"id": 1815,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -74946,7 +74889,7 @@
 											}
 										},
 										{
-											"id": 1809,
+											"id": 1816,
 											"name": "data",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -74973,25 +74916,25 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.createCoverageReport",
-										"id": 1307
+										"id": 1313
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 44,
+									"line": 61,
 									"character": 22
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.createCoverageReport",
-								"id": 1307
+								"id": 1313
 							}
 						},
 						{
-							"id": 1828,
+							"id": 1835,
 							"name": "formatError",
 							"kind": 2048,
 							"kindString": "Method",
@@ -75001,14 +74944,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1829,
+									"id": 1836,
 									"name": "formatError",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1830,
+											"id": 1837,
 											"name": "error",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -75019,7 +74962,7 @@
 											}
 										},
 										{
-											"id": 1831,
+											"id": 1838,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -75040,7 +74983,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -75054,11 +74997,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
-							"id": 1797,
+							"id": 1804,
 							"name": "getReporterOptions",
 							"kind": 2048,
 							"kindString": "Method",
@@ -75068,7 +75011,7 @@
 							},
 							"signatures": [
 								{
-									"id": 1798,
+									"id": 1805,
 									"name": "getReporterOptions",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -75076,21 +75019,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1799,
+											"id": 1806,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 1800,
+													"id": 1807,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1801,
+															"id": 1808,
 															"name": "key",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -75119,7 +75062,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Coverage.getReporterOptions",
-										"id": 1302
+										"id": 1308
 									}
 								}
 							],
@@ -75133,11 +75076,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.getReporterOptions",
-								"id": 1302
+								"id": 1308
 							}
 						},
 						{
-							"id": 1810,
+							"id": 1817,
 							"name": "runEnd",
 							"kind": 2048,
 							"kindString": "Method",
@@ -75160,7 +75103,7 @@
 							],
 							"signatures": [
 								{
-									"id": 1811,
+									"id": 1818,
 									"name": "runEnd",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -75172,21 +75115,21 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.runEnd",
-										"id": 1311
+										"id": 1317
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 66,
+									"line": 84,
 									"character": 8
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.runEnd",
-								"id": 1311
+								"id": 1317
 							}
 						}
 					],
@@ -75195,43 +75138,43 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								1793
+								1800
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								1812,
-								1816,
-								1813,
-								1814,
-								1815,
-								1804,
-								1802,
-								1803,
-								1792,
-								1791,
-								1805
+								1819,
+								1823,
+								1820,
+								1821,
+								1822,
+								1811,
+								1809,
+								1810,
+								1799,
+								1798,
+								1812
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								1820,
-								1824
+								1827,
+								1831
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								1832,
-								1806,
-								1828,
-								1797,
-								1810
+								1839,
+								1813,
+								1835,
+								1804,
+								1817
 							]
 						}
 					],
@@ -75246,29 +75189,29 @@
 						{
 							"type": "reference",
 							"name": "Coverage",
-							"id": 1292
+							"id": 1298
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						},
 						{
 							"type": "reference",
 							"name": "CoverageProperties",
-							"id": 1335
+							"id": 1292
 						},
 						{
 							"type": "reference",
 							"name": "CoberturaCoverageProperties",
-							"id": 1834
+							"id": 1841
 						}
 					]
 				},
 				{
-					"id": 1834,
+					"id": 1841,
 					"name": "CoberturaCoverageProperties",
 					"kind": 256,
 					"kindString": "Interface",
@@ -75278,7 +75221,7 @@
 					},
 					"children": [
 						{
-							"id": 1840,
+							"id": 1847,
 							"name": "console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -75300,11 +75243,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
-							"id": 1837,
+							"id": 1844,
 							"name": "directory",
 							"kind": 1024,
 							"kindString": "Property",
@@ -75314,12 +75257,12 @@
 								"isOptional": true
 							},
 							"comment": {
-								"shortText": "A direcotry to write coverage data to"
+								"shortText": "A directory provided to the coverage reporter"
 							},
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 79,
+									"line": 18,
 									"character": 11
 								}
 							],
@@ -75339,11 +75282,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.directory",
-								"id": 1337
+								"id": 1294
 							}
 						},
 						{
-							"id": 1836,
+							"id": 1843,
 							"name": "filename",
 							"kind": 1024,
 							"kindString": "Property",
@@ -75353,12 +75296,12 @@
 								"isOptional": true
 							},
 							"comment": {
-								"shortText": "A filename to write coverage data to"
+								"shortText": "A filename provided to the coverage reporter"
 							},
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 76,
+									"line": 15,
 									"character": 10
 								}
 							],
@@ -75378,11 +75321,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.filename",
-								"id": 1336
+								"id": 1293
 							}
 						},
 						{
-							"id": 1839,
+							"id": 1846,
 							"name": "output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -75400,16 +75343,16 @@
 							"type": {
 								"type": "reference",
 								"name": "ReporterOutput",
-								"id": 4076
+								"id": 4083
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						},
 						{
-							"id": 1835,
+							"id": 1842,
 							"name": "projectRoot",
 							"kind": 1024,
 							"kindString": "Property",
@@ -75440,7 +75383,7 @@
 							}
 						},
 						{
-							"id": 1838,
+							"id": 1845,
 							"name": "watermarks",
 							"kind": 1024,
 							"kindString": "Property",
@@ -75455,7 +75398,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 82,
+									"line": 21,
 									"character": 12
 								}
 							],
@@ -75466,7 +75409,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.watermarks",
-								"id": 1338
+								"id": 1295
 							}
 						}
 					],
@@ -75475,12 +75418,12 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								1840,
-								1837,
-								1836,
-								1839,
-								1835,
-								1838
+								1847,
+								1844,
+								1843,
+								1846,
+								1842,
+								1845
 							]
 						}
 					],
@@ -75495,19 +75438,19 @@
 						{
 							"type": "reference",
 							"name": "CoverageProperties",
-							"id": 1335
+							"id": 1292
 						}
 					],
 					"implementedBy": [
 						{
 							"type": "reference",
 							"name": "Cobertura",
-							"id": 1790
+							"id": 1797
 						}
 					]
 				},
 				{
-					"id": 1841,
+					"id": 1848,
 					"name": "CoberturaCoverageOptions",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -75529,7 +75472,7 @@
 							{
 								"type": "reference",
 								"name": "CoberturaCoverageProperties",
-								"id": 1834
+								"id": 1841
 							}
 						]
 					}
@@ -75540,21 +75483,21 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						1790
+						1797
 					]
 				},
 				{
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						1834
+						1841
 					]
 				},
 				{
 					"title": "Type aliases",
 					"kind": 4194304,
 					"children": [
-						1841
+						1848
 					]
 				}
 			],
@@ -75616,7 +75559,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Executor",
-												"id": 3780
+												"id": 3787
 											}
 										},
 										{
@@ -75628,7 +75571,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOptions",
-												"id": 4092
+												"id": 4099
 											},
 											"defaultValue": " {}"
 										}
@@ -75641,7 +75584,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Reporter.__constructor",
-										"id": 4055
+										"id": 4062
 									}
 								}
 							],
@@ -75655,7 +75598,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.__constructor",
-								"id": 4055
+								"id": 4062
 							}
 						},
 						{
@@ -75691,7 +75634,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
@@ -75769,7 +75712,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
@@ -75795,7 +75738,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -75806,7 +75749,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
@@ -75845,7 +75788,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
@@ -75871,7 +75814,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -75882,7 +75825,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
@@ -75904,12 +75847,12 @@
 							"type": {
 								"type": "reference",
 								"name": "Executor",
-								"id": 3780
+								"id": 3787
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							}
 						},
 						{
@@ -75935,7 +75878,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -75966,7 +75909,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -75985,12 +75928,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
@@ -76012,12 +75955,12 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -76038,7 +75981,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -76049,7 +75992,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -76068,12 +76011,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						},
 						{
@@ -76103,7 +76046,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -76117,7 +76060,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
@@ -76226,7 +76169,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -76240,7 +76183,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
@@ -76282,7 +76225,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -76339,7 +76282,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -76396,7 +76339,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Test",
-												"id": 3317
+												"id": 3324
 											}
 										}
 									],
@@ -76467,14 +76410,14 @@
 						{
 							"type": "reference",
 							"name": "Reporter",
-							"id": 4045
+							"id": 4052
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						}
 					]
 				}
@@ -76508,7 +76451,7 @@
 			"originalName": "src/lib/reporters/Coverage.ts",
 			"children": [
 				{
-					"id": 1292,
+					"id": 1298,
 					"name": "Coverage",
 					"kind": 128,
 					"kindString": "Class",
@@ -76519,7 +76462,7 @@
 					},
 					"children": [
 						{
-							"id": 1298,
+							"id": 1304,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -76529,14 +76472,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1299,
+									"id": 1305,
 									"name": "new Coverage",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1300,
+											"id": 1306,
 											"name": "executor",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -76544,11 +76487,11 @@
 											"type": {
 												"type": "reference",
 												"name": "Node",
-												"id": 2600
+												"id": 2607
 											}
 										},
 										{
-											"id": 1301,
+											"id": 1307,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -76556,7 +76499,7 @@
 											"type": {
 												"type": "reference",
 												"name": "CoverageOptions",
-												"id": 1342
+												"id": 1341
 											},
 											"defaultValue": " {}"
 										}
@@ -76564,30 +76507,30 @@
 									"type": {
 										"type": "reference",
 										"name": "Coverage",
-										"id": 1292
+										"id": 1298
 									},
 									"overwrites": {
 										"type": "reference",
 										"name": "Reporter.__constructor",
-										"id": 4055
+										"id": 4062
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 22,
+									"line": 35,
 									"character": 26
 								}
 							],
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.__constructor",
-								"id": 4055
+								"id": 4062
 							}
 						},
 						{
-							"id": 1313,
+							"id": 1319,
 							"name": "_console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -76619,11 +76562,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
-							"id": 1317,
+							"id": 1323,
 							"name": "_eventHandlers",
 							"kind": 1024,
 							"kindString": "Property",
@@ -76648,21 +76591,21 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1318,
+											"id": 1324,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 1319,
+													"id": 1325,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1320,
+															"id": 1326,
 															"name": "eventName",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -76697,11 +76640,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
-							"id": 1314,
+							"id": 1320,
 							"name": "_executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -76723,7 +76666,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -76734,11 +76677,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
-							"id": 1315,
+							"id": 1321,
 							"name": "_handles",
 							"kind": 1024,
 							"kindString": "Property",
@@ -76773,11 +76716,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
-							"id": 1316,
+							"id": 1322,
 							"name": "_output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -76799,7 +76742,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -76810,11 +76753,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
-							"id": 1296,
+							"id": 1302,
 							"name": "directory",
 							"kind": 1024,
 							"kindString": "Property",
@@ -76826,7 +76769,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 21,
+									"line": 34,
 									"character": 11
 								}
 							],
@@ -76846,11 +76789,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.directory",
-								"id": 1337
+								"id": 1294
 							}
 						},
 						{
-							"id": 1294,
+							"id": 1300,
 							"name": "executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -76861,23 +76804,23 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 18,
+									"line": 31,
 									"character": 19
 								}
 							],
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							},
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							}
 						},
 						{
-							"id": 1295,
+							"id": 1301,
 							"name": "filename",
 							"kind": 1024,
 							"kindString": "Property",
@@ -76889,7 +76832,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 20,
+									"line": 33,
 									"character": 10
 								}
 							],
@@ -76909,11 +76852,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.filename",
-								"id": 1336
+								"id": 1293
 							}
 						},
 						{
-							"id": 1293,
+							"id": 1299,
 							"name": "reportType",
 							"kind": 1024,
 							"kindString": "Property",
@@ -76925,7 +76868,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 17,
+									"line": 30,
 									"character": 30
 								}
 							],
@@ -76935,7 +76878,7 @@
 							}
 						},
 						{
-							"id": 1297,
+							"id": 1303,
 							"name": "watermarks",
 							"kind": 1024,
 							"kindString": "Property",
@@ -76947,7 +76890,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 22,
+									"line": 35,
 									"character": 12
 								}
 							],
@@ -76958,11 +76901,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.watermarks",
-								"id": 1338
+								"id": 1295
 							}
 						},
 						{
-							"id": 1321,
+							"id": 1327,
 							"name": "console",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -76972,7 +76915,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 1322,
+									"id": 1328,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -76984,20 +76927,20 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 1323,
+									"id": 1329,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1324,
+											"id": 1330,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -77015,7 +76958,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -77034,16 +76977,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.console",
-								"id": 1340
+								"id": 1297
 							}
 						},
 						{
-							"id": 1325,
+							"id": 1331,
 							"name": "output",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -77053,7 +76996,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 1326,
+									"id": 1332,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -77061,25 +77004,25 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 1327,
+									"id": 1333,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1328,
+											"id": 1334,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -77087,7 +77030,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -77098,7 +77041,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -77117,16 +77060,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.output",
-								"id": 1339
+								"id": 1296
 							}
 						},
 						{
-							"id": 1333,
+							"id": 1339,
 							"name": "_registerEventHandlers",
 							"kind": 2048,
 							"kindString": "Method",
@@ -77137,7 +77080,7 @@
 							},
 							"signatures": [
 								{
-									"id": 1334,
+									"id": 1340,
 									"name": "_registerEventHandlers",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -77152,7 +77095,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -77166,11 +77109,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
-							"id": 1307,
+							"id": 1313,
 							"name": "createCoverageReport",
 							"kind": 2048,
 							"kindString": "Method",
@@ -77180,14 +77123,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1308,
+									"id": 1314,
 									"name": "createCoverageReport",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1309,
+											"id": 1315,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -77198,7 +77141,7 @@
 											}
 										},
 										{
-											"id": 1310,
+											"id": 1316,
 											"name": "data",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -77227,13 +77170,13 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 44,
+									"line": 61,
 									"character": 22
 								}
 							]
 						},
 						{
-							"id": 1329,
+							"id": 1335,
 							"name": "formatError",
 							"kind": 2048,
 							"kindString": "Method",
@@ -77243,14 +77186,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1330,
+									"id": 1336,
 									"name": "formatError",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1331,
+											"id": 1337,
 											"name": "error",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -77261,7 +77204,7 @@
 											}
 										},
 										{
-											"id": 1332,
+											"id": 1338,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -77282,7 +77225,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -77296,11 +77239,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
-							"id": 1302,
+							"id": 1308,
 							"name": "getReporterOptions",
 							"kind": 2048,
 							"kindString": "Method",
@@ -77310,29 +77253,32 @@
 							},
 							"signatures": [
 								{
-									"id": 1303,
+									"id": 1309,
 									"name": "getReporterOptions",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
+									"comment": {
+										"shortText": "This is a bag of data provided to the selected istanbul reporter (defined by `reportType`).\nby default this provides a filename (if present), though not all reporters use a filename."
+									},
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1304,
+											"id": 1310,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 1305,
+													"id": 1311,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1306,
+															"id": 1312,
 															"name": "key",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -77352,7 +77298,7 @@
 											"sources": [
 												{
 													"fileName": "lib/reporters/Coverage.ts",
-													"line": 38,
+													"line": 55,
 													"character": 23
 												}
 											]
@@ -77363,13 +77309,13 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 38,
+									"line": 55,
 									"character": 20
 								}
 							]
 						},
 						{
-							"id": 1311,
+							"id": 1317,
 							"name": "runEnd",
 							"kind": 2048,
 							"kindString": "Method",
@@ -77392,7 +77338,7 @@
 							],
 							"signatures": [
 								{
-									"id": 1312,
+									"id": 1318,
 									"name": "runEnd",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -77406,7 +77352,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 66,
+									"line": 84,
 									"character": 8
 								}
 							]
@@ -77417,49 +77363,49 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								1298
+								1304
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								1313,
-								1317,
-								1314,
-								1315,
-								1316,
-								1296,
-								1294,
-								1295,
-								1293,
-								1297
+								1319,
+								1323,
+								1320,
+								1321,
+								1322,
+								1302,
+								1300,
+								1301,
+								1299,
+								1303
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								1321,
-								1325
+								1327,
+								1331
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								1333,
-								1307,
-								1329,
-								1302,
-								1311
+								1339,
+								1313,
+								1335,
+								1308,
+								1317
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "lib/reporters/Coverage.ts",
-							"line": 15,
+							"line": 28,
 							"character": 38
 						}
 					],
@@ -77467,7 +77413,7 @@
 						{
 							"type": "reference",
 							"name": "Reporter",
-							"id": 4045
+							"id": 4052
 						}
 					],
 					"extendedBy": [
@@ -77479,39 +77425,39 @@
 						{
 							"type": "reference",
 							"name": "Cobertura",
-							"id": 1790
+							"id": 1797
 						},
 						{
 							"type": "reference",
 							"name": "JsonCoverage",
-							"id": 1843
+							"id": 1850
 						},
 						{
 							"type": "reference",
 							"name": "HtmlCoverage",
-							"id": 1887
+							"id": 1894
 						},
 						{
 							"type": "reference",
 							"name": "LcovCoverage",
-							"id": 1940
+							"id": 1947
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						},
 						{
 							"type": "reference",
 							"name": "CoverageProperties",
-							"id": 1335
+							"id": 1292
 						}
 					]
 				},
 				{
-					"id": 1335,
+					"id": 1292,
 					"name": "CoverageProperties",
 					"kind": 256,
 					"kindString": "Interface",
@@ -77521,7 +77467,7 @@
 					},
 					"children": [
 						{
-							"id": 1340,
+							"id": 1297,
 							"name": "console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -77543,11 +77489,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
-							"id": 1337,
+							"id": 1294,
 							"name": "directory",
 							"kind": 1024,
 							"kindString": "Property",
@@ -77557,12 +77503,12 @@
 								"isOptional": true
 							},
 							"comment": {
-								"shortText": "A direcotry to write coverage data to"
+								"shortText": "A directory provided to the coverage reporter"
 							},
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 79,
+									"line": 18,
 									"character": 11
 								}
 							],
@@ -77581,7 +77527,7 @@
 							}
 						},
 						{
-							"id": 1336,
+							"id": 1293,
 							"name": "filename",
 							"kind": 1024,
 							"kindString": "Property",
@@ -77591,12 +77537,12 @@
 								"isOptional": true
 							},
 							"comment": {
-								"shortText": "A filename to write coverage data to"
+								"shortText": "A filename provided to the coverage reporter"
 							},
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 76,
+									"line": 15,
 									"character": 10
 								}
 							],
@@ -77615,7 +77561,7 @@
 							}
 						},
 						{
-							"id": 1339,
+							"id": 1296,
 							"name": "output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -77633,16 +77579,16 @@
 							"type": {
 								"type": "reference",
 								"name": "ReporterOutput",
-								"id": 4076
+								"id": 4083
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						},
 						{
-							"id": 1338,
+							"id": 1295,
 							"name": "watermarks",
 							"kind": 1024,
 							"kindString": "Property",
@@ -77657,7 +77603,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 82,
+									"line": 21,
 									"character": 12
 								}
 							],
@@ -77672,18 +77618,18 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								1340,
-								1337,
-								1336,
-								1339,
-								1338
+								1297,
+								1294,
+								1293,
+								1296,
+								1295
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "lib/reporters/Coverage.ts",
-							"line": 74,
+							"line": 13,
 							"character": 35
 						}
 					],
@@ -77691,7 +77637,7 @@
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						}
 					],
 					"extendedBy": [
@@ -77703,39 +77649,39 @@
 						{
 							"type": "reference",
 							"name": "CoberturaCoverageProperties",
-							"id": 1834
+							"id": 1841
 						},
 						{
 							"type": "reference",
 							"name": "HtmlCoverageProperties",
-							"id": 1931
+							"id": 1938
 						}
 					],
 					"implementedBy": [
 						{
 							"type": "reference",
 							"name": "Cobertura",
-							"id": 1790
+							"id": 1797
 						},
 						{
 							"type": "reference",
 							"name": "Coverage",
-							"id": 1292
+							"id": 1298
 						},
 						{
 							"type": "reference",
 							"name": "HtmlCoverage",
-							"id": 1887
+							"id": 1894
 						},
 						{
 							"type": "reference",
 							"name": "JsonCoverage",
-							"id": 1843
+							"id": 1850
 						},
 						{
 							"type": "reference",
 							"name": "LcovCoverage",
-							"id": 1940
+							"id": 1947
 						},
 						{
 							"type": "reference",
@@ -77760,7 +77706,7 @@
 					]
 				},
 				{
-					"id": 1342,
+					"id": 1341,
 					"name": "CoverageOptions",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -77771,7 +77717,7 @@
 					"sources": [
 						{
 							"fileName": "lib/reporters/Coverage.ts",
-							"line": 85,
+							"line": 24,
 							"character": 27
 						}
 					],
@@ -77782,13 +77728,13 @@
 							{
 								"type": "reference",
 								"name": "CoverageProperties",
-								"id": 1335
+								"id": 1292
 							}
 						]
 					}
 				},
 				{
-					"id": 1341,
+					"id": 1342,
 					"name": "eventHandler",
 					"kind": 32,
 					"kindString": "Variable",
@@ -77799,7 +77745,7 @@
 					"sources": [
 						{
 							"fileName": "lib/reporters/Coverage.ts",
-							"line": 13,
+							"line": 26,
 							"character": 18
 						}
 					],
@@ -77846,7 +77792,7 @@
 					"sources": [
 						{
 							"fileName": "lib/reporters/Coverage.ts",
-							"line": 87,
+							"line": 92,
 							"character": 22
 						}
 					]
@@ -77857,28 +77803,28 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						1292
+						1298
 					]
 				},
 				{
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						1335
+						1292
 					]
 				},
 				{
 					"title": "Type aliases",
 					"kind": 4194304,
 					"children": [
-						1342
+						1341
 					]
 				},
 				{
 					"title": "Variables",
 					"kind": 32,
 					"children": [
-						1341
+						1342
 					]
 				},
 				{
@@ -77947,7 +77893,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Executor",
-												"id": 3780
+												"id": 3787
 											}
 										},
 										{
@@ -77972,7 +77918,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Reporter.__constructor",
-										"id": 4055
+										"id": 4062
 									}
 								}
 							],
@@ -77986,7 +77932,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.__constructor",
-								"id": 4055
+								"id": 4062
 							}
 						},
 						{
@@ -78022,7 +77968,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
@@ -78100,7 +78046,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
@@ -78126,7 +78072,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -78137,7 +78083,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
@@ -78176,7 +78122,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
@@ -78202,7 +78148,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -78213,7 +78159,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
@@ -78256,12 +78202,12 @@
 							"type": {
 								"type": "reference",
 								"name": "Executor",
-								"id": 3780
+								"id": 3787
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							}
 						},
 						{
@@ -78338,7 +78284,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -78369,7 +78315,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -78388,12 +78334,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
@@ -78415,12 +78361,12 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -78441,7 +78387,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -78452,7 +78398,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -78471,12 +78417,12 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						},
 						{
@@ -78506,7 +78452,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -78520,7 +78466,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
@@ -78629,7 +78575,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -78643,7 +78589,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
@@ -78685,7 +78631,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -78742,7 +78688,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -78799,7 +78745,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Test",
-												"id": 3317
+												"id": 3324
 											}
 										}
 									],
@@ -78856,7 +78802,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Test",
-												"id": 3317
+												"id": 3324
 											}
 										}
 									],
@@ -78931,14 +78877,14 @@
 						{
 							"type": "reference",
 							"name": "Reporter",
-							"id": 4045
+							"id": 4052
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						}
 					]
 				},
@@ -78975,7 +78921,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
@@ -79018,12 +78964,12 @@
 							"type": {
 								"type": "reference",
 								"name": "ReporterOutput",
-								"id": 4076
+								"id": 4083
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						},
 						{
@@ -79071,7 +79017,7 @@
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						}
 					]
 				},
@@ -79185,7 +79131,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Executor",
-												"id": 3780
+												"id": 3787
 											}
 										},
 										{
@@ -79210,7 +79156,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Reporter.__constructor",
-										"id": 4055
+										"id": 4062
 									}
 								}
 							],
@@ -79224,7 +79170,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.__constructor",
-								"id": 4055
+								"id": 4062
 							}
 						},
 						{
@@ -79260,7 +79206,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
@@ -79338,7 +79284,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
@@ -79364,7 +79310,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -79375,7 +79321,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
@@ -79436,7 +79382,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
@@ -79485,7 +79431,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -79496,7 +79442,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
@@ -79876,12 +79822,12 @@
 							"type": {
 								"type": "reference",
 								"name": "Executor",
-								"id": 3780
+								"id": 3787
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							}
 						},
 						{
@@ -79933,7 +79879,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -79964,7 +79910,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -79983,7 +79929,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -80010,12 +79956,12 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -80036,7 +79982,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -80047,7 +79993,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -80066,7 +80012,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -80107,7 +80053,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -80227,7 +80173,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -80241,7 +80187,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
@@ -80426,7 +80372,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -80440,7 +80386,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
@@ -80525,7 +80471,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -80582,7 +80528,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -80639,7 +80585,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Test",
-												"id": 3317
+												"id": 3324
 											}
 										}
 									],
@@ -80732,14 +80678,14 @@
 						{
 							"type": "reference",
 							"name": "Reporter",
-							"id": 4045
+							"id": 4052
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						},
 						{
 							"type": "reference",
@@ -80781,7 +80727,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
@@ -80845,12 +80791,12 @@
 							"type": {
 								"type": "reference",
 								"name": "ReporterOutput",
-								"id": 4076
+								"id": 4083
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						}
 					],
@@ -80877,7 +80823,7 @@
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						}
 					],
 					"implementedBy": [
@@ -81385,7 +81331,7 @@
 			]
 		},
 		{
-			"id": 1886,
+			"id": 1893,
 			"name": "\"lib/reporters/HtmlCoverage\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -81396,7 +81342,7 @@
 			"originalName": "src/lib/reporters/HtmlCoverage.ts",
 			"children": [
 				{
-					"id": 1887,
+					"id": 1894,
 					"name": "HtmlCoverage",
 					"kind": 128,
 					"kindString": "Class",
@@ -81406,7 +81352,7 @@
 					},
 					"children": [
 						{
-							"id": 1890,
+							"id": 1897,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -81416,14 +81362,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1891,
+									"id": 1898,
 									"name": "new HtmlCoverage",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1892,
+											"id": 1899,
 											"name": "executor",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -81431,11 +81377,11 @@
 											"type": {
 												"type": "reference",
 												"name": "Node",
-												"id": 2600
+												"id": 2607
 											}
 										},
 										{
-											"id": 1893,
+											"id": 1900,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -81443,7 +81389,7 @@
 											"type": {
 												"type": "reference",
 												"name": "HtmlCoverageOptions",
-												"id": 1938
+												"id": 1945
 											},
 											"defaultValue": " {}"
 										}
@@ -81451,12 +81397,12 @@
 									"type": {
 										"type": "reference",
 										"name": "HtmlCoverage",
-										"id": 1887
+										"id": 1894
 									},
 									"overwrites": {
 										"type": "reference",
 										"name": "Coverage.__constructor",
-										"id": 1298
+										"id": 1304
 									}
 								}
 							],
@@ -81470,11 +81416,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.__constructor",
-								"id": 1298
+								"id": 1304
 							}
 						},
 						{
-							"id": 1909,
+							"id": 1916,
 							"name": "_console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -81506,11 +81452,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
-							"id": 1913,
+							"id": 1920,
 							"name": "_eventHandlers",
 							"kind": 1024,
 							"kindString": "Property",
@@ -81535,21 +81481,21 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1914,
+											"id": 1921,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 1915,
+													"id": 1922,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1916,
+															"id": 1923,
 															"name": "eventName",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -81584,11 +81530,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
-							"id": 1910,
+							"id": 1917,
 							"name": "_executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -81610,7 +81556,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -81621,11 +81567,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
-							"id": 1911,
+							"id": 1918,
 							"name": "_handles",
 							"kind": 1024,
 							"kindString": "Property",
@@ -81660,11 +81606,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
-							"id": 1912,
+							"id": 1919,
 							"name": "_output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -81686,7 +81632,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -81697,11 +81643,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
-							"id": 1901,
+							"id": 1908,
 							"name": "directory",
 							"kind": 1024,
 							"kindString": "Property",
@@ -81713,7 +81659,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 21,
+									"line": 34,
 									"character": 11
 								}
 							],
@@ -81733,16 +81679,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.directory",
-								"id": 1296
+								"id": 1302
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "HtmlCoverageProperties.directory",
-								"id": 1934
+								"id": 1941
 							}
 						},
 						{
-							"id": 1899,
+							"id": 1906,
 							"name": "executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -81753,28 +81699,28 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 18,
+									"line": 31,
 									"character": 19
 								}
 							],
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							},
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.executor",
-								"id": 1294
+								"id": 1300
 							}
 						},
 						{
-							"id": 1900,
+							"id": 1907,
 							"name": "filename",
 							"kind": 1024,
 							"kindString": "Property",
@@ -81786,7 +81732,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 20,
+									"line": 33,
 									"character": 10
 								}
 							],
@@ -81806,16 +81752,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.filename",
-								"id": 1295
+								"id": 1301
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "HtmlCoverageProperties.filename",
-								"id": 1933
+								"id": 1940
 							}
 						},
 						{
-							"id": 1888,
+							"id": 1895,
 							"name": "reportType",
 							"kind": 1024,
 							"kindString": "Property",
@@ -81838,11 +81784,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.reportType",
-								"id": 1293
+								"id": 1299
 							}
 						},
 						{
-							"id": 1889,
+							"id": 1896,
 							"name": "verbose",
 							"kind": 1024,
 							"kindString": "Property",
@@ -81873,11 +81819,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "HtmlCoverageProperties.verbose",
-								"id": 1932
+								"id": 1939
 							}
 						},
 						{
-							"id": 1902,
+							"id": 1909,
 							"name": "watermarks",
 							"kind": 1024,
 							"kindString": "Property",
@@ -81889,7 +81835,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 22,
+									"line": 35,
 									"character": 12
 								}
 							],
@@ -81900,16 +81846,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.watermarks",
-								"id": 1297
+								"id": 1303
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "HtmlCoverageProperties.watermarks",
-								"id": 1935
+								"id": 1942
 							}
 						},
 						{
-							"id": 1917,
+							"id": 1924,
 							"name": "console",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -81919,7 +81865,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 1918,
+									"id": 1925,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -81931,20 +81877,20 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 1919,
+									"id": 1926,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1920,
+											"id": 1927,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -81962,7 +81908,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -81981,16 +81927,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "HtmlCoverageProperties.console",
-								"id": 1937
+								"id": 1944
 							}
 						},
 						{
-							"id": 1921,
+							"id": 1928,
 							"name": "output",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -82000,7 +81946,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 1922,
+									"id": 1929,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -82008,25 +81954,25 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 1923,
+									"id": 1930,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1924,
+											"id": 1931,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -82034,7 +81980,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -82045,7 +81991,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -82064,16 +82010,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "HtmlCoverageProperties.output",
-								"id": 1936
+								"id": 1943
 							}
 						},
 						{
-							"id": 1929,
+							"id": 1936,
 							"name": "_registerEventHandlers",
 							"kind": 2048,
 							"kindString": "Method",
@@ -82084,7 +82030,7 @@
 							},
 							"signatures": [
 								{
-									"id": 1930,
+									"id": 1937,
 									"name": "_registerEventHandlers",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -82099,7 +82045,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -82113,11 +82059,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
-							"id": 1903,
+							"id": 1910,
 							"name": "createCoverageReport",
 							"kind": 2048,
 							"kindString": "Method",
@@ -82127,14 +82073,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1904,
+									"id": 1911,
 									"name": "createCoverageReport",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1905,
+											"id": 1912,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -82145,7 +82091,7 @@
 											}
 										},
 										{
-											"id": 1906,
+											"id": 1913,
 											"name": "data",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -82172,25 +82118,25 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.createCoverageReport",
-										"id": 1307
+										"id": 1313
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 44,
+									"line": 61,
 									"character": 22
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.createCoverageReport",
-								"id": 1307
+								"id": 1313
 							}
 						},
 						{
-							"id": 1925,
+							"id": 1932,
 							"name": "formatError",
 							"kind": 2048,
 							"kindString": "Method",
@@ -82200,14 +82146,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1926,
+									"id": 1933,
 									"name": "formatError",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1927,
+											"id": 1934,
 											"name": "error",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -82218,7 +82164,7 @@
 											}
 										},
 										{
-											"id": 1928,
+											"id": 1935,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -82239,7 +82185,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -82253,11 +82199,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
-							"id": 1894,
+							"id": 1901,
 							"name": "getReporterOptions",
 							"kind": 2048,
 							"kindString": "Method",
@@ -82267,7 +82213,7 @@
 							},
 							"signatures": [
 								{
-									"id": 1895,
+									"id": 1902,
 									"name": "getReporterOptions",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -82275,21 +82221,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1896,
+											"id": 1903,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 1897,
+													"id": 1904,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1898,
+															"id": 1905,
 															"name": "key",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -82318,7 +82264,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Coverage.getReporterOptions",
-										"id": 1302
+										"id": 1308
 									}
 								}
 							],
@@ -82332,11 +82278,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.getReporterOptions",
-								"id": 1302
+								"id": 1308
 							}
 						},
 						{
-							"id": 1907,
+							"id": 1914,
 							"name": "runEnd",
 							"kind": 2048,
 							"kindString": "Method",
@@ -82359,7 +82305,7 @@
 							],
 							"signatures": [
 								{
-									"id": 1908,
+									"id": 1915,
 									"name": "runEnd",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -82371,21 +82317,21 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.runEnd",
-										"id": 1311
+										"id": 1317
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 66,
+									"line": 84,
 									"character": 8
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.runEnd",
-								"id": 1311
+								"id": 1317
 							}
 						}
 					],
@@ -82394,43 +82340,43 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								1890
+								1897
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								1909,
-								1913,
-								1910,
-								1911,
-								1912,
-								1901,
-								1899,
-								1900,
-								1888,
-								1889,
-								1902
+								1916,
+								1920,
+								1917,
+								1918,
+								1919,
+								1908,
+								1906,
+								1907,
+								1895,
+								1896,
+								1909
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								1917,
-								1921
+								1924,
+								1928
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								1929,
-								1903,
-								1925,
-								1894,
-								1907
+								1936,
+								1910,
+								1932,
+								1901,
+								1914
 							]
 						}
 					],
@@ -82445,29 +82391,29 @@
 						{
 							"type": "reference",
 							"name": "Coverage",
-							"id": 1292
+							"id": 1298
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						},
 						{
 							"type": "reference",
 							"name": "CoverageProperties",
-							"id": 1335
+							"id": 1292
 						},
 						{
 							"type": "reference",
 							"name": "HtmlCoverageProperties",
-							"id": 1931
+							"id": 1938
 						}
 					]
 				},
 				{
-					"id": 1931,
+					"id": 1938,
 					"name": "HtmlCoverageProperties",
 					"kind": 256,
 					"kindString": "Interface",
@@ -82477,7 +82423,7 @@
 					},
 					"children": [
 						{
-							"id": 1937,
+							"id": 1944,
 							"name": "console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -82499,11 +82445,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
-							"id": 1934,
+							"id": 1941,
 							"name": "directory",
 							"kind": 1024,
 							"kindString": "Property",
@@ -82513,12 +82459,12 @@
 								"isOptional": true
 							},
 							"comment": {
-								"shortText": "A direcotry to write coverage data to"
+								"shortText": "A directory provided to the coverage reporter"
 							},
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 79,
+									"line": 18,
 									"character": 11
 								}
 							],
@@ -82538,11 +82484,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.directory",
-								"id": 1337
+								"id": 1294
 							}
 						},
 						{
-							"id": 1933,
+							"id": 1940,
 							"name": "filename",
 							"kind": 1024,
 							"kindString": "Property",
@@ -82552,12 +82498,12 @@
 								"isOptional": true
 							},
 							"comment": {
-								"shortText": "A filename to write coverage data to"
+								"shortText": "A filename provided to the coverage reporter"
 							},
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 76,
+									"line": 15,
 									"character": 10
 								}
 							],
@@ -82577,11 +82523,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.filename",
-								"id": 1336
+								"id": 1293
 							}
 						},
 						{
-							"id": 1936,
+							"id": 1943,
 							"name": "output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -82599,16 +82545,16 @@
 							"type": {
 								"type": "reference",
 								"name": "ReporterOutput",
-								"id": 4076
+								"id": 4083
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						},
 						{
-							"id": 1932,
+							"id": 1939,
 							"name": "verbose",
 							"kind": 1024,
 							"kindString": "Property",
@@ -82638,7 +82584,7 @@
 							}
 						},
 						{
-							"id": 1935,
+							"id": 1942,
 							"name": "watermarks",
 							"kind": 1024,
 							"kindString": "Property",
@@ -82653,7 +82599,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 82,
+									"line": 21,
 									"character": 12
 								}
 							],
@@ -82664,7 +82610,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.watermarks",
-								"id": 1338
+								"id": 1295
 							}
 						}
 					],
@@ -82673,12 +82619,12 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								1937,
-								1934,
-								1933,
-								1936,
-								1932,
-								1935
+								1944,
+								1941,
+								1940,
+								1943,
+								1939,
+								1942
 							]
 						}
 					],
@@ -82693,19 +82639,19 @@
 						{
 							"type": "reference",
 							"name": "CoverageProperties",
-							"id": 1335
+							"id": 1292
 						}
 					],
 					"implementedBy": [
 						{
 							"type": "reference",
 							"name": "HtmlCoverage",
-							"id": 1887
+							"id": 1894
 						}
 					]
 				},
 				{
-					"id": 1938,
+					"id": 1945,
 					"name": "HtmlCoverageOptions",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -82727,7 +82673,7 @@
 							{
 								"type": "reference",
 								"name": "HtmlCoverageProperties",
-								"id": 1931
+								"id": 1938
 							}
 						]
 					}
@@ -82738,21 +82684,21 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						1887
+						1894
 					]
 				},
 				{
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						1931
+						1938
 					]
 				},
 				{
 					"title": "Type aliases",
 					"kind": 4194304,
 					"children": [
-						1938
+						1945
 					]
 				}
 			],
@@ -82765,7 +82711,7 @@
 			]
 		},
 		{
-			"id": 1720,
+			"id": 1726,
 			"name": "\"lib/reporters/JUnit\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -82776,7 +82722,7 @@
 			"originalName": "src/lib/reporters/JUnit.ts",
 			"children": [
 				{
-					"id": 1721,
+					"id": 1732,
 					"name": "JUnit",
 					"kind": 128,
 					"kindString": "Class",
@@ -82789,7 +82735,7 @@
 					},
 					"children": [
 						{
-							"id": 1723,
+							"id": 1734,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -82799,14 +82745,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1724,
+									"id": 1735,
 									"name": "new JUnit",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1725,
+											"id": 1736,
 											"name": "executor",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -82814,11 +82760,11 @@
 											"type": {
 												"type": "reference",
 												"name": "Executor",
-												"id": 3780
+												"id": 3787
 											}
 										},
 										{
-											"id": 1726,
+											"id": 1737,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -82830,7 +82776,7 @@
 													{
 														"type": "reference",
 														"name": "JUnitProperties",
-														"id": 1752
+														"id": 1727
 													}
 												]
 											},
@@ -82840,30 +82786,30 @@
 									"type": {
 										"type": "reference",
 										"name": "JUnit",
-										"id": 1721
+										"id": 1732
 									},
 									"overwrites": {
 										"type": "reference",
 										"name": "Reporter.__constructor",
-										"id": 4055
+										"id": 4062
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/JUnit.ts",
-									"line": 16,
+									"line": 22,
 									"character": 40
 								}
 							],
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.__constructor",
-								"id": 4055
+								"id": 4062
 							}
 						},
 						{
-							"id": 1730,
+							"id": 1741,
 							"name": "_console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -82895,11 +82841,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
-							"id": 1734,
+							"id": 1745,
 							"name": "_eventHandlers",
 							"kind": 1024,
 							"kindString": "Property",
@@ -82924,21 +82870,21 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1735,
+											"id": 1746,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 1736,
+													"id": 1747,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1737,
+															"id": 1748,
 															"name": "eventName",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -82973,11 +82919,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
-							"id": 1731,
+							"id": 1742,
 							"name": "_executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -82999,7 +82945,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -83010,11 +82956,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
-							"id": 1732,
+							"id": 1743,
 							"name": "_handles",
 							"kind": 1024,
 							"kindString": "Property",
@@ -83049,11 +82995,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
-							"id": 1733,
+							"id": 1744,
 							"name": "_output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -83075,7 +83021,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -83086,11 +83032,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
-							"id": 1729,
+							"id": 1740,
 							"name": "executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -83108,16 +83054,16 @@
 							"type": {
 								"type": "reference",
 								"name": "Executor",
-								"id": 3780
+								"id": 3787
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							}
 						},
 						{
-							"id": 1722,
+							"id": 1733,
 							"name": "filename",
 							"kind": 1024,
 							"kindString": "Property",
@@ -83128,7 +83074,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/JUnit.ts",
-									"line": 16,
+									"line": 22,
 									"character": 19
 								}
 							],
@@ -83147,7 +83093,7 @@
 							}
 						},
 						{
-							"id": 1738,
+							"id": 1749,
 							"name": "console",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -83157,7 +83103,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 1739,
+									"id": 1750,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -83169,20 +83115,20 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 1740,
+									"id": 1751,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1741,
+											"id": 1752,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -83200,7 +83146,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -83219,16 +83165,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
-							"id": 1742,
+							"id": 1753,
 							"name": "output",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -83238,7 +83184,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 1743,
+									"id": 1754,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -83246,25 +83192,25 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 1744,
+									"id": 1755,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1745,
+											"id": 1756,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -83272,7 +83218,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -83283,7 +83229,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -83302,16 +83248,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						},
 						{
-							"id": 1750,
+							"id": 1761,
 							"name": "_registerEventHandlers",
 							"kind": 2048,
 							"kindString": "Method",
@@ -83322,7 +83268,7 @@
 							},
 							"signatures": [
 								{
-									"id": 1751,
+									"id": 1762,
 									"name": "_registerEventHandlers",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -83337,7 +83283,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -83351,11 +83297,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
-							"id": 1746,
+							"id": 1757,
 							"name": "formatError",
 							"kind": 2048,
 							"kindString": "Method",
@@ -83365,14 +83311,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1747,
+									"id": 1758,
 									"name": "formatError",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1748,
+											"id": 1759,
 											"name": "error",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -83383,7 +83329,7 @@
 											}
 										},
 										{
-											"id": 1749,
+											"id": 1760,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -83404,7 +83350,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -83418,11 +83364,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
-							"id": 1727,
+							"id": 1738,
 							"name": "runEnd",
 							"kind": 2048,
 							"kindString": "Method",
@@ -83445,7 +83391,7 @@
 							],
 							"signatures": [
 								{
-									"id": 1728,
+									"id": 1739,
 									"name": "runEnd",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -83459,7 +83405,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/JUnit.ts",
-									"line": 30,
+									"line": 37,
 									"character": 8
 								}
 							]
@@ -83470,44 +83416,44 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								1723
+								1734
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								1730,
-								1734,
-								1731,
-								1732,
-								1733,
-								1729,
-								1722
+								1741,
+								1745,
+								1742,
+								1743,
+								1744,
+								1740,
+								1733
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								1738,
-								1742
+								1749,
+								1753
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								1750,
-								1746,
-								1727
+								1761,
+								1757,
+								1738
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "lib/reporters/JUnit.ts",
-							"line": 15,
+							"line": 21,
 							"character": 26
 						}
 					],
@@ -83515,19 +83461,19 @@
 						{
 							"type": "reference",
 							"name": "Reporter",
-							"id": 4045
+							"id": 4052
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						}
 					]
 				},
 				{
-					"id": 1756,
+					"id": 1763,
 					"name": "XmlNode",
 					"kind": 128,
 					"kindString": "Class",
@@ -83555,7 +83501,7 @@
 					},
 					"children": [
 						{
-							"id": 1760,
+							"id": 1767,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -83564,14 +83510,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1761,
+									"id": 1768,
 									"name": "new XmlNode",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1762,
+											"id": 1769,
 											"name": "nodeName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -83582,7 +83528,7 @@
 											}
 										},
 										{
-											"id": 1763,
+											"id": 1770,
 											"name": "attributes",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -83598,20 +83544,20 @@
 									"type": {
 										"type": "reference",
 										"name": "XmlNode",
-										"id": 1756
+										"id": 1763
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/JUnit.ts",
-									"line": 54,
+									"line": 57,
 									"character": 18
 								}
 							]
 						},
 						{
-							"id": 1759,
+							"id": 1766,
 							"name": "attributes",
 							"kind": 1024,
 							"kindString": "Property",
@@ -83621,7 +83567,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/JUnit.ts",
-									"line": 54,
+									"line": 57,
 									"character": 12
 								}
 							],
@@ -83631,7 +83577,7 @@
 							}
 						},
 						{
-							"id": 1758,
+							"id": 1765,
 							"name": "childNodes",
 							"kind": 1024,
 							"kindString": "Property",
@@ -83641,7 +83587,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/JUnit.ts",
-									"line": 53,
+									"line": 56,
 									"character": 12
 								}
 							],
@@ -83655,7 +83601,7 @@
 							"defaultValue": " []"
 						},
 						{
-							"id": 1757,
+							"id": 1764,
 							"name": "nodeName",
 							"kind": 1024,
 							"kindString": "Property",
@@ -83665,7 +83611,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/JUnit.ts",
-									"line": 52,
+									"line": 55,
 									"character": 10
 								}
 							],
@@ -83676,7 +83622,7 @@
 							"defaultValue": "\"\""
 						},
 						{
-							"id": 1768,
+							"id": 1775,
 							"name": "_escape",
 							"kind": 2048,
 							"kindString": "Method",
@@ -83685,14 +83631,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1769,
+									"id": 1776,
 									"name": "_escape",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1770,
+											"id": 1777,
 											"name": "str",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -83712,13 +83658,13 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/JUnit.ts",
-									"line": 80,
+									"line": 83,
 									"character": 9
 								}
 							]
 						},
 						{
-							"id": 1771,
+							"id": 1778,
 							"name": "_serializeAttributes",
 							"kind": 2048,
 							"kindString": "Method",
@@ -83727,7 +83673,7 @@
 							},
 							"signatures": [
 								{
-									"id": 1772,
+									"id": 1779,
 									"name": "_serializeAttributes",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -83741,13 +83687,13 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/JUnit.ts",
-									"line": 87,
+									"line": 90,
 									"character": 22
 								}
 							]
 						},
 						{
-							"id": 1773,
+							"id": 1780,
 							"name": "_serializeContent",
 							"kind": 2048,
 							"kindString": "Method",
@@ -83756,7 +83702,7 @@
 							},
 							"signatures": [
 								{
-									"id": 1774,
+									"id": 1781,
 									"name": "_serializeContent",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -83770,13 +83716,13 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/JUnit.ts",
-									"line": 100,
+									"line": 103,
 									"character": 19
 								}
 							]
 						},
 						{
-							"id": 1764,
+							"id": 1771,
 							"name": "createNode",
 							"kind": 2048,
 							"kindString": "Method",
@@ -83785,7 +83731,7 @@
 							},
 							"signatures": [
 								{
-									"id": 1765,
+									"id": 1772,
 									"name": "createNode",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -83796,7 +83742,7 @@
 									},
 									"parameters": [
 										{
-											"id": 1766,
+											"id": 1773,
 											"name": "nodeName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -83810,7 +83756,7 @@
 											}
 										},
 										{
-											"id": 1767,
+											"id": 1774,
 											"name": "attributes",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -83827,20 +83773,20 @@
 									"type": {
 										"type": "reference",
 										"name": "XmlNode",
-										"id": 1756
+										"id": 1763
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/JUnit.ts",
-									"line": 74,
+									"line": 77,
 									"character": 12
 								}
 							]
 						},
 						{
-							"id": 1775,
+							"id": 1782,
 							"name": "toString",
 							"kind": 2048,
 							"kindString": "Method",
@@ -83849,7 +83795,7 @@
 							},
 							"signatures": [
 								{
-									"id": 1776,
+									"id": 1783,
 									"name": "toString",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -83867,7 +83813,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/JUnit.ts",
-									"line": 118,
+									"line": 121,
 									"character": 10
 								}
 							]
@@ -83878,40 +83824,40 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								1760
+								1767
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								1759,
-								1758,
-								1757
+								1766,
+								1765,
+								1764
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								1768,
+								1775,
+								1778,
+								1780,
 								1771,
-								1773,
-								1764,
-								1775
+								1782
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "lib/reporters/JUnit.ts",
-							"line": 51,
+							"line": 54,
 							"character": 13
 						}
 					]
 				},
 				{
-					"id": 1752,
+					"id": 1727,
 					"name": "JUnitProperties",
 					"kind": 256,
 					"kindString": "Interface",
@@ -83921,7 +83867,7 @@
 					},
 					"children": [
 						{
-							"id": 1755,
+							"id": 1731,
 							"name": "console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -83943,11 +83889,32 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
-							"id": 1753,
+							"id": 1728,
+							"name": "directory",
+							"kind": 1024,
+							"kindString": "Property",
+							"flags": {
+								"isExported": true,
+								"isExternal": true
+							},
+							"sources": [
+								{
+									"fileName": "lib/reporters/JUnit.ts",
+									"line": 12,
+									"character": 11
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1729,
 							"name": "filename",
 							"kind": 1024,
 							"kindString": "Property",
@@ -83959,7 +83926,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/JUnit.ts",
-									"line": 42,
+									"line": 13,
 									"character": 10
 								}
 							],
@@ -83978,7 +83945,7 @@
 							}
 						},
 						{
-							"id": 1754,
+							"id": 1730,
 							"name": "output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -83996,12 +83963,12 @@
 							"type": {
 								"type": "reference",
 								"name": "ReporterOutput",
-								"id": 4076
+								"id": 4083
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						}
 					],
@@ -84010,16 +83977,17 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								1755,
-								1753,
-								1754
+								1731,
+								1728,
+								1729,
+								1730
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "lib/reporters/JUnit.ts",
-							"line": 41,
+							"line": 11,
 							"character": 32
 						}
 					],
@@ -84027,12 +83995,12 @@
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						}
 					]
 				},
 				{
-					"id": 1777,
+					"id": 1784,
 					"name": "createChildErrorNode",
 					"kind": 64,
 					"kindString": "Function",
@@ -84041,14 +84009,14 @@
 					},
 					"signatures": [
 						{
-							"id": 1778,
+							"id": 1785,
 							"name": "createChildErrorNode",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1779,
+									"id": 1786,
 									"name": "error",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -84059,7 +84027,7 @@
 									}
 								},
 								{
-									"id": 1780,
+									"id": 1787,
 									"name": "reporter",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -84067,27 +84035,27 @@
 									"type": {
 										"type": "reference",
 										"name": "JUnit",
-										"id": 1721
+										"id": 1732
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
 								"name": "XmlNode",
-								"id": 1756
+								"id": 1763
 							}
 						}
 					],
 					"sources": [
 						{
 							"fileName": "lib/reporters/JUnit.ts",
-							"line": 130,
+							"line": 133,
 							"character": 29
 						}
 					]
 				},
 				{
-					"id": 1781,
+					"id": 1788,
 					"name": "createSuiteNode",
 					"kind": 64,
 					"kindString": "Function",
@@ -84096,14 +84064,14 @@
 					},
 					"signatures": [
 						{
-							"id": 1782,
+							"id": 1789,
 							"name": "createSuiteNode",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1783,
+									"id": 1790,
 									"name": "suite",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -84111,11 +84079,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Suite",
-										"id": 3400
+										"id": 3407
 									}
 								},
 								{
-									"id": 1784,
+									"id": 1791,
 									"name": "reporter",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -84123,27 +84091,27 @@
 									"type": {
 										"type": "reference",
 										"name": "JUnit",
-										"id": 1721
+										"id": 1732
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
 								"name": "XmlNode",
-								"id": 1756
+								"id": 1763
 							}
 						}
 					],
 					"sources": [
 						{
 							"fileName": "lib/reporters/JUnit.ts",
-							"line": 138,
+							"line": 141,
 							"character": 24
 						}
 					]
 				},
 				{
-					"id": 1785,
+					"id": 1792,
 					"name": "createTestNode",
 					"kind": 64,
 					"kindString": "Function",
@@ -84152,14 +84120,14 @@
 					},
 					"signatures": [
 						{
-							"id": 1786,
+							"id": 1793,
 							"name": "createTestNode",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1787,
+									"id": 1794,
 									"name": "test",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -84170,18 +84138,18 @@
 											{
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											},
 											{
 												"type": "reference",
 												"name": "Test",
-												"id": 3317
+												"id": 3324
 											}
 										]
 									}
 								},
 								{
-									"id": 1788,
+									"id": 1795,
 									"name": "reporter",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -84189,21 +84157,21 @@
 									"type": {
 										"type": "reference",
 										"name": "JUnit",
-										"id": 1721
+										"id": 1732
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
 								"name": "XmlNode",
-								"id": 1756
+								"id": 1763
 							}
 						}
 					],
 					"sources": [
 						{
 							"fileName": "lib/reporters/JUnit.ts",
-							"line": 161,
+							"line": 164,
 							"character": 23
 						}
 					]
@@ -84214,24 +84182,24 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						1721,
-						1756
+						1732,
+						1763
 					]
 				},
 				{
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						1752
+						1727
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						1777,
-						1781,
-						1785
+						1784,
+						1788,
+						1792
 					]
 				}
 			],
@@ -84244,7 +84212,7 @@
 			]
 		},
 		{
-			"id": 1842,
+			"id": 1849,
 			"name": "\"lib/reporters/JsonCoverage\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -84255,7 +84223,7 @@
 			"originalName": "src/lib/reporters/JsonCoverage.ts",
 			"children": [
 				{
-					"id": 1843,
+					"id": 1850,
 					"name": "JsonCoverage",
 					"kind": 128,
 					"kindString": "Class",
@@ -84265,7 +84233,7 @@
 					},
 					"children": [
 						{
-							"id": 1849,
+							"id": 1856,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -84275,14 +84243,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1850,
+									"id": 1857,
 									"name": "new JsonCoverage",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1851,
+											"id": 1858,
 											"name": "executor",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -84290,11 +84258,11 @@
 											"type": {
 												"type": "reference",
 												"name": "Node",
-												"id": 2600
+												"id": 2607
 											}
 										},
 										{
-											"id": 1852,
+											"id": 1859,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -84302,7 +84270,7 @@
 											"type": {
 												"type": "reference",
 												"name": "CoverageOptions",
-												"id": 1342
+												"id": 1341
 											},
 											"defaultValue": " {}"
 										}
@@ -84310,40 +84278,40 @@
 									"type": {
 										"type": "reference",
 										"name": "JsonCoverage",
-										"id": 1843
+										"id": 1850
 									},
 									"overwrites": {
 										"type": "reference",
 										"name": "Reporter.__constructor",
-										"id": 4055
+										"id": 4062
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.__constructor",
-										"id": 1298
+										"id": 1304
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 22,
+									"line": 35,
 									"character": 26
 								}
 							],
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.__constructor",
-								"id": 4055
+								"id": 4062
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.__constructor",
-								"id": 1298
+								"id": 1304
 							}
 						},
 						{
-							"id": 1864,
+							"id": 1871,
 							"name": "_console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -84375,11 +84343,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
-							"id": 1868,
+							"id": 1875,
 							"name": "_eventHandlers",
 							"kind": 1024,
 							"kindString": "Property",
@@ -84404,21 +84372,21 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1869,
+											"id": 1876,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 1870,
+													"id": 1877,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1871,
+															"id": 1878,
 															"name": "eventName",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -84453,11 +84421,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
-							"id": 1865,
+							"id": 1872,
 							"name": "_executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -84479,7 +84447,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -84490,11 +84458,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
-							"id": 1866,
+							"id": 1873,
 							"name": "_handles",
 							"kind": 1024,
 							"kindString": "Property",
@@ -84529,11 +84497,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
-							"id": 1867,
+							"id": 1874,
 							"name": "_output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -84555,7 +84523,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -84566,11 +84534,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
-							"id": 1847,
+							"id": 1854,
 							"name": "directory",
 							"kind": 1024,
 							"kindString": "Property",
@@ -84582,7 +84550,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 21,
+									"line": 34,
 									"character": 11
 								}
 							],
@@ -84602,16 +84570,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.directory",
-								"id": 1296
+								"id": 1302
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.directory",
-								"id": 1337
+								"id": 1294
 							}
 						},
 						{
-							"id": 1845,
+							"id": 1852,
 							"name": "executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -84622,28 +84590,28 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 18,
+									"line": 31,
 									"character": 19
 								}
 							],
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							},
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.executor",
-								"id": 1294
+								"id": 1300
 							}
 						},
 						{
-							"id": 1846,
+							"id": 1853,
 							"name": "filename",
 							"kind": 1024,
 							"kindString": "Property",
@@ -84655,7 +84623,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 20,
+									"line": 33,
 									"character": 10
 								}
 							],
@@ -84675,16 +84643,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.filename",
-								"id": 1295
+								"id": 1301
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.filename",
-								"id": 1336
+								"id": 1293
 							}
 						},
 						{
-							"id": 1844,
+							"id": 1851,
 							"name": "reportType",
 							"kind": 1024,
 							"kindString": "Property",
@@ -84707,11 +84675,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.reportType",
-								"id": 1293
+								"id": 1299
 							}
 						},
 						{
-							"id": 1848,
+							"id": 1855,
 							"name": "watermarks",
 							"kind": 1024,
 							"kindString": "Property",
@@ -84723,7 +84691,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 22,
+									"line": 35,
 									"character": 12
 								}
 							],
@@ -84734,16 +84702,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.watermarks",
-								"id": 1297
+								"id": 1303
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.watermarks",
-								"id": 1338
+								"id": 1295
 							}
 						},
 						{
-							"id": 1872,
+							"id": 1879,
 							"name": "console",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -84753,7 +84721,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 1873,
+									"id": 1880,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -84765,20 +84733,20 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 1874,
+									"id": 1881,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1875,
+											"id": 1882,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -84796,7 +84764,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -84815,16 +84783,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.console",
-								"id": 1340
+								"id": 1297
 							}
 						},
 						{
-							"id": 1876,
+							"id": 1883,
 							"name": "output",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -84834,7 +84802,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 1877,
+									"id": 1884,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -84842,25 +84810,25 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 1878,
+									"id": 1885,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1879,
+											"id": 1886,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -84868,7 +84836,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -84879,7 +84847,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -84898,16 +84866,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.output",
-								"id": 1339
+								"id": 1296
 							}
 						},
 						{
-							"id": 1884,
+							"id": 1891,
 							"name": "_registerEventHandlers",
 							"kind": 2048,
 							"kindString": "Method",
@@ -84918,7 +84886,7 @@
 							},
 							"signatures": [
 								{
-									"id": 1885,
+									"id": 1892,
 									"name": "_registerEventHandlers",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -84933,7 +84901,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -84947,11 +84915,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
-							"id": 1858,
+							"id": 1865,
 							"name": "createCoverageReport",
 							"kind": 2048,
 							"kindString": "Method",
@@ -84961,14 +84929,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1859,
+									"id": 1866,
 									"name": "createCoverageReport",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1860,
+											"id": 1867,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -84979,7 +84947,7 @@
 											}
 										},
 										{
-											"id": 1861,
+											"id": 1868,
 											"name": "data",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -85006,25 +84974,25 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.createCoverageReport",
-										"id": 1307
+										"id": 1313
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 44,
+									"line": 61,
 									"character": 22
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.createCoverageReport",
-								"id": 1307
+								"id": 1313
 							}
 						},
 						{
-							"id": 1880,
+							"id": 1887,
 							"name": "formatError",
 							"kind": 2048,
 							"kindString": "Method",
@@ -85034,14 +85002,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1881,
+									"id": 1888,
 									"name": "formatError",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1882,
+											"id": 1889,
 											"name": "error",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -85052,7 +85020,7 @@
 											}
 										},
 										{
-											"id": 1883,
+											"id": 1890,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -85073,7 +85041,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -85087,11 +85055,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
-							"id": 1853,
+							"id": 1860,
 							"name": "getReporterOptions",
 							"kind": 2048,
 							"kindString": "Method",
@@ -85101,29 +85069,32 @@
 							},
 							"signatures": [
 								{
-									"id": 1854,
+									"id": 1861,
 									"name": "getReporterOptions",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
+									"comment": {
+										"shortText": "This is a bag of data provided to the selected istanbul reporter (defined by `reportType`).\nby default this provides a filename (if present), though not all reporters use a filename."
+									},
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1855,
+											"id": 1862,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 1856,
+													"id": 1863,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1857,
+															"id": 1864,
 															"name": "key",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -85143,7 +85114,7 @@
 											"sources": [
 												{
 													"fileName": "lib/reporters/Coverage.ts",
-													"line": 38,
+													"line": 55,
 													"character": 23
 												}
 											]
@@ -85152,25 +85123,25 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.getReporterOptions",
-										"id": 1302
+										"id": 1308
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 38,
+									"line": 55,
 									"character": 20
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.getReporterOptions",
-								"id": 1302
+								"id": 1308
 							}
 						},
 						{
-							"id": 1862,
+							"id": 1869,
 							"name": "runEnd",
 							"kind": 2048,
 							"kindString": "Method",
@@ -85193,7 +85164,7 @@
 							],
 							"signatures": [
 								{
-									"id": 1863,
+									"id": 1870,
 									"name": "runEnd",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -85205,21 +85176,21 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.runEnd",
-										"id": 1311
+										"id": 1317
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 66,
+									"line": 84,
 									"character": 8
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.runEnd",
-								"id": 1311
+								"id": 1317
 							}
 						}
 					],
@@ -85228,42 +85199,42 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								1849
+								1856
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								1864,
-								1868,
-								1865,
-								1866,
-								1867,
-								1847,
-								1845,
-								1846,
-								1844,
-								1848
+								1871,
+								1875,
+								1872,
+								1873,
+								1874,
+								1854,
+								1852,
+								1853,
+								1851,
+								1855
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								1872,
-								1876
+								1879,
+								1883
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								1884,
-								1858,
-								1880,
-								1853,
-								1862
+								1891,
+								1865,
+								1887,
+								1860,
+								1869
 							]
 						}
 					],
@@ -85278,19 +85249,19 @@
 						{
 							"type": "reference",
 							"name": "Coverage",
-							"id": 1292
+							"id": 1298
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						},
 						{
 							"type": "reference",
 							"name": "CoverageProperties",
-							"id": 1335
+							"id": 1292
 						}
 					]
 				}
@@ -85300,7 +85271,7 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						1843
+						1850
 					]
 				}
 			],
@@ -85313,7 +85284,7 @@
 			]
 		},
 		{
-			"id": 1939,
+			"id": 1946,
 			"name": "\"lib/reporters/Lcov\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -85324,7 +85295,7 @@
 			"originalName": "src/lib/reporters/Lcov.ts",
 			"children": [
 				{
-					"id": 1940,
+					"id": 1947,
 					"name": "LcovCoverage",
 					"kind": 128,
 					"kindString": "Class",
@@ -85334,7 +85305,7 @@
 					},
 					"children": [
 						{
-							"id": 1946,
+							"id": 1953,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -85344,14 +85315,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1947,
+									"id": 1954,
 									"name": "new LcovCoverage",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1948,
+											"id": 1955,
 											"name": "executor",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -85359,11 +85330,11 @@
 											"type": {
 												"type": "reference",
 												"name": "Node",
-												"id": 2600
+												"id": 2607
 											}
 										},
 										{
-											"id": 1949,
+											"id": 1956,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -85371,7 +85342,7 @@
 											"type": {
 												"type": "reference",
 												"name": "CoverageOptions",
-												"id": 1342
+												"id": 1341
 											},
 											"defaultValue": " {}"
 										}
@@ -85379,40 +85350,40 @@
 									"type": {
 										"type": "reference",
 										"name": "LcovCoverage",
-										"id": 1940
+										"id": 1947
 									},
 									"overwrites": {
 										"type": "reference",
 										"name": "Reporter.__constructor",
-										"id": 4055
+										"id": 4062
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.__constructor",
-										"id": 1298
+										"id": 1304
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 22,
+									"line": 35,
 									"character": 26
 								}
 							],
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.__constructor",
-								"id": 4055
+								"id": 4062
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.__constructor",
-								"id": 1298
+								"id": 1304
 							}
 						},
 						{
-							"id": 1961,
+							"id": 1968,
 							"name": "_console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -85444,11 +85415,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
-							"id": 1965,
+							"id": 1972,
 							"name": "_eventHandlers",
 							"kind": 1024,
 							"kindString": "Property",
@@ -85473,21 +85444,21 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1966,
+											"id": 1973,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 1967,
+													"id": 1974,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1968,
+															"id": 1975,
 															"name": "eventName",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -85522,11 +85493,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
-							"id": 1962,
+							"id": 1969,
 							"name": "_executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -85548,7 +85519,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -85559,11 +85530,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
-							"id": 1963,
+							"id": 1970,
 							"name": "_handles",
 							"kind": 1024,
 							"kindString": "Property",
@@ -85598,11 +85569,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
-							"id": 1964,
+							"id": 1971,
 							"name": "_output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -85624,7 +85595,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -85635,11 +85606,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
-							"id": 1944,
+							"id": 1951,
 							"name": "directory",
 							"kind": 1024,
 							"kindString": "Property",
@@ -85651,7 +85622,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 21,
+									"line": 34,
 									"character": 11
 								}
 							],
@@ -85671,16 +85642,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.directory",
-								"id": 1296
+								"id": 1302
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.directory",
-								"id": 1337
+								"id": 1294
 							}
 						},
 						{
-							"id": 1942,
+							"id": 1949,
 							"name": "executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -85691,28 +85662,28 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 18,
+									"line": 31,
 									"character": 19
 								}
 							],
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							},
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.executor",
-								"id": 1294
+								"id": 1300
 							}
 						},
 						{
-							"id": 1943,
+							"id": 1950,
 							"name": "filename",
 							"kind": 1024,
 							"kindString": "Property",
@@ -85724,7 +85695,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 20,
+									"line": 33,
 									"character": 10
 								}
 							],
@@ -85744,16 +85715,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.filename",
-								"id": 1295
+								"id": 1301
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.filename",
-								"id": 1336
+								"id": 1293
 							}
 						},
 						{
-							"id": 1941,
+							"id": 1948,
 							"name": "reportType",
 							"kind": 1024,
 							"kindString": "Property",
@@ -85776,11 +85747,11 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.reportType",
-								"id": 1293
+								"id": 1299
 							}
 						},
 						{
-							"id": 1945,
+							"id": 1952,
 							"name": "watermarks",
 							"kind": 1024,
 							"kindString": "Property",
@@ -85792,7 +85763,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 22,
+									"line": 35,
 									"character": 12
 								}
 							],
@@ -85803,16 +85774,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.watermarks",
-								"id": 1297
+								"id": 1303
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.watermarks",
-								"id": 1338
+								"id": 1295
 							}
 						},
 						{
-							"id": 1969,
+							"id": 1976,
 							"name": "console",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -85822,7 +85793,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 1970,
+									"id": 1977,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -85834,20 +85805,20 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 1971,
+									"id": 1978,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1972,
+											"id": 1979,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -85865,7 +85836,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -85884,16 +85855,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.console",
-								"id": 1340
+								"id": 1297
 							}
 						},
 						{
-							"id": 1973,
+							"id": 1980,
 							"name": "output",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -85903,7 +85874,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 1974,
+									"id": 1981,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -85911,25 +85882,25 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 1975,
+									"id": 1982,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1976,
+											"id": 1983,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -85937,7 +85908,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -85948,7 +85919,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -85967,16 +85938,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "CoverageProperties.output",
-								"id": 1339
+								"id": 1296
 							}
 						},
 						{
-							"id": 1981,
+							"id": 1988,
 							"name": "_registerEventHandlers",
 							"kind": 2048,
 							"kindString": "Method",
@@ -85987,7 +85958,7 @@
 							},
 							"signatures": [
 								{
-									"id": 1982,
+									"id": 1989,
 									"name": "_registerEventHandlers",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -86002,7 +85973,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -86016,11 +85987,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
-							"id": 1955,
+							"id": 1962,
 							"name": "createCoverageReport",
 							"kind": 2048,
 							"kindString": "Method",
@@ -86030,14 +86001,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1956,
+									"id": 1963,
 									"name": "createCoverageReport",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1957,
+											"id": 1964,
 											"name": "type",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -86048,7 +86019,7 @@
 											}
 										},
 										{
-											"id": 1958,
+											"id": 1965,
 											"name": "data",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -86075,25 +86046,25 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.createCoverageReport",
-										"id": 1307
+										"id": 1313
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 44,
+									"line": 61,
 									"character": 22
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.createCoverageReport",
-								"id": 1307
+								"id": 1313
 							}
 						},
 						{
-							"id": 1977,
+							"id": 1984,
 							"name": "formatError",
 							"kind": 2048,
 							"kindString": "Method",
@@ -86103,14 +86074,14 @@
 							},
 							"signatures": [
 								{
-									"id": 1978,
+									"id": 1985,
 									"name": "formatError",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 1979,
+											"id": 1986,
 											"name": "error",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -86121,7 +86092,7 @@
 											}
 										},
 										{
-											"id": 1980,
+											"id": 1987,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -86142,7 +86113,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -86156,11 +86127,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
-							"id": 1950,
+							"id": 1957,
 							"name": "getReporterOptions",
 							"kind": 2048,
 							"kindString": "Method",
@@ -86170,29 +86141,32 @@
 							},
 							"signatures": [
 								{
-									"id": 1951,
+									"id": 1958,
 									"name": "getReporterOptions",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
+									"comment": {
+										"shortText": "This is a bag of data provided to the selected istanbul reporter (defined by `reportType`).\nby default this provides a filename (if present), though not all reporters use a filename."
+									},
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1952,
+											"id": 1959,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 1953,
+													"id": 1960,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1954,
+															"id": 1961,
 															"name": "key",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -86212,7 +86186,7 @@
 											"sources": [
 												{
 													"fileName": "lib/reporters/Coverage.ts",
-													"line": 38,
+													"line": 55,
 													"character": 23
 												}
 											]
@@ -86221,25 +86195,25 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.getReporterOptions",
-										"id": 1302
+										"id": 1308
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 38,
+									"line": 55,
 									"character": 20
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.getReporterOptions",
-								"id": 1302
+								"id": 1308
 							}
 						},
 						{
-							"id": 1959,
+							"id": 1966,
 							"name": "runEnd",
 							"kind": 2048,
 							"kindString": "Method",
@@ -86262,7 +86236,7 @@
 							],
 							"signatures": [
 								{
-									"id": 1960,
+									"id": 1967,
 									"name": "runEnd",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -86274,21 +86248,21 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.runEnd",
-										"id": 1311
+										"id": 1317
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 66,
+									"line": 84,
 									"character": 8
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.runEnd",
-								"id": 1311
+								"id": 1317
 							}
 						}
 					],
@@ -86297,42 +86271,42 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								1946
+								1953
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								1961,
-								1965,
-								1962,
-								1963,
-								1964,
-								1944,
-								1942,
-								1943,
-								1941,
-								1945
+								1968,
+								1972,
+								1969,
+								1970,
+								1971,
+								1951,
+								1949,
+								1950,
+								1948,
+								1952
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								1969,
-								1973
+								1976,
+								1980
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								1981,
-								1955,
-								1977,
-								1950,
-								1959
+								1988,
+								1962,
+								1984,
+								1957,
+								1966
 							]
 						}
 					],
@@ -86347,19 +86321,19 @@
 						{
 							"type": "reference",
 							"name": "Coverage",
-							"id": 1292
+							"id": 1298
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						},
 						{
 							"type": "reference",
 							"name": "CoverageProperties",
-							"id": 1335
+							"id": 1292
 						}
 					]
 				}
@@ -86369,7 +86343,7 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						1940
+						1947
 					]
 				}
 			],
@@ -86515,7 +86489,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Node",
-												"id": 2600
+												"id": 2607
 											}
 										},
 										{
@@ -86621,7 +86595,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
@@ -86699,7 +86673,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
@@ -86725,7 +86699,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -86736,7 +86710,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
@@ -86775,7 +86749,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
@@ -86848,7 +86822,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -86859,7 +86833,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
@@ -87064,7 +87038,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 21,
+									"line": 34,
 									"character": 11
 								}
 							],
@@ -87084,7 +87058,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.directory",
-								"id": 1296
+								"id": 1302
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -87104,24 +87078,24 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 18,
+									"line": 31,
 									"character": 19
 								}
 							],
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							},
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.executor",
-								"id": 1294
+								"id": 1300
 							}
 						},
 						{
@@ -87137,7 +87111,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 20,
+									"line": 33,
 									"character": 10
 								}
 							],
@@ -87157,7 +87131,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.filename",
-								"id": 1295
+								"id": 1301
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -87255,7 +87229,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.reportType",
-								"id": 1293
+								"id": 1299
 							},
 							"inheritedFrom": {
 								"type": "reference",
@@ -87323,7 +87297,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 22,
+									"line": 35,
 									"character": 12
 								}
 							],
@@ -87334,7 +87308,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.watermarks",
-								"id": 1297
+								"id": 1303
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -87365,7 +87339,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -87396,7 +87370,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -87415,7 +87389,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -87442,12 +87416,12 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -87468,7 +87442,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -87479,7 +87453,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -87498,7 +87472,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -87533,7 +87507,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -87547,7 +87521,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
@@ -87619,7 +87593,7 @@
 											"type": {
 												"type": "reference",
 												"name": "CoverageMessage",
-												"id": 3993
+												"id": 4000
 											}
 										}
 									],
@@ -87693,21 +87667,21 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.createCoverageReport",
-										"id": 1307
+										"id": 1313
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 44,
+									"line": 61,
 									"character": 22
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.createCoverageReport",
-								"id": 1307
+								"id": 1313
 							}
 						},
 						{
@@ -87749,7 +87723,7 @@
 											"type": {
 												"type": "reference",
 												"name": "DeprecationMessage",
-												"id": 3997
+												"id": 4004
 											}
 										}
 									],
@@ -87873,7 +87847,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -87887,7 +87861,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
@@ -87952,7 +87926,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Coverage.getReporterOptions",
-										"id": 1302
+										"id": 1308
 									},
 									"inheritedFrom": {
 										"type": "reference",
@@ -87971,7 +87945,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.getReporterOptions",
-								"id": 1302
+								"id": 1308
 							},
 							"inheritedFrom": {
 								"type": "reference",
@@ -88015,7 +87989,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Coverage.runEnd",
-										"id": 1311
+										"id": 1317
 									}
 								}
 							],
@@ -88029,7 +88003,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.runEnd",
-								"id": 1311
+								"id": 1317
 							}
 						},
 						{
@@ -88114,7 +88088,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -88171,7 +88145,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -88228,7 +88202,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Test",
-												"id": 3317
+												"id": 3324
 											}
 										}
 									],
@@ -88285,7 +88259,7 @@
 											"type": {
 												"type": "reference",
 												"name": "TunnelMessage",
-												"id": 3252
+												"id": 3259
 											}
 										}
 									],
@@ -88342,7 +88316,7 @@
 											"type": {
 												"type": "reference",
 												"name": "TunnelMessage",
-												"id": 3252
+												"id": 3259
 											}
 										}
 									],
@@ -88446,12 +88420,12 @@
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						},
 						{
 							"type": "reference",
 							"name": "CoverageProperties",
-							"id": 1335
+							"id": 1292
 						},
 						{
 							"type": "reference",
@@ -89088,7 +89062,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
@@ -89123,12 +89097,12 @@
 								"isOptional": true
 							},
 							"comment": {
-								"shortText": "A direcotry to write coverage data to"
+								"shortText": "A directory provided to the coverage reporter"
 							},
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 79,
+									"line": 18,
 									"character": 11
 								}
 							],
@@ -89148,7 +89122,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.directory",
-								"id": 1337
+								"id": 1294
 							}
 						},
 						{
@@ -89162,12 +89136,12 @@
 								"isOptional": true
 							},
 							"comment": {
-								"shortText": "A filename to write coverage data to"
+								"shortText": "A filename provided to the coverage reporter"
 							},
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 76,
+									"line": 15,
 									"character": 10
 								}
 							],
@@ -89187,7 +89161,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.filename",
-								"id": 1336
+								"id": 1293
 							}
 						},
 						{
@@ -89269,12 +89243,12 @@
 							"type": {
 								"type": "reference",
 								"name": "ReporterOutput",
-								"id": 4076
+								"id": 4083
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						},
 						{
@@ -89314,7 +89288,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 82,
+									"line": 21,
 									"character": 12
 								}
 							],
@@ -89325,7 +89299,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.watermarks",
-								"id": 1338
+								"id": 1295
 							}
 						}
 					],
@@ -89917,7 +89891,7 @@
 			]
 		},
 		{
-			"id": 4044,
+			"id": 4051,
 			"name": "\"lib/reporters/Reporter\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -89928,7 +89902,7 @@
 			"originalName": "src/lib/reporters/Reporter.ts",
 			"children": [
 				{
-					"id": 4045,
+					"id": 4052,
 					"name": "Reporter",
 					"kind": 128,
 					"kindString": "Class",
@@ -89941,7 +89915,7 @@
 					},
 					"children": [
 						{
-							"id": 4055,
+							"id": 4062,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -89951,14 +89925,14 @@
 							},
 							"signatures": [
 								{
-									"id": 4056,
+									"id": 4063,
 									"name": "new Reporter",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4057,
+											"id": 4064,
 											"name": "executor",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -89966,11 +89940,11 @@
 											"type": {
 												"type": "reference",
 												"name": "Executor",
-												"id": 3780
+												"id": 3787
 											}
 										},
 										{
-											"id": 4058,
+											"id": 4065,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -89978,7 +89952,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOptions",
-												"id": 4092
+												"id": 4099
 											},
 											"defaultValue": " {}"
 										}
@@ -89986,7 +89960,7 @@
 									"type": {
 										"type": "reference",
 										"name": "Reporter",
-										"id": 4045
+										"id": 4052
 									}
 								}
 							],
@@ -89999,7 +89973,7 @@
 							]
 						},
 						{
-							"id": 4047,
+							"id": 4054,
 							"name": "_console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -90030,7 +90004,7 @@
 							}
 						},
 						{
-							"id": 4051,
+							"id": 4058,
 							"name": "_eventHandlers",
 							"kind": 1024,
 							"kindString": "Property",
@@ -90055,21 +90029,21 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 4052,
+											"id": 4059,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 4053,
+													"id": 4060,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 4054,
+															"id": 4061,
 															"name": "eventName",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -90103,7 +90077,7 @@
 							}
 						},
 						{
-							"id": 4048,
+							"id": 4055,
 							"name": "_executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -90125,7 +90099,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -90135,7 +90109,7 @@
 							}
 						},
 						{
-							"id": 4049,
+							"id": 4056,
 							"name": "_handles",
 							"kind": 1024,
 							"kindString": "Property",
@@ -90169,7 +90143,7 @@
 							}
 						},
 						{
-							"id": 4050,
+							"id": 4057,
 							"name": "_output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -90191,7 +90165,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -90201,7 +90175,7 @@
 							}
 						},
 						{
-							"id": 4046,
+							"id": 4053,
 							"name": "executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -90219,11 +90193,11 @@
 							"type": {
 								"type": "reference",
 								"name": "Executor",
-								"id": 3780
+								"id": 3787
 							}
 						},
 						{
-							"id": 4059,
+							"id": 4066,
 							"name": "console",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -90233,7 +90207,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 4060,
+									"id": 4067,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -90246,14 +90220,14 @@
 							],
 							"setSignature": [
 								{
-									"id": 4061,
+									"id": 4068,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4062,
+											"id": 4069,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -90285,11 +90259,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
-							"id": 4063,
+							"id": 4070,
 							"name": "output",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -90299,7 +90273,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 4064,
+									"id": 4071,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -90307,20 +90281,20 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 4065,
+									"id": 4072,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4066,
+											"id": 4073,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -90328,7 +90302,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -90353,11 +90327,11 @@
 							"implementationOf": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						},
 						{
-							"id": 4071,
+							"id": 4078,
 							"name": "_registerEventHandlers",
 							"kind": 2048,
 							"kindString": "Method",
@@ -90368,7 +90342,7 @@
 							},
 							"signatures": [
 								{
-									"id": 4072,
+									"id": 4079,
 									"name": "_registerEventHandlers",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -90391,7 +90365,7 @@
 							]
 						},
 						{
-							"id": 4067,
+							"id": 4074,
 							"name": "formatError",
 							"kind": 2048,
 							"kindString": "Method",
@@ -90401,14 +90375,14 @@
 							},
 							"signatures": [
 								{
-									"id": 4068,
+									"id": 4075,
 									"name": "formatError",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4069,
+											"id": 4076,
 											"name": "error",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -90419,7 +90393,7 @@
 											}
 										},
 										{
-											"id": 4070,
+											"id": 4077,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -90453,35 +90427,35 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								4055
+								4062
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4047,
-								4051,
-								4048,
-								4049,
-								4050,
-								4046
+								4054,
+								4058,
+								4055,
+								4056,
+								4057,
+								4053
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								4059,
-								4063
+								4066,
+								4070
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								4071,
-								4067
+								4078,
+								4074
 							]
 						}
 					],
@@ -90511,34 +90485,34 @@
 						{
 							"type": "reference",
 							"name": "Coverage",
-							"id": 1292
+							"id": 1298
 						},
 						{
 							"type": "reference",
 							"name": "JUnit",
-							"id": 1721
+							"id": 1732
 						},
 						{
 							"type": "reference",
 							"name": "BenchmarkReporter",
-							"id": 2444
+							"id": 2451
 						},
 						{
 							"type": "reference",
 							"name": "TeamCity",
-							"id": 2550
+							"id": 2557
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						}
 					]
 				},
 				{
-					"id": 4076,
+					"id": 4083,
 					"name": "ReporterOutput",
 					"kind": 256,
 					"kindString": "Interface",
@@ -90551,7 +90525,7 @@
 					},
 					"children": [
 						{
-							"id": 4082,
+							"id": 4089,
 							"name": "end",
 							"kind": 2048,
 							"kindString": "Method",
@@ -90561,14 +90535,14 @@
 							},
 							"signatures": [
 								{
-									"id": 4083,
+									"id": 4090,
 									"name": "end",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4084,
+											"id": 4091,
 											"name": "chunk",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -90588,7 +90562,7 @@
 											}
 										},
 										{
-											"id": 4085,
+											"id": 4092,
 											"name": "encoding",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -90610,7 +90584,7 @@
 											}
 										},
 										{
-											"id": 4086,
+											"id": 4093,
 											"name": "callback",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -90638,7 +90612,7 @@
 							]
 						},
 						{
-							"id": 4077,
+							"id": 4084,
 							"name": "write",
 							"kind": 2048,
 							"kindString": "Method",
@@ -90648,14 +90622,14 @@
 							},
 							"signatures": [
 								{
-									"id": 4078,
+									"id": 4085,
 									"name": "write",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 4079,
+											"id": 4086,
 											"name": "chunk",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -90675,7 +90649,7 @@
 											}
 										},
 										{
-											"id": 4080,
+											"id": 4087,
 											"name": "encoding",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -90697,7 +90671,7 @@
 											}
 										},
 										{
-											"id": 4081,
+											"id": 4088,
 											"name": "callback",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -90730,8 +90704,8 @@
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								4082,
-								4077
+								4089,
+								4084
 							]
 						}
 					],
@@ -90744,7 +90718,7 @@
 					]
 				},
 				{
-					"id": 4073,
+					"id": 4080,
 					"name": "ReporterProperties",
 					"kind": 256,
 					"kindString": "Interface",
@@ -90754,7 +90728,7 @@
 					},
 					"children": [
 						{
-							"id": 4075,
+							"id": 4082,
 							"name": "console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -90775,7 +90749,7 @@
 							}
 						},
 						{
-							"id": 4074,
+							"id": 4081,
 							"name": "output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -90793,7 +90767,7 @@
 							"type": {
 								"type": "reference",
 								"name": "ReporterOutput",
-								"id": 4076
+								"id": 4083
 							}
 						}
 					],
@@ -90802,8 +90776,8 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4075,
-								4074
+								4082,
+								4081
 							]
 						}
 					],
@@ -90828,29 +90802,29 @@
 						{
 							"type": "reference",
 							"name": "CoverageProperties",
-							"id": 1335
+							"id": 1292
 						},
 						{
 							"type": "reference",
 							"name": "JUnitProperties",
-							"id": 1752
+							"id": 1727
 						},
 						{
 							"type": "reference",
 							"name": "BenchmarkReporterProperties",
-							"id": 2538
+							"id": 2545
 						}
 					],
 					"implementedBy": [
 						{
 							"type": "reference",
 							"name": "BenchmarkReporter",
-							"id": 2444
+							"id": 2451
 						},
 						{
 							"type": "reference",
 							"name": "Cobertura",
-							"id": 1790
+							"id": 1797
 						},
 						{
 							"type": "reference",
@@ -90860,7 +90834,7 @@
 						{
 							"type": "reference",
 							"name": "Coverage",
-							"id": 1292
+							"id": 1298
 						},
 						{
 							"type": "reference",
@@ -90875,22 +90849,22 @@
 						{
 							"type": "reference",
 							"name": "HtmlCoverage",
-							"id": 1887
+							"id": 1894
 						},
 						{
 							"type": "reference",
 							"name": "JUnit",
-							"id": 1721
+							"id": 1732
 						},
 						{
 							"type": "reference",
 							"name": "JsonCoverage",
-							"id": 1843
+							"id": 1850
 						},
 						{
 							"type": "reference",
 							"name": "LcovCoverage",
-							"id": 1940
+							"id": 1947
 						},
 						{
 							"type": "reference",
@@ -90900,7 +90874,7 @@
 						{
 							"type": "reference",
 							"name": "Reporter",
-							"id": 4045
+							"id": 4052
 						},
 						{
 							"type": "reference",
@@ -90915,7 +90889,7 @@
 						{
 							"type": "reference",
 							"name": "TeamCity",
-							"id": 2550
+							"id": 2557
 						},
 						{
 							"type": "reference",
@@ -90925,7 +90899,7 @@
 					]
 				},
 				{
-					"id": 4092,
+					"id": 4099,
 					"name": "ReporterOptions",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -90947,13 +90921,13 @@
 							{
 								"type": "reference",
 								"name": "ReporterProperties",
-								"id": 4073
+								"id": 4080
 							}
 						]
 					}
 				},
 				{
-					"id": 4091,
+					"id": 4098,
 					"name": "eventHandler",
 					"kind": 32,
 					"kindString": "Variable",
@@ -90979,7 +90953,7 @@
 					"defaultValue": " createEventHandler()"
 				},
 				{
-					"id": 4087,
+					"id": 4094,
 					"name": "createEventHandler",
 					"kind": 64,
 					"kindString": "Function",
@@ -90989,7 +90963,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4088,
+							"id": 4095,
 							"name": "createEventHandler",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -90999,7 +90973,7 @@
 							},
 							"typeParameter": [
 								{
-									"id": 4089,
+									"id": 4096,
 									"name": "E",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -91007,11 +90981,11 @@
 									"type": {
 										"type": "reference",
 										"name": "Events",
-										"id": 4004
+										"id": 4011
 									}
 								},
 								{
-									"id": 4090,
+									"id": 4097,
 									"name": "N",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -91019,7 +90993,7 @@
 									"type": {
 										"type": "reference",
 										"name": "NoDataEvents",
-										"id": 4043
+										"id": 4050
 									}
 								}
 							],
@@ -91038,7 +91012,7 @@
 					]
 				},
 				{
-					"id": 4093,
+					"id": 4100,
 					"name": "getConsole",
 					"kind": 64,
 					"kindString": "Function",
@@ -91047,7 +91021,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4094,
+							"id": 4101,
 							"name": "getConsole",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -91067,7 +91041,7 @@
 					]
 				},
 				{
-					"id": 4095,
+					"id": 4102,
 					"name": "noop",
 					"kind": 64,
 					"kindString": "Function",
@@ -91076,7 +91050,7 @@
 					},
 					"signatures": [
 						{
-							"id": 4096,
+							"id": 4103,
 							"name": "noop",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -91101,38 +91075,38 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						4045
+						4052
 					]
 				},
 				{
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						4076,
-						4073
+						4083,
+						4080
 					]
 				},
 				{
 					"title": "Type aliases",
 					"kind": 4194304,
 					"children": [
-						4092
+						4099
 					]
 				},
 				{
 					"title": "Variables",
 					"kind": 32,
 					"children": [
-						4091
+						4098
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						4087,
-						4093,
-						4095
+						4094,
+						4100,
+						4102
 					]
 				}
 			],
@@ -91191,7 +91165,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Node",
-												"id": 2600
+												"id": 2607
 											}
 										},
 										{
@@ -91272,7 +91246,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
@@ -91350,7 +91324,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
@@ -91376,7 +91350,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -91387,7 +91361,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
@@ -91426,7 +91400,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
@@ -91452,7 +91426,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -91463,7 +91437,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
@@ -91502,7 +91476,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 21,
+									"line": 34,
 									"character": 11
 								}
 							],
@@ -91522,7 +91496,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.directory",
-								"id": 1296
+								"id": 1302
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -91542,24 +91516,24 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 18,
+									"line": 31,
 									"character": 19
 								}
 							],
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							},
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.executor",
-								"id": 1294
+								"id": 1300
 							}
 						},
 						{
@@ -91575,7 +91549,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 20,
+									"line": 33,
 									"character": 10
 								}
 							],
@@ -91595,7 +91569,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.filename",
-								"id": 1295
+								"id": 1301
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -91787,7 +91761,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.reportType",
-								"id": 1293
+								"id": 1299
 							},
 							"inheritedFrom": {
 								"type": "reference",
@@ -91935,7 +91909,7 @@
 															"type": {
 																"type": "reference",
 																"name": "Suite",
-																"id": 2328
+																"id": 2335
 															}
 														}
 													],
@@ -91983,7 +91957,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 22,
+									"line": 35,
 									"character": 12
 								}
 							],
@@ -91994,7 +91968,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.watermarks",
-								"id": 1297
+								"id": 1303
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -92025,7 +91999,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -92056,7 +92030,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -92075,7 +92049,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -92102,12 +92076,12 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -92128,7 +92102,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -92139,7 +92113,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -92158,7 +92132,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -92193,7 +92167,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -92207,7 +92181,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
@@ -92249,7 +92223,7 @@
 											"type": {
 												"type": "reference",
 												"name": "CoverageMessage",
-												"id": 3993
+												"id": 4000
 											}
 										}
 									],
@@ -92323,21 +92297,21 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.createCoverageReport",
-										"id": 1307
+										"id": 1313
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 44,
+									"line": 61,
 									"character": 22
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.createCoverageReport",
-								"id": 1307
+								"id": 1313
 							}
 						},
 						{
@@ -92379,7 +92353,7 @@
 											"type": {
 												"type": "reference",
 												"name": "DeprecationMessage",
-												"id": 3997
+												"id": 4004
 											}
 										}
 									],
@@ -92503,7 +92477,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -92517,7 +92491,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
@@ -92582,7 +92556,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Coverage.getReporterOptions",
-										"id": 1302
+										"id": 1308
 									},
 									"inheritedFrom": {
 										"type": "reference",
@@ -92601,7 +92575,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.getReporterOptions",
-								"id": 1302
+								"id": 1308
 							},
 							"inheritedFrom": {
 								"type": "reference",
@@ -92701,7 +92675,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Coverage.runEnd",
-										"id": 1311
+										"id": 1317
 									}
 								}
 							],
@@ -92715,7 +92689,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.runEnd",
-								"id": 1311
+								"id": 1317
 							}
 						},
 						{
@@ -92814,7 +92788,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -92871,7 +92845,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -92928,7 +92902,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Test",
-												"id": 3317
+												"id": 3324
 											}
 										}
 									],
@@ -92985,7 +92959,7 @@
 											"type": {
 												"type": "reference",
 												"name": "TunnelMessage",
-												"id": 3252
+												"id": 3259
 											}
 										}
 									],
@@ -93042,7 +93016,7 @@
 											"type": {
 												"type": "reference",
 												"name": "TunnelMessage",
-												"id": 3252
+												"id": 3259
 											}
 										}
 									],
@@ -93099,7 +93073,7 @@
 											"type": {
 												"type": "reference",
 												"name": "TunnelMessage",
-												"id": 3252
+												"id": 3259
 											}
 										}
 									],
@@ -93266,12 +93240,12 @@
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						},
 						{
 							"type": "reference",
 							"name": "CoverageProperties",
-							"id": 1335
+							"id": 1292
 						},
 						{
 							"type": "reference",
@@ -93318,7 +93292,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
@@ -93332,12 +93306,12 @@
 								"isOptional": true
 							},
 							"comment": {
-								"shortText": "A direcotry to write coverage data to"
+								"shortText": "A directory provided to the coverage reporter"
 							},
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 79,
+									"line": 18,
 									"character": 11
 								}
 							],
@@ -93357,7 +93331,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.directory",
-								"id": 1337
+								"id": 1294
 							}
 						},
 						{
@@ -93371,12 +93345,12 @@
 								"isOptional": true
 							},
 							"comment": {
-								"shortText": "A filename to write coverage data to"
+								"shortText": "A filename provided to the coverage reporter"
 							},
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 76,
+									"line": 15,
 									"character": 10
 								}
 							],
@@ -93396,7 +93370,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.filename",
-								"id": 1336
+								"id": 1293
 							}
 						},
 						{
@@ -93520,12 +93494,12 @@
 							"type": {
 								"type": "reference",
 								"name": "ReporterOutput",
-								"id": 4076
+								"id": 4083
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						},
 						{
@@ -93544,7 +93518,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 82,
+									"line": 21,
 									"character": 12
 								}
 							],
@@ -93555,7 +93529,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.watermarks",
-								"id": 1338
+								"id": 1295
 							}
 						}
 					],
@@ -93730,7 +93704,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Node",
-												"id": 2600
+												"id": 2607
 											}
 										},
 										{
@@ -93755,7 +93729,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Coverage.__constructor",
-										"id": 1298
+										"id": 1304
 									},
 									"inheritedFrom": {
 										"type": "reference",
@@ -93774,7 +93748,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.__constructor",
-								"id": 1298
+								"id": 1304
 							},
 							"inheritedFrom": {
 								"type": "reference",
@@ -93815,7 +93789,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
@@ -93893,7 +93867,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
@@ -93919,7 +93893,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -93930,7 +93904,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
@@ -93969,7 +93943,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
@@ -93995,7 +93969,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -94006,7 +93980,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
@@ -94022,7 +93996,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 21,
+									"line": 34,
 									"character": 11
 								}
 							],
@@ -94042,7 +94016,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.directory",
-								"id": 1296
+								"id": 1302
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -94062,24 +94036,24 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 18,
+									"line": 31,
 									"character": 19
 								}
 							],
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							},
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.executor",
-								"id": 1294
+								"id": 1300
 							}
 						},
 						{
@@ -94095,7 +94069,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 20,
+									"line": 33,
 									"character": 10
 								}
 							],
@@ -94115,7 +94089,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.filename",
-								"id": 1295
+								"id": 1301
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -94187,7 +94161,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.reportType",
-								"id": 1293
+								"id": 1299
 							},
 							"inheritedFrom": {
 								"type": "reference",
@@ -94208,7 +94182,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 22,
+									"line": 35,
 									"character": 12
 								}
 							],
@@ -94219,7 +94193,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.watermarks",
-								"id": 1297
+								"id": 1303
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -94250,7 +94224,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -94281,7 +94255,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -94300,7 +94274,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -94327,12 +94301,12 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -94353,7 +94327,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -94364,7 +94338,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -94383,7 +94357,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -94418,7 +94392,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -94432,7 +94406,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
@@ -94491,21 +94465,21 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.createCoverageReport",
-										"id": 1307
+										"id": 1313
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 44,
+									"line": 61,
 									"character": 22
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.createCoverageReport",
-								"id": 1307
+								"id": 1313
 							}
 						},
 						{
@@ -94614,7 +94588,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -94628,7 +94602,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
@@ -94693,7 +94667,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Coverage.getReporterOptions",
-										"id": 1302
+										"id": 1308
 									},
 									"inheritedFrom": {
 										"type": "reference",
@@ -94712,7 +94686,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.getReporterOptions",
-								"id": 1302
+								"id": 1308
 							},
 							"inheritedFrom": {
 								"type": "reference",
@@ -94812,21 +94786,21 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.runEnd",
-										"id": 1311
+										"id": 1317
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 66,
+									"line": 84,
 									"character": 8
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.runEnd",
-								"id": 1311
+								"id": 1317
 							}
 						},
 						{
@@ -94868,7 +94842,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -94925,7 +94899,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Test",
-												"id": 3317
+												"id": 3324
 											}
 										}
 									],
@@ -95011,12 +94985,12 @@
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						},
 						{
 							"type": "reference",
 							"name": "CoverageProperties",
-							"id": 1335
+							"id": 1292
 						},
 						{
 							"type": "reference",
@@ -95044,7 +95018,7 @@
 			]
 		},
 		{
-			"id": 2549,
+			"id": 2556,
 			"name": "\"lib/reporters/TeamCity\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -95055,7 +95029,7 @@
 			"originalName": "src/lib/reporters/TeamCity.ts",
 			"children": [
 				{
-					"id": 2550,
+					"id": 2557,
 					"name": "TeamCity",
 					"kind": 128,
 					"kindString": "Class",
@@ -95069,7 +95043,7 @@
 					},
 					"children": [
 						{
-							"id": 2581,
+							"id": 2588,
 							"name": "constructor",
 							"kind": 512,
 							"kindString": "Constructor",
@@ -95079,14 +95053,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2582,
+									"id": 2589,
 									"name": "new TeamCity",
 									"kind": 16384,
 									"kindString": "Constructor signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2583,
+											"id": 2590,
 											"name": "executor",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -95094,11 +95068,11 @@
 											"type": {
 												"type": "reference",
 												"name": "Executor",
-												"id": 3780
+												"id": 3787
 											}
 										},
 										{
-											"id": 2584,
+											"id": 2591,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -95106,7 +95080,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOptions",
-												"id": 4092
+												"id": 4099
 											},
 											"defaultValue": " {}"
 										}
@@ -95114,12 +95088,12 @@
 									"type": {
 										"type": "reference",
 										"name": "TeamCity",
-										"id": 2550
+										"id": 2557
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.__constructor",
-										"id": 4055
+										"id": 4062
 									}
 								}
 							],
@@ -95133,11 +95107,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.__constructor",
-								"id": 4055
+								"id": 4062
 							}
 						},
 						{
-							"id": 2573,
+							"id": 2580,
 							"name": "_console",
 							"kind": 1024,
 							"kindString": "Property",
@@ -95169,11 +95143,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
-							"id": 2577,
+							"id": 2584,
 							"name": "_eventHandlers",
 							"kind": 1024,
 							"kindString": "Property",
@@ -95198,21 +95172,21 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 2578,
+											"id": 2585,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 2579,
+													"id": 2586,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 2580,
+															"id": 2587,
 															"name": "eventName",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -95247,11 +95221,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
-							"id": 2574,
+							"id": 2581,
 							"name": "_executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -95273,7 +95247,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -95284,11 +95258,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
-							"id": 2575,
+							"id": 2582,
 							"name": "_handles",
 							"kind": 1024,
 							"kindString": "Property",
@@ -95323,11 +95297,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
-							"id": 2551,
+							"id": 2558,
 							"name": "_ignoredTestIds",
 							"kind": 1024,
 							"kindString": "Property",
@@ -95348,21 +95322,21 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 2552,
+											"id": 2559,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": [
 												{
-													"id": 2553,
+													"id": 2560,
 													"name": "__index",
 													"kind": 8192,
 													"kindString": "Index signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 2554,
+															"id": 2561,
 															"name": "sessionId",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -95376,21 +95350,21 @@
 													"type": {
 														"type": "reflection",
 														"declaration": {
-															"id": 2555,
+															"id": 2562,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"indexSignature": [
 																{
-																	"id": 2556,
+																	"id": 2563,
 																	"name": "__index",
 																	"kind": 8192,
 																	"kindString": "Index signature",
 																	"flags": {},
 																	"parameters": [
 																		{
-																			"id": 2557,
+																			"id": 2564,
 																			"name": "testId",
 																			"kind": 32768,
 																			"kindString": "Parameter",
@@ -95435,7 +95409,7 @@
 							}
 						},
 						{
-							"id": 2576,
+							"id": 2583,
 							"name": "_output",
 							"kind": 1024,
 							"kindString": "Property",
@@ -95457,7 +95431,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -95468,11 +95442,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
-							"id": 2572,
+							"id": 2579,
 							"name": "executor",
 							"kind": 1024,
 							"kindString": "Property",
@@ -95490,16 +95464,16 @@
 							"type": {
 								"type": "reference",
 								"name": "Executor",
-								"id": 3780
+								"id": 3787
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							}
 						},
 						{
-							"id": 2585,
+							"id": 2592,
 							"name": "console",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -95509,7 +95483,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2586,
+									"id": 2593,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -95521,20 +95495,20 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 2587,
+									"id": 2594,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2588,
+											"id": 2595,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -95552,7 +95526,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -95571,16 +95545,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
-							"id": 2589,
+							"id": 2596,
 							"name": "output",
 							"kind": 262144,
 							"kindString": "Accessor",
@@ -95590,7 +95564,7 @@
 							},
 							"getSignature": [
 								{
-									"id": 2590,
+									"id": 2597,
 									"name": "__get",
 									"kind": 524288,
 									"kindString": "Get signature",
@@ -95598,25 +95572,25 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
 							"setSignature": [
 								{
-									"id": 2591,
+									"id": 2598,
 									"name": "__set",
 									"kind": 1048576,
 									"kindString": "Set signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2592,
+											"id": 2599,
 											"name": "value",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -95624,7 +95598,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -95635,7 +95609,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -95654,16 +95628,16 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						},
 						{
-							"id": 2597,
+							"id": 2604,
 							"name": "_registerEventHandlers",
 							"kind": 2048,
 							"kindString": "Method",
@@ -95674,7 +95648,7 @@
 							},
 							"signatures": [
 								{
-									"id": 2598,
+									"id": 2605,
 									"name": "_registerEventHandlers",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -95689,7 +95663,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -95703,11 +95677,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
-							"id": 2593,
+							"id": 2600,
 							"name": "formatError",
 							"kind": 2048,
 							"kindString": "Method",
@@ -95717,14 +95691,14 @@
 							},
 							"signatures": [
 								{
-									"id": 2594,
+									"id": 2601,
 									"name": "formatError",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2595,
+											"id": 2602,
 											"name": "error",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -95735,7 +95709,7 @@
 											}
 										},
 										{
-											"id": 2596,
+											"id": 2603,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -95756,7 +95730,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -95770,11 +95744,11 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
-							"id": 2558,
+							"id": 2565,
 							"name": "runStart",
 							"kind": 2048,
 							"kindString": "Method",
@@ -95797,7 +95771,7 @@
 							],
 							"signatures": [
 								{
-									"id": 2559,
+									"id": 2566,
 									"name": "runStart",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -95817,7 +95791,7 @@
 							]
 						},
 						{
-							"id": 2569,
+							"id": 2576,
 							"name": "suiteEnd",
 							"kind": 2048,
 							"kindString": "Method",
@@ -95840,14 +95814,14 @@
 							],
 							"signatures": [
 								{
-									"id": 2570,
+									"id": 2577,
 									"name": "suiteEnd",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2571,
+											"id": 2578,
 											"name": "suite",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -95855,7 +95829,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -95874,7 +95848,7 @@
 							]
 						},
 						{
-							"id": 2566,
+							"id": 2573,
 							"name": "suiteStart",
 							"kind": 2048,
 							"kindString": "Method",
@@ -95897,14 +95871,14 @@
 							],
 							"signatures": [
 								{
-									"id": 2567,
+									"id": 2574,
 									"name": "suiteStart",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2568,
+											"id": 2575,
 											"name": "suite",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -95912,7 +95886,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Suite",
-												"id": 3400
+												"id": 3407
 											}
 										}
 									],
@@ -95931,7 +95905,7 @@
 							]
 						},
 						{
-							"id": 2563,
+							"id": 2570,
 							"name": "testEnd",
 							"kind": 2048,
 							"kindString": "Method",
@@ -95954,14 +95928,14 @@
 							],
 							"signatures": [
 								{
-									"id": 2564,
+									"id": 2571,
 									"name": "testEnd",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2565,
+											"id": 2572,
 											"name": "test",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -95969,7 +95943,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Test",
-												"id": 3317
+												"id": 3324
 											}
 										}
 									],
@@ -95988,7 +95962,7 @@
 							]
 						},
 						{
-							"id": 2560,
+							"id": 2567,
 							"name": "testStart",
 							"kind": 2048,
 							"kindString": "Method",
@@ -96011,14 +95985,14 @@
 							],
 							"signatures": [
 								{
-									"id": 2561,
+									"id": 2568,
 									"name": "testStart",
 									"kind": 4096,
 									"kindString": "Call signature",
 									"flags": {},
 									"parameters": [
 										{
-											"id": 2562,
+											"id": 2569,
 											"name": "test",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -96026,7 +96000,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Test",
-												"id": 3317
+												"id": 3324
 											}
 										}
 									],
@@ -96050,41 +96024,41 @@
 							"title": "Constructors",
 							"kind": 512,
 							"children": [
-								2581
+								2588
 							]
 						},
 						{
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2573,
-								2577,
-								2574,
-								2575,
-								2551,
-								2576,
-								2572
+								2580,
+								2584,
+								2581,
+								2582,
+								2558,
+								2583,
+								2579
 							]
 						},
 						{
 							"title": "Accessors",
 							"kind": 262144,
 							"children": [
-								2585,
-								2589
+								2592,
+								2596
 							]
 						},
 						{
 							"title": "Methods",
 							"kind": 2048,
 							"children": [
-								2597,
-								2593,
-								2558,
-								2569,
-								2566,
-								2563,
-								2560
+								2604,
+								2600,
+								2565,
+								2576,
+								2573,
+								2570,
+								2567
 							]
 						}
 					],
@@ -96099,14 +96073,14 @@
 						{
 							"type": "reference",
 							"name": "Reporter",
-							"id": 4045
+							"id": 4052
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						}
 					]
 				}
@@ -96116,7 +96090,7 @@
 					"title": "Classes",
 					"kind": 128,
 					"children": [
-						2550
+						2557
 					]
 				}
 			],
@@ -96175,7 +96149,7 @@
 											"type": {
 												"type": "reference",
 												"name": "Node",
-												"id": 2600
+												"id": 2607
 											}
 										},
 										{
@@ -96200,7 +96174,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Coverage.__constructor",
-										"id": 1298
+										"id": 1304
 									}
 								}
 							],
@@ -96214,7 +96188,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.__constructor",
-								"id": 1298
+								"id": 1304
 							}
 						},
 						{
@@ -96250,7 +96224,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._console",
-								"id": 4047
+								"id": 4054
 							}
 						},
 						{
@@ -96328,7 +96302,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._eventHandlers",
-								"id": 4051
+								"id": 4058
 							}
 						},
 						{
@@ -96354,7 +96328,7 @@
 									{
 										"type": "reference",
 										"name": "Executor",
-										"id": 3780
+										"id": 3787
 									},
 									{
 										"type": "intrinsic",
@@ -96365,7 +96339,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._executor",
-								"id": 4048
+								"id": 4055
 							}
 						},
 						{
@@ -96404,7 +96378,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._handles",
-								"id": 4049
+								"id": 4056
 							}
 						},
 						{
@@ -96430,7 +96404,7 @@
 									{
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									{
 										"type": "intrinsic",
@@ -96441,7 +96415,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._output",
-								"id": 4050
+								"id": 4057
 							}
 						},
 						{
@@ -96457,7 +96431,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 21,
+									"line": 34,
 									"character": 11
 								}
 							],
@@ -96477,7 +96451,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.directory",
-								"id": 1296
+								"id": 1302
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -96497,24 +96471,24 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 18,
+									"line": 31,
 									"character": 19
 								}
 							],
 							"type": {
 								"type": "reference",
 								"name": "Node",
-								"id": 2600
+								"id": 2607
 							},
 							"overwrites": {
 								"type": "reference",
 								"name": "Reporter.executor",
-								"id": 4046
+								"id": 4053
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.executor",
-								"id": 1294
+								"id": 1300
 							}
 						},
 						{
@@ -96530,7 +96504,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 20,
+									"line": 33,
 									"character": 10
 								}
 							],
@@ -96550,7 +96524,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.filename",
-								"id": 1295
+								"id": 1301
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -96617,7 +96591,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.reportType",
-								"id": 1293
+								"id": 1299
 							}
 						},
 						{
@@ -96633,7 +96607,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 22,
+									"line": 35,
 									"character": 12
 								}
 							],
@@ -96644,7 +96618,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.watermarks",
-								"id": 1297
+								"id": 1303
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -96675,7 +96649,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -96706,7 +96680,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.console",
-										"id": 4059
+										"id": 4066
 									}
 								}
 							],
@@ -96725,7 +96699,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.console",
-								"id": 4059
+								"id": 4066
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -96752,12 +96726,12 @@
 									"type": {
 										"type": "reference",
 										"name": "ReporterOutput",
-										"id": 4076
+										"id": 4083
 									},
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -96778,7 +96752,7 @@
 											"type": {
 												"type": "reference",
 												"name": "ReporterOutput",
-												"id": 4076
+												"id": 4083
 											}
 										}
 									],
@@ -96789,7 +96763,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.output",
-										"id": 4063
+										"id": 4070
 									}
 								}
 							],
@@ -96808,7 +96782,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.output",
-								"id": 4063
+								"id": 4070
 							},
 							"implementationOf": {
 								"type": "reference",
@@ -96843,7 +96817,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter._registerEventHandlers",
-										"id": 4071
+										"id": 4078
 									}
 								}
 							],
@@ -96857,7 +96831,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter._registerEventHandlers",
-								"id": 4071
+								"id": 4078
 							}
 						},
 						{
@@ -96916,21 +96890,21 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.createCoverageReport",
-										"id": 1307
+										"id": 1313
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 44,
+									"line": 61,
 									"character": 22
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.createCoverageReport",
-								"id": 1307
+								"id": 1313
 							}
 						},
 						{
@@ -96983,7 +96957,7 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Reporter.formatError",
-										"id": 4067
+										"id": 4074
 									}
 								}
 							],
@@ -96997,7 +96971,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Reporter.formatError",
-								"id": 4067
+								"id": 4074
 							}
 						},
 						{
@@ -97062,7 +97036,7 @@
 									"overwrites": {
 										"type": "reference",
 										"name": "Coverage.getReporterOptions",
-										"id": 1302
+										"id": 1308
 									}
 								}
 							],
@@ -97076,7 +97050,7 @@
 							"overwrites": {
 								"type": "reference",
 								"name": "Coverage.getReporterOptions",
-								"id": 1302
+								"id": 1308
 							}
 						},
 						{
@@ -97115,21 +97089,21 @@
 									"inheritedFrom": {
 										"type": "reference",
 										"name": "Coverage.runEnd",
-										"id": 1311
+										"id": 1317
 									}
 								}
 							],
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 66,
+									"line": 84,
 									"character": 8
 								}
 							],
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "Coverage.runEnd",
-								"id": 1311
+								"id": 1317
 							}
 						}
 					],
@@ -97189,7 +97163,7 @@
 						{
 							"type": "reference",
 							"name": "Coverage",
-							"id": 1292
+							"id": 1298
 						}
 					],
 					"extendedBy": [
@@ -97213,12 +97187,12 @@
 						{
 							"type": "reference",
 							"name": "ReporterProperties",
-							"id": 4073
+							"id": 4080
 						},
 						{
 							"type": "reference",
 							"name": "CoverageProperties",
-							"id": 1335
+							"id": 1292
 						},
 						{
 							"type": "reference",
@@ -97260,7 +97234,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.console",
-								"id": 4075
+								"id": 4082
 							}
 						},
 						{
@@ -97274,12 +97248,12 @@
 								"isOptional": true
 							},
 							"comment": {
-								"shortText": "A direcotry to write coverage data to"
+								"shortText": "A directory provided to the coverage reporter"
 							},
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 79,
+									"line": 18,
 									"character": 11
 								}
 							],
@@ -97299,7 +97273,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.directory",
-								"id": 1337
+								"id": 1294
 							}
 						},
 						{
@@ -97313,12 +97287,12 @@
 								"isOptional": true
 							},
 							"comment": {
-								"shortText": "A filename to write coverage data to"
+								"shortText": "A filename provided to the coverage reporter"
 							},
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 76,
+									"line": 15,
 									"character": 10
 								}
 							],
@@ -97338,7 +97312,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.filename",
-								"id": 1336
+								"id": 1293
 							}
 						},
 						{
@@ -97394,12 +97368,12 @@
 							"type": {
 								"type": "reference",
 								"name": "ReporterOutput",
-								"id": 4076
+								"id": 4083
 							},
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "ReporterProperties.output",
-								"id": 4074
+								"id": 4081
 							}
 						},
 						{
@@ -97418,7 +97392,7 @@
 							"sources": [
 								{
 									"fileName": "lib/reporters/Coverage.ts",
-									"line": 82,
+									"line": 21,
 									"character": 12
 								}
 							],
@@ -97429,7 +97403,7 @@
 							"inheritedFrom": {
 								"type": "reference",
 								"name": "CoverageProperties.watermarks",
-								"id": 1338
+								"id": 1295
 							}
 						}
 					],
@@ -97458,7 +97432,7 @@
 						{
 							"type": "reference",
 							"name": "CoverageProperties",
-							"id": 1335
+							"id": 1292
 						}
 					],
 					"extendedBy": [
@@ -97723,6 +97697,146 @@
 			"sources": [
 				{
 					"fileName": "lib/reporters/html/icons.ts",
+					"line": 1,
+					"character": 0
+				}
+			]
+		},
+		{
+			"id": 1720,
+			"name": "\"lib/reporters/util/getPath\"",
+			"kind": 1,
+			"kindString": "External module",
+			"flags": {
+				"isExported": true,
+				"isExternal": true
+			},
+			"originalName": "src/lib/reporters/util/getPath.ts",
+			"children": [
+				{
+					"id": 1721,
+					"name": "getPath",
+					"kind": 64,
+					"kindString": "Function",
+					"flags": {
+						"isExported": true,
+						"isExternal": true
+					},
+					"signatures": [
+						{
+							"id": 1722,
+							"name": "getPath",
+							"kind": 4096,
+							"kindString": "Call signature",
+							"flags": {},
+							"comment": {
+								"shortText": "This method helps to normalize the rules surrounding LEGACY reporters.",
+								"text": "DO NOT use this method when writing new Reporters. New reporters should ALWAYS require a directory\nand if needed an optional filename. If the filename is not provided, but necessary, then a default\nshould be assigned by the reporter.\n\ngetPath() normalizes legacy Reporters following these rules:\n\n1. If a directory exists:\n1a. and a filename exists; return the joined directory and filename\n1b. and a default filename exists; return the joined directory and default filename\n1c. return just the directory\n2. If a filename exists; return just the filename as a full path\n3. If no conditions are met, return undefined\n\nThe defaultFilename exists as a separate parameter so it is only used when a directory exists.\n"
+							},
+							"parameters": [
+								{
+									"id": 1723,
+									"name": "directory",
+									"kind": 32768,
+									"kindString": "Parameter",
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											},
+											{
+												"type": "intrinsic",
+												"name": "string"
+											}
+										]
+									}
+								},
+								{
+									"id": 1724,
+									"name": "filename",
+									"kind": 32768,
+									"kindString": "Parameter",
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											},
+											{
+												"type": "intrinsic",
+												"name": "string"
+											}
+										]
+									}
+								},
+								{
+									"id": 1725,
+									"name": "defaultFilename",
+									"kind": 32768,
+									"kindString": "Parameter",
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											},
+											{
+												"type": "intrinsic",
+												"name": "string"
+											}
+										]
+									}
+								}
+							],
+							"type": {
+								"type": "union",
+								"types": [
+									{
+										"type": "intrinsic",
+										"name": "undefined"
+									},
+									{
+										"type": "intrinsic",
+										"name": "string"
+									}
+								]
+							}
+						}
+					],
+					"sources": [
+						{
+							"fileName": "lib/reporters/util/getPath.ts",
+							"line": 21,
+							"character": 23
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Functions",
+					"kind": 64,
+					"children": [
+						1721
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "lib/reporters/util/getPath.ts",
 					"line": 1,
 					"character": 0
 				}
@@ -98866,7 +98980,7 @@
 							"type": {
 								"type": "reference",
 								"name": "LifecycleMethod",
-								"id": 3502
+								"id": 3509
 							}
 						},
 						{
@@ -98928,7 +99042,7 @@
 							"type": {
 								"type": "reference",
 								"name": "Test",
-								"id": 3317
+								"id": 3324
 							}
 						},
 						{
@@ -99110,7 +99224,7 @@
 			]
 		},
 		{
-			"id": 4351,
+			"id": 4355,
 			"name": "\"loaders/default\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -99127,7 +99241,7 @@
 			]
 		},
 		{
-			"id": 4352,
+			"id": 4356,
 			"name": "\"loaders/dojo\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -99144,7 +99258,7 @@
 			]
 		},
 		{
-			"id": 4353,
+			"id": 4357,
 			"name": "\"loaders/dojo2\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -99161,7 +99275,7 @@
 			]
 		},
 		{
-			"id": 4354,
+			"id": 4358,
 			"name": "\"loaders/esm\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -99178,7 +99292,7 @@
 			]
 		},
 		{
-			"id": 4355,
+			"id": 4359,
 			"name": "\"loaders/systemjs\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -99195,7 +99309,7 @@
 			]
 		},
 		{
-			"id": 4356,
+			"id": 4360,
 			"name": "\"tasks/intern\"",
 			"kind": 1,
 			"kindString": "External module",
@@ -99205,21 +99319,21 @@
 			"originalName": "src/tasks/intern.ts",
 			"children": [
 				{
-					"id": 4357,
+					"id": 4361,
 					"name": "TaskOptions",
 					"kind": 256,
 					"kindString": "Interface",
 					"flags": {},
 					"indexSignature": [
 						{
-							"id": 4358,
+							"id": 4362,
 							"name": "__index",
 							"kind": 8192,
 							"kindString": "Index signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 4359,
+									"id": 4363,
 									"name": "key",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -99238,7 +99352,7 @@
 					],
 					"children": [
 						{
-							"id": 4361,
+							"id": 4365,
 							"name": "files",
 							"kind": 1024,
 							"kindString": "Property",
@@ -99262,7 +99376,7 @@
 							}
 						},
 						{
-							"id": 4360,
+							"id": 4364,
 							"name": "options",
 							"kind": 1024,
 							"kindString": "Property",
@@ -99291,8 +99405,8 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								4361,
-								4360
+								4365,
+								4364
 							]
 						}
 					],
@@ -99311,7 +99425,7 @@
 						{
 							"type": "reflection",
 							"declaration": {
-								"id": 4362,
+								"id": 4366,
 								"name": "__type",
 								"kind": 65536,
 								"kindString": "Type literal",
@@ -99328,21 +99442,21 @@
 					]
 				},
 				{
-					"id": 4363,
+					"id": 4367,
 					"name": "getConfigAndOptions",
 					"kind": 64,
 					"kindString": "Function",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 4364,
+							"id": 4368,
 							"name": "getConfigAndOptions",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 4365,
+									"id": 4369,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -99350,7 +99464,7 @@
 									"type": {
 										"type": "reference",
 										"name": "TaskOptions",
-										"id": 4357
+										"id": 4361
 									}
 								}
 							],
@@ -99361,14 +99475,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 4366,
+											"id": 4370,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 4367,
+													"id": 4371,
 													"name": "config",
 													"kind": 32,
 													"kindString": "Variable",
@@ -99387,13 +99501,13 @@
 															{
 																"type": "reference",
 																"name": "Config",
-																"id": 4098
+																"id": 4105
 															}
 														]
 													}
 												},
 												{
-													"id": 4368,
+													"id": 4372,
 													"name": "options",
 													"kind": 32,
 													"kindString": "Variable",
@@ -99408,7 +99522,7 @@
 													"type": {
 														"type": "reference",
 														"name": "TaskOptions",
-														"id": 4357
+														"id": 4361
 													}
 												}
 											],
@@ -99417,8 +99531,8 @@
 													"title": "Variables",
 													"kind": 32,
 													"children": [
-														4367,
-														4368
+														4371,
+														4372
 													]
 												}
 											],
@@ -99449,14 +99563,14 @@
 					"title": "Interfaces",
 					"kind": 256,
 					"children": [
-						4357
+						4361
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						4363
+						4367
 					]
 				}
 			],
@@ -99474,34 +99588,34 @@
 			"title": "External modules",
 			"kind": 1,
 			"children": [
+				4350,
 				4346,
-				4342,
-				3652,
-				1983,
-				4445,
+				3659,
+				1990,
+				4449,
 				2,
 				529,
 				125,
 				1030,
 				1237,
-				3399,
-				3316,
+				3406,
+				3323,
 				617,
 				1185,
-				4407,
-				4369,
+				4411,
+				4373,
 				51,
-				4097,
+				4104,
 				607,
 				34,
-				4193,
+				4200,
 				862,
-				3779,
-				2599,
-				3627,
-				3742,
-				3503,
-				3550,
+				3786,
+				2606,
+				3634,
+				3749,
+				3510,
+				3557,
 				1231,
 				1220,
 				1213,
@@ -99510,32 +99624,33 @@
 				1217,
 				90,
 				1,
-				4300,
-				2443,
-				1789,
+				4304,
+				2450,
+				1796,
 				821,
 				1291,
 				768,
 				660,
-				1886,
-				1720,
-				1842,
-				1939,
+				1893,
+				1726,
+				1849,
+				1946,
 				1399,
-				4044,
+				4051,
 				1554,
 				1663,
-				2549,
+				2556,
 				1346,
 				653,
+				1720,
 				547,
 				22,
-				4351,
-				4352,
-				4353,
-				4354,
 				4355,
-				4356
+				4356,
+				4357,
+				4358,
+				4359,
+				4360
 			]
 		}
 	]

--- a/intern.json
+++ b/intern.json
@@ -31,7 +31,9 @@
       "_tests/tests/unit/bin/intern.js",
       "_tests/tests/unit/lib/executors/Node.js",
       "_tests/tests/unit/lib/node/**/*.js",
-      "_tests/tests/unit/tasks/**/*.js"
+      "_tests/tests/unit/tasks/**/*.js",
+      "_tests/tests/unit/lib/reporters/util/*.js",
+      "_tests/tests/unit/lib/reporters/JUnit.js"
     ],
     "plugins": [
       "_tests/tests/support/nodeMocking.js",

--- a/src/lib/reporters/Coverage.ts
+++ b/src/lib/reporters/Coverage.ts
@@ -10,6 +10,19 @@ import Node, { NodeEvents } from '../executors/Node';
 
 export { ReportType };
 
+export interface CoverageProperties extends ReporterProperties {
+  /** A filename provided to the coverage reporter */
+  filename?: string;
+
+  /** A directory provided to the coverage reporter */
+  directory?: string;
+
+  /** Watermarks used to check coverage */
+  watermarks?: Watermarks;
+}
+
+export type CoverageOptions = Partial<CoverageProperties>;
+
 const eventHandler = createEventHandler<NodeEvents>();
 
 export default abstract class Coverage extends Reporter
@@ -35,6 +48,10 @@ export default abstract class Coverage extends Reporter
     }
   }
 
+  /**
+   * This is a bag of data provided to the selected istanbul reporter (defined by `reportType`).
+   * by default this provides a filename (if present), though not all reporters use a filename.
+   */
   getReporterOptions(): { [key: string]: any } {
     return {
       file: this.filename
@@ -52,6 +69,7 @@ export default abstract class Coverage extends Reporter
 
     const transformed = this.executor.sourceMapStore.transformCoverage(map);
 
+    // context is a bag of data used by the report. Values will not necessarily be used (it depends on the specific reporter)
     const context = createContext({
       dir: this.directory,
       sourceFinder: transformed.sourceFinder,
@@ -70,19 +88,6 @@ export default abstract class Coverage extends Reporter
     }
   }
 }
-
-export interface CoverageProperties extends ReporterProperties {
-  /** A filename to write coverage data to */
-  filename?: string;
-
-  /** A direcotry to write coverage data to */
-  directory?: string;
-
-  /** Watermarks used to check coverage */
-  watermarks?: Watermarks;
-}
-
-export type CoverageOptions = Partial<CoverageProperties>;
 
 function isCoverageMap(value: any): value is CoverageMap {
   return value != null && typeof value.files === 'function';

--- a/src/lib/reporters/JUnit.ts
+++ b/src/lib/reporters/JUnit.ts
@@ -1,11 +1,17 @@
 import { createWriteStream } from 'fs';
 import { dirname } from 'path';
 
+import { Executor } from '../executors/Executor';
+import { mkdirp } from '../node/util';
 import Suite, { isSuite } from '../Suite';
 import Test from '../Test';
 import Reporter, { eventHandler, ReporterProperties } from './Reporter';
-import { Executor } from '../executors/Executor';
-import { mkdirp } from '../node/util';
+import { getPath } from './util/getPath';
+
+export interface JUnitProperties extends ReporterProperties {
+  directory: string;
+  filename?: string;
+}
 
 /**
  * There is no formal spec for this format and everyone does it differently, so
@@ -17,8 +23,9 @@ export default class JUnit extends Reporter {
 
   constructor(executor: Executor, options: Partial<JUnitProperties> = {}) {
     super(executor, options);
-    if (options.filename) {
-      this.filename = options.filename;
+    const path = getPath(options.directory, options.filename, 'junit.xml');
+    if (path) {
+      this.filename = path;
       if (dirname(this.filename) !== '.') {
         mkdirp(dirname(this.filename));
       }
@@ -36,10 +43,6 @@ export default class JUnit extends Reporter {
       '<?xml version="1.0" encoding="UTF-8" ?>' + rootNode.toString() + '\n';
     this.output.end(report);
   }
-}
-
-export interface JUnitProperties extends ReporterProperties {
-  filename?: string;
 }
 
 /**

--- a/src/lib/reporters/util/getPath.ts
+++ b/src/lib/reporters/util/getPath.ts
@@ -1,0 +1,37 @@
+import { join } from 'path';
+
+/**
+ * This method helps to normalize the rules surrounding LEGACY reporters.
+ *
+ * DO NOT use this method when writing new Reporters. New reporters should ALWAYS require a directory
+ * and if needed an optional filename. If the filename is not provided, but necessary, then a default
+ * should be assigned by the reporter.
+ *
+ * getPath() normalizes legacy Reporters following these rules:
+ *
+ * 1. If a directory exists:
+ * 1a. and a filename exists; return the joined directory and filename
+ * 1b. and a default filename exists; return the joined directory and default filename
+ * 1c. return just the directory
+ * 2. If a filename exists; return just the filename as a full path
+ * 3. If no conditions are met, return undefined
+ *
+ * The defaultFilename exists as a separate parameter so it is only used when a directory exists.
+ */
+export function getPath(
+  directory?: string,
+  filename?: string,
+  defaultFilename?: string
+) {
+  if (directory) {
+    if (filename) {
+      return join(directory, filename);
+    } else if (defaultFilename) {
+      return join(directory, defaultFilename);
+    }
+
+    return directory;
+  } else if (filename) {
+    return filename;
+  }
+}

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -40,6 +40,7 @@
     "./unit/lib/reporters/Simple.ts",
     "./unit/lib/reporters/TeamCity.ts",
     "./unit/lib/reporters/TextCoverage.ts",
+    "./unit/lib/reporters/util/getPath.ts",
     "./unit/lib/*.ts",
     "./unit/loaders/*.ts",
     "./unit/tasks/*.ts",

--- a/tests/unit/lib/reporters/JUnit.ts
+++ b/tests/unit/lib/reporters/JUnit.ts
@@ -1,6 +1,5 @@
 import { spy, stub } from 'sinon';
 
-import _JUnit from 'src/lib/reporters/JUnit';
 import Test from 'src/lib/Test';
 import Suite from 'src/lib/Suite';
 
@@ -21,7 +20,7 @@ registerSuite('lib/reporters/JUnit', function() {
     mkdirSync: spy()
   };
 
-  let JUnit: typeof _JUnit;
+  let JUnit: typeof import('src/lib/reporters/JUnit').default;
   let removeMocks: () => void;
 
   const getReportOutput = () => {

--- a/tests/unit/lib/reporters/util/getPath.ts
+++ b/tests/unit/lib/reporters/util/getPath.ts
@@ -1,0 +1,35 @@
+import { getPath } from 'src/lib/reporters/util/getPath';
+import { join } from 'path';
+
+const DIR = 'directory';
+const FILE = 'file.name';
+
+registerSuite('lib/reporters/util/getPath', {
+  tests: {
+    'getPath()': {
+      'no parameters; returns undefined'() {
+        assert.isUndefined(getPath());
+      },
+
+      'directory only; returns directory'() {
+        assert.strictEqual(getPath(DIR), DIR);
+      },
+
+      'directory and filename; returns joined path'() {
+        assert.strictEqual(getPath(DIR, FILE), join(DIR, FILE));
+      },
+
+      'directory and defaultFilename; returns joined path'() {
+        assert.strictEqual(getPath(DIR, undefined, FILE), join(DIR, FILE));
+      },
+
+      'filename only; returns filename'() {
+        assert.strictEqual(getPath(undefined, FILE), FILE);
+      },
+
+      'defaultFilename only; returns undefined'() {
+        assert.isUndefined(getPath(undefined, undefined, FILE));
+      }
+    }
+  }
+});


### PR DESCRIPTION
Added `getPath`, which handles the progressive fallback of directory/filename options.

I also included comments in `Coverage` that includes my findings on how it uses `filename` and `directory` as a base class (throws them in bags and hands them off to the Istanbul reporters).

The functionality here is done, but perhaps it could use some cleanup since the work has been isolated to JUnit (due to the above discoveries)

Resolves #985