### PR TITLE
Disable existing stylesheets in Html reporter

### DIFF
--- a/src/lib/reporters/Html.ts
+++ b/src/lib/reporters/Html.ts
@@ -473,6 +473,10 @@ export default class Html extends Reporter implements HtmlProperties {
     if (!suite.hasParent) {
       this._generateSummary(suite);
 
+      for (let i = 0; i < document.styleSheets.length; i++) {
+        document.styleSheets[i].disabled = true;
+      }
+
       // Load styles via webpack
       require('./html/html.styl');
 
@@ -530,8 +534,8 @@ export default class Html extends Reporter implements HtmlProperties {
     const rowStatus = allTestsSkipped
       ? 'skipped'
       : numFailedTests > 0 || hasSuiteFailures
-        ? 'failed'
-        : 'passed';
+      ? 'failed'
+      : 'passed';
 
     // Mark a suite as failed if any of its child tests failed, and
     addClass(rowNode, rowStatus);

--- a/tests/unit/lib/reporters/Html.ts
+++ b/tests/unit/lib/reporters/Html.ts
@@ -136,6 +136,8 @@ registerSuite('intern/lib/reporters/Html', {
         reporter.runStart();
         reporter.suiteEnd(suite);
 
+        // TODO: add check that existing stylesheets are disabled
+
         const header = doc.body.getElementsByTagName('h1')[0];
         assert.isDefined(header, 'expected header element to exist');
         assert.equal(header.textContent, 'Intern Test Report');


### PR DESCRIPTION
The Html reporter needs some css rules to properly show the overview.
The css rules of the executed test cases also add styling to the browser, which can interfere with the way the overview is rendered. E.g. this can cause scrolling to be disabled.
This PR disables the existing stylesheets to make sure that only the proper css rules are applied.