### PR TITLE
Serialize Executor events

### DIFF
--- a/src/lib/executors/Executor.ts
+++ b/src/lib/executors/Executor.ts
@@ -302,7 +302,7 @@ export default abstract class BaseExecutor<
       'coverage',
       'error',
       'log'
-    ].includes(eventName);
+    ].includes(<string>eventName);
     let notifications = needsSeparateNotificationChain
       ? Task.resolve()
       : this._notifications;

--- a/src/lib/executors/Executor.ts
+++ b/src/lib/executors/Executor.ts
@@ -286,15 +286,6 @@ export default abstract class BaseExecutor<
       }
     };
 
-    const needsSeparateNotificationChain = [
-      'coverage',
-      'error',
-      'log'
-    ].includes(eventName);
-    const notifications = needsSeparateNotificationChain
-      ? Task.resolve()
-      : this._notifications;
-
     let error: InternError | undefined;
     if (eventName === 'error') {
       error = <any>data;
@@ -307,6 +298,14 @@ export default abstract class BaseExecutor<
       }
     };
 
+    const needsSeparateNotificationChain = [
+      'coverage',
+      'error',
+      'log'
+    ].includes(eventName);
+    let notifications = needsSeparateNotificationChain
+      ? Task.resolve()
+      : this._notifications;
     let hasNotifications = false;
 
     // First, notify the listeners specifically listening for this event

--- a/src/lib/executors/Executor.ts
+++ b/src/lib/executors/Executor.ts
@@ -303,6 +303,7 @@ export default abstract class BaseExecutor<
       'error',
       'log'
     ].includes(<string>eventName);
+
     let notifications = needsSeparateNotificationChain
       ? Task.resolve()
       : this._notifications;

--- a/src/lib/executors/Executor.ts
+++ b/src/lib/executors/Executor.ts
@@ -298,11 +298,8 @@ export default abstract class BaseExecutor<
       }
     };
 
-    const needsSeparateNotificationChain = [
-      'coverage',
-      'error',
-      'log'
-    ].includes(<string>eventName);
+    const needsSeparateNotificationChain =
+      ['coverage', 'error', 'log'].indexOf(<string>eventName) > -1;
 
     let notifications = needsSeparateNotificationChain
       ? Task.resolve()


### PR DESCRIPTION
Individual calls to `emit(<event>)` currently start a new asynchronous promise chain. In the [intern-cucumber](https://github.com/rhpijnacker/intern-cucumber) plugin, this causes overlapping handling of the events, since the `suiteEnd` handling is not yet finished before the new `suiteStart` event is triggered.
This problem is easily fixed by chaining this `suiteStart` event at the end of the `suiteEnd` chain.