### PR TITLE
Updates warning log in object to use executor.emit()

### DIFF
--- a/src/core/lib/interfaces/object.ts
+++ b/src/core/lib/interfaces/object.ts
@@ -162,7 +162,7 @@ export function createSuite<S extends typeof Suite, T extends typeof Test>(
         name === 'afterEach'
       ) {
         parent.executor.emit('warning',
-          `Warning: created test with lifecycle method name "${name}"`
+          `Created test with lifecycle method name "${name}"`
         );
       }
 

--- a/src/core/lib/interfaces/object.ts
+++ b/src/core/lib/interfaces/object.ts
@@ -161,7 +161,7 @@ export function createSuite<S extends typeof Suite, T extends typeof Test>(
         name === 'beforeEach' ||
         name === 'afterEach'
       ) {
-        parent.executor.log(
+        parent.executor.emit('warning',
           `Warning: created test with lifecycle method name "${name}"`
         );
       }

--- a/tests/unit/core/lib/interfaces/object.ts
+++ b/tests/unit/core/lib/interfaces/object.ts
@@ -223,7 +223,7 @@ registerSuite('core/lib/interfaces/object', function() {
           assert.equal(executor.emit.args[0][0], 'warning');
           assert.match(
             executor.emit.args[0][1],
-            /created test with lifecycle method name/,
+            /Created test with lifecycle method name/,
             'expected log message to mention test name'
           );
         },

--- a/tests/unit/core/lib/interfaces/object.ts
+++ b/tests/unit/core/lib/interfaces/object.ts
@@ -218,13 +218,11 @@ registerSuite('core/lib/interfaces/object', function() {
             Suite,
             Test
           );
-          assert.isTrue(
-            executor.log.calledOnce,
-            'expected a log message to have been emitted'
-          );
+          assert.equal(executor.emit.callCount, 3);
           // Suite should emit a log message
+          assert.equal(executor.emit.args[0][0], 'warning');
           assert.match(
-            executor.log.args[0][0],
+            executor.emit.args[0][1],
             /created test with lifecycle method name/,
             'expected log message to mention test name'
           );

--- a/tests/unit/core/lib/interfaces/tdd.ts
+++ b/tests/unit/core/lib/interfaces/tdd.ts
@@ -185,10 +185,12 @@ registerSuite('core/lib/interfaces/tdd', function() {
         }
 
         return {
-          before: createTest('before', false),
-          after: createTest('after', false),
-          beforeEach: createTest('beforeEach', true),
-          afterEach: createTest('afterEach', true)
+          tests: {
+            beforeMethod: createTest('before', false),
+            afterMethod: createTest('after', false),
+            beforeEachMethod: createTest('beforeEach', true),
+            afterEachMethod: createTest('afterEach', true)
+          }
         };
       })(),
 

--- a/tests/unit/tunnels/SeleniumTunnel.ts
+++ b/tests/unit/tunnels/SeleniumTunnel.ts
@@ -71,7 +71,7 @@ registerSuite('tunnels/SeleniumTunnel', {
       const oldLog = console.log;
 
       return {
-        afterEach() {
+        afterEachSeleniumTunnelTest() {
           console.log = oldLog;
         },
         '3.0.0': createTest('3.0.0', false),

--- a/tests/unit/tunnels/SeleniumTunnel.ts
+++ b/tests/unit/tunnels/SeleniumTunnel.ts
@@ -71,13 +71,15 @@ registerSuite('tunnels/SeleniumTunnel', {
       const oldLog = console.log;
 
       return {
-        afterEachSeleniumTunnelTest() {
+        afterEach() {
           console.log = oldLog;
         },
-        '3.0.0': createTest('3.0.0', false),
-        '3.5.0': createTest('3.5.0', false),
-        '3.14.0': createTest('3.14.0', false),
-        '3.141.59': createTest('3.141.59', false)
+        tests: {
+          '3.0.0': createTest('3.0.0', false),
+          '3.5.0': createTest('3.5.0', false),
+          '3.14.0': createTest('3.14.0', false),
+          '3.141.59': createTest('3.141.59', false)
+        }
       };
     })()
   }


### PR DESCRIPTION
This updates the warning log in the `core/lib/interfaces/object` file to use `executer.emit`

resolves: #1104 