### PR TITLE
docs: Fix simple typo, wihtout -> without

### DIFF
--- a/docs/how_to.md
+++ b/docs/how_to.md
@@ -393,7 +393,7 @@ order specified.
 When writing unit tests with Intern, occasionally you will need to interact with
 a web service. However, because the Intern serves code at
 `http://localhost:9000` by default, any cross-origin requests will fail. In
-order to test Ajax requests wihtout using CORS of JSONP, setup a reverse proxy
+order to test Ajax requests without using CORS of JSONP, setup a reverse proxy
 to Intern and tell the in-browser test runner to load from that URL by setting
 the `serverUrl` configuration option.
 


### PR DESCRIPTION
There is a small typo in docs/how_to.md.

Should read `without` rather than `wihtout`.

