### PR TITLE
Disallow async suite functions

### DIFF
--- a/src/core/lib/interfaces/tdd.ts
+++ b/src/core/lib/interfaces/tdd.ts
@@ -23,7 +23,7 @@
  *     test('baz', () => { ... });
  * });
  */ /** */
-import { global } from '../../../common';
+import { global, isPromise } from '../../../common';
 import Suite, {
   SuiteProperties,
   SuiteLifecycleFunction,
@@ -46,7 +46,7 @@ export interface TddLifecycleInterface {
   afterEach(fn: SuiteProperties['afterEach']): void;
 }
 
-export type TddSuiteFactory = (suite: Suite) => void;
+export type TddSuiteFactory = (suite: Suite) => undefined | void;
 
 export function suite(name: string, factory: TddSuiteFactory) {
   return _suite(global.intern, name, factory);
@@ -133,7 +133,12 @@ function registerSuite(name: string, factory: TddSuiteFactory) {
   currentSuite = new Suite({ name, parent });
   parent.add(currentSuite);
 
-  factory(currentSuite);
+  const returnValue = factory(currentSuite);
+  if (isPromise(returnValue)) {
+    throw new Error(
+      `Suite functions may not be asynchronous: ${currentSuite.id}`
+    );
+  }
 
   currentSuite = parent;
 }

--- a/tests/unit/core/lib/interfaces/tdd.ts
+++ b/tests/unit/core/lib/interfaces/tdd.ts
@@ -26,7 +26,9 @@ registerSuite('core/lib/interfaces/tdd', function() {
   };
 
   return {
-    async before() {
+    async beforeEach() {
+      // Re-import tdd before each test to ensure the module-level variables are
+      // reset
       tddInt = await mockImport(
         () => import('src/core/lib/interfaces/tdd'),
         replace => {
@@ -40,9 +42,6 @@ registerSuite('core/lib/interfaces/tdd', function() {
           replace(() => import('src/core/lib/Test')).withDefault(Test);
         }
       );
-    },
-
-    beforeEach() {
       sandbox.resetHistory();
       parent = new Suite(<any>{ name: 'parent', executor });
     },
@@ -62,11 +61,22 @@ registerSuite('core/lib/interfaces/tdd', function() {
         assert.equal(parent.tests[0].name, 'fooSuite');
       },
 
-      suite() {
-        tddInt.suite('foo', () => {});
-        assert.lengthOf(parent.tests, 1);
-        assert.instanceOf(parent.tests[0], Suite);
-        assert.equal(parent.tests[0].name, 'foo');
+      suite: {
+        normal() {
+          tddInt.suite('foo', () => {});
+          assert.lengthOf(parent.tests, 1);
+          assert.instanceOf(parent.tests[0], Suite);
+          assert.equal(parent.tests[0].name, 'foo');
+        },
+
+        async() {
+          assert.throws(
+            // @ts-ignore
+            () => tddInt.suite('foo', async () => {}),
+            /async/,
+            'using an async suite function should throw'
+          );
+        }
       },
 
       test() {


### PR DESCRIPTION
An async factory function could be provided to the tdd/bdd suite
registration functions (`suite` and `describe`). This was not supported,
and would cause runtime errors. This is now detected at compile time and
runtime.

resolves #1148