### PR TITLE
Webdriver list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ _examples/
 _tests/
 _testIntern/
 _publish/
+_ghpages/
 src/**/*.js
 selenium-standalone/
 benchmark.json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,9 @@ your `intern.json` file that points to the schema, like:
 }
 ```
 
+The schema is also available at
+`https://theintern.io/intern/resources/5/schemas/config.json`.
+
 ## Environment-specific config
 
 Tests can run in two basic environments: Node and browsers. By default,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "test:safari": "ts-node scripts/test.ts --config @safari",
     "watch:tests": "ts-node scripts/test.ts --watch",
     "watch": "ts-node scripts/build.ts --watch",
-    "ci": "ts-node scripts/test.ts --config @ci"
+    "ci": "ts-node scripts/test.ts --config @ci",
+    "ghpages": "ts-node scripts/ghpages.ts",
+    "webdriver": "ts-node scripts/webdriver.ts"
   },
   "dependencies": {
     "@types/benchmark": "~1.0.31",

--- a/scripts/ghpages.ts
+++ b/scripts/ghpages.ts
@@ -1,0 +1,75 @@
+// Publish assets to gh-pages
+
+import execa from 'execa';
+import { join, resolve } from 'path';
+import { cp, mkdir, rm } from 'shelljs';
+import packageJson from '../package.json';
+import { ask, init, isYesNo, print, stop } from './lib/rl';
+
+const ghpagesDir = '_ghpages';
+const projectRoot = resolve(__dirname, '..');
+process.chdir(projectRoot);
+
+function getInternVersion() {
+  return packageJson.version
+    .split('.')
+    .slice(0, 2)
+    .join('.');
+}
+
+async function updateGhPages() {
+  // Create a package build directory and clone this repo into it
+  await execa('git', ['clone', '.', ghpagesDir]);
+
+  process.chdir(ghpagesDir);
+  try {
+    await execa('git', ['checkout', 'gh-pages']);
+
+    const version = getInternVersion();
+    const resources = join('resources', version);
+    mkdir('-p', resources);
+
+    const wdDest = resources;
+    const schemaDest = join(resources, 'schemas');
+
+    cp('../src/tunnels/webdrivers.json', wdDest);
+    cp('-r', '../schemas', schemaDest);
+
+    await execa('git', ['add', resources]);
+    await execa('git', ['commit', '-m', 'Update assets']);
+  } finally {
+    process.chdir(projectRoot);
+  }
+}
+
+async function publishGhPages() {
+  process.chdir(ghpagesDir);
+
+  try {
+    await execa('git', ['push']);
+    process.chdir(projectRoot);
+    await execa('git', ['push', 'origin', 'gh-pages']);
+  } finally {
+    process.chdir(projectRoot);
+  }
+}
+
+async function main() {
+  init();
+
+  print(`Updating gh-pages in ${ghpagesDir}...`);
+  await updateGhPages();
+
+  const answer = await ask('Publish updated gh-pages [yN]? ', isYesNo);
+  if (answer.toLowerCase() === 'y') {
+    await publishGhPages();
+  }
+
+  print('Cleaning up...');
+  rm('-rf', ghpagesDir);
+}
+
+main()
+  .catch(error => console.error(error))
+  .finally(() => stop())
+  .finally(() => print('Done'));

--- a/scripts/ghpages.ts
+++ b/scripts/ghpages.ts
@@ -11,10 +11,7 @@ const projectRoot = resolve(__dirname, '..');
 process.chdir(projectRoot);
 
 function getInternVersion() {
-  return packageJson.version
-    .split('.')
-    .slice(0, 2)
-    .join('.');
+  return packageJson.version.split('.')[0];
 }
 
 async function updateGhPages() {

--- a/scripts/lib/rl.ts
+++ b/scripts/lib/rl.ts
@@ -1,0 +1,50 @@
+import readline from 'readline';
+
+let rl: readline.Interface;
+
+export async function ask(
+  question: string,
+  isValid = defaultValidator
+): Promise<string> {
+  for (;;) {
+    const asker = new Promise<string>(resolve => {
+      rl.question(question, resolve);
+    });
+    const answer = await asker;
+    if (isValid(answer)) {
+      return answer;
+    }
+    print("Input isn't in the expected format. Try again.");
+  }
+}
+
+export function defaultValidator(value: string): boolean {
+  return Boolean(value);
+}
+
+export function init() {
+  rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+
+  process.on('exit', () => {
+    rl.close();
+  });
+}
+
+export function isVersion(value: string): boolean {
+  return /^\d+(\.\d+)+$/.test(value);
+}
+
+export function isYesNo(value: string): boolean {
+  return /^(y|n)$/i.test(value);
+}
+
+export function print(message?: string) {
+  console.log(message || '');
+}
+
+export function stop() {
+  rl.close();
+}

--- a/scripts/webdriver.ts
+++ b/scripts/webdriver.ts
@@ -1,0 +1,121 @@
+import { promises } from 'fs';
+import { resolve } from 'path';
+import SeleniumTunnel from '../src/tunnels/SeleniumTunnel';
+import webdrivers from '../src/tunnels/webdrivers.json';
+import { ask, init, isVersion, print, stop } from './lib/rl';
+
+const projectRoot = resolve(__dirname, '..');
+process.chdir(projectRoot);
+
+type WebDriverData = typeof webdrivers;
+
+async function saveWebdriverJson(data: WebDriverData, filename?: string) {
+  if (!filename) {
+    filename = resolve(__dirname, '..', 'src', 'tunnels', 'webdrivers.json');
+  }
+  await promises.writeFile(filename, JSON.stringify(data, null, '  '));
+}
+
+async function verifyDrivers(data: WebDriverData) {
+  const tunnel = new SeleniumTunnel({
+    drivers: [
+      { browserName: 'chrome', version: data.drivers.chrome.latest },
+      { browserName: 'firefox', version: data.drivers.firefox.latest },
+      {
+        browserName: 'edgeChromium',
+        version: data.drivers.edgeChromium.latest
+      },
+      { browserName: 'ie', version: data.drivers.ie.latest }
+    ]
+  });
+
+  await tunnel.download(true);
+}
+
+async function main() {
+  const updated = JSON.parse(JSON.stringify(webdrivers));
+
+  init();
+
+  print(
+    'This script will ask for the current versions of drivers and generate an'
+  );
+  print('updated webdriver.json file.');
+  print();
+  print('Driver information can be found in the following locations:');
+  print('  Selenium and IEDriverServer:');
+  print('    https://selenium.dev/downloads');
+  print();
+  print('  chromedriver:');
+  print('    https://chromedriver.chromium.org/home');
+  print();
+  print('  geckodriver:');
+  print('    https://github.com/mozilla/geckodriver/releases');
+  print();
+  print('  edgedriver:');
+  print(
+    '    https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver'
+  );
+  print();
+
+  const commands: {
+    [key: string]: {
+      name: string;
+      property: keyof typeof webdrivers.drivers;
+    };
+  } = {
+    '1': { name: 'Selenium', property: 'selenium' },
+    '2': { name: 'chromedriver', property: 'chrome' },
+    '3': { name: 'geckodriver', property: 'firefox' },
+    '4': { name: 'iedriver', property: 'ie' },
+    '5': { name: 'edgedriver', property: 'edgeChromium' }
+  };
+
+  for (;;) {
+    const modified = JSON.stringify(webdrivers) !== JSON.stringify(updated);
+
+    for (const key in commands) {
+      print(
+        `${key}. ${commands[key].name}: ${
+          webdrivers.drivers[commands[key].property].latest
+        }`
+      );
+    }
+    if (modified) {
+      print('s. save');
+    }
+    print('q. quit');
+    print();
+    const resp = await ask('> ');
+
+    if (Object.keys(commands).indexOf(resp) !== -1) {
+      const prop = commands[resp].property;
+      webdrivers.drivers[prop].latest = await ask(
+        `Latest ${commands[resp].name} version: `,
+        isVersion
+      );
+    } else if (resp === 's') {
+      try {
+        print('Verifying drivers...');
+        await verifyDrivers(webdrivers);
+        print('Everything seems good');
+
+        await saveWebdriverJson(webdrivers);
+        print('Updated webdrivers.json');
+      } catch (error) {
+        console.error(error);
+      }
+    } else if (resp === 'q') {
+      return;
+    } else {
+      print('Invalid command');
+    }
+
+    print();
+  }
+}
+
+main()
+  .catch(error => console.error(error))
+  .finally(() => stop())
+  .finally(() => print('Done'));

--- a/src/cli/lib/util.ts
+++ b/src/cli/lib/util.ts
@@ -10,6 +10,7 @@ import {
 import { dirname, join } from 'path';
 import { format as _format } from 'util';
 import commander from 'commander';
+import { Config } from '../../core/lib/config';
 
 export let screenWidth = 80;
 
@@ -175,6 +176,27 @@ export function readJsonFile(file: string) {
 }
 
 /**
+ * Display Intern's config
+ */
+export async function showConfig(showConfigArg: string | boolean) {
+  let sorted: any;
+  await intern.resolveConfig();
+
+  if (typeof showConfigArg === 'string') {
+    const value = intern.config[showConfigArg as keyof Config];
+    if (value && typeof value === 'object') {
+      sorted = sortObjectKeys(value);
+    } else {
+      sorted = value;
+    }
+  } else {
+    sorted = sortObjectKeys(intern.config);
+  }
+
+  console.log(stringify(sorted));
+}
+
+/**
  * Wraps a string to a certain line length, maintaining the indent of the first
  * line.
  */
@@ -261,7 +283,7 @@ function format(...args: any[]) {
  * Deeply sort the keys of an object. Don't try to sort
  * non-simple objects.
  */
-export function sortObjectKeys(obj: object) {
+function sortObjectKeys(obj: object) {
   if (Array.isArray(obj)) {
     obj = obj.map(sortObjectKeys).sort();
   } else if (typeof obj === 'object' && obj.constructor === Object) {
@@ -279,7 +301,7 @@ export function sortObjectKeys(obj: object) {
 /**
  * Stringify an object
  */
-export function stringify(obj: object) {
+function stringify(obj: object) {
   return JSON.stringify(
     obj,
     (_key, value) => {

--- a/src/common/lib/request.ts
+++ b/src/common/lib/request.ts
@@ -46,6 +46,7 @@ export interface RequestOptions {
   httpAgent?: HttpAgent;
   httpsAgent?: HttpsAgent;
   retries?: number;
+  timeout?: number;
   cancelToken?: CancelToken;
 }
 

--- a/src/tunnels/SeleniumTunnel.ts
+++ b/src/tunnels/SeleniumTunnel.ts
@@ -172,7 +172,7 @@ export default class SeleniumTunnel extends Tunnel
           const dontExtract = Boolean(config.dontExtract);
           const directory = config.directory;
 
-          if (fileExists(join(this.directory, executable))) {
+          if (fileExists(join(this.directory, executable)) && !forceDownload) {
             return undefined;
           }
 

--- a/src/tunnels/SeleniumTunnel.ts
+++ b/src/tunnels/SeleniumTunnel.ts
@@ -4,6 +4,7 @@ import Tunnel, {
   DownloadOptions,
   ChildExecutor
 } from './Tunnel';
+import { readFileSync, writeFileSync } from 'fs';
 import { format } from 'util';
 import { join } from 'path';
 import {
@@ -20,7 +21,7 @@ import webdriversJson from './webdrivers.json';
 
 // This is the webdriver verison data that will be used when initializing the
 // driver config objects.
-const webdrivers = webdriversJson.drivers;
+const webDrivers = webdriversJson.drivers;
 
 /**
  * A Selenium tunnel. This tunnel downloads the
@@ -115,7 +116,7 @@ export default class SeleniumTunnel extends Tunnel
   webDriverDataUrl: string | null =
     'https://theintern.io/intern/resources/5/webdrivers.json';
 
-  private _webdriverDataLoaded = false;
+  private _webDriverDataLoaded = false;
 
   constructor(options?: Partial<SeleniumProperties>) {
     super(
@@ -123,8 +124,8 @@ export default class SeleniumTunnel extends Tunnel
         {
           seleniumArgs: [],
           drivers: ['chrome'],
-          baseUrl: webdrivers.selenium.baseUrl,
-          version: webdrivers.selenium.latest,
+          baseUrl: webDrivers.selenium.baseUrl,
+          version: webDrivers.selenium.latest,
           seleniumTimeout: 5000,
           directory: join(__dirname, 'selenium-standalone')
         },
@@ -165,7 +166,7 @@ export default class SeleniumTunnel extends Tunnel
   }
 
   async download(forceDownload = false): Promise<void> {
-    await this.updateWebdDriverData();
+    await this._updateWebDriverData();
 
     if (!forceDownload && this.isDownloaded) {
       return Promise.resolve();
@@ -230,12 +231,17 @@ export default class SeleniumTunnel extends Tunnel
    * This method updates the data used to configure the various webdriver config
    * classes.
    */
-  async updateWebdDriverData(): Promise<typeof webdrivers | undefined> {
+  protected async _updateWebDriverData(): Promise<
+    typeof webDrivers | undefined
+  > {
     // Don't try to retrieve new data if we've already done it or if the URL is
     // cleared
-    if (this._webdriverDataLoaded || !this.webDriverDataUrl) {
+    if (this._webDriverDataLoaded || !this.webDriverDataUrl) {
       return;
     }
+
+    const updatedDataFile = join(this.directory, 'webdrivers.json');
+    let updatedData: typeof webdriversJson | undefined;
 
     try {
       const resp = await request(this.webDriverDataUrl, {
@@ -244,16 +250,27 @@ export default class SeleniumTunnel extends Tunnel
       });
 
       if (resp.status === 200) {
-        const data = await resp.json<typeof webdriversJson>();
-        this._webdriverDataLoaded = true;
-        // Always mix in downloaded data. The assumption is that any downloaded
-        // webdriver data will be newer that whatever's included with Intern
-        deepMixin(webdrivers, data.drivers);
+        updatedData = await resp.json<typeof webdriversJson>();
+        this._webDriverDataLoaded = true;
+        // Save the downloaded data for use if a download fails in a future
+        // session
+        writeFileSync(updatedDataFile, JSON.stringify(updatedData));
       }
     } catch (error) {
       if (this.verbose) {
         console.warn(error);
       }
+
+      try {
+        const data = readFileSync(updatedDataFile, { encoding: 'utf8' });
+        updatedData = JSON.parse(data);
+      } catch {
+        // ignored
+      }
+    }
+
+    if (updatedData) {
+      deepMixin(webDrivers, updatedData.drivers);
     }
   }
 
@@ -456,9 +473,9 @@ class ChromeConfig extends Config<Partial<ChromeProperties>>
       Object.assign(
         {
           arch: global.process.arch,
-          baseUrl: webdrivers.chrome.baseUrl,
+          baseUrl: webDrivers.chrome.baseUrl,
           platform: global.process.platform,
-          version: webdrivers.chrome.latest
+          version: webDrivers.chrome.latest
         },
         options
       )
@@ -518,9 +535,9 @@ class FirefoxConfig extends Config<Partial<FirefoxProperties>>
       Object.assign(
         {
           arch: global.process.arch,
-          baseUrl: webdrivers.firefox.baseUrl,
+          baseUrl: webDrivers.firefox.baseUrl,
           platform: global.process.platform,
-          version: webdrivers.firefox.latest
+          version: webDrivers.firefox.latest
         },
         options
       )
@@ -576,8 +593,8 @@ class IEConfig extends Config<Partial<IEProperties>>
       Object.assign(
         {
           arch: global.process.arch,
-          baseUrl: webdrivers.ie.baseUrl,
-          version: webdrivers.ie.latest
+          baseUrl: webDrivers.ie.baseUrl,
+          version: webDrivers.ie.latest
         },
         options
       )
@@ -624,7 +641,7 @@ class EdgeConfig extends Config<Partial<EdgeProperties>>
   arch!: string;
   baseUrl!: string;
   uuid: string | undefined;
-  version!: keyof typeof webdrivers.edge.versions;
+  version!: keyof typeof webDrivers.edge.versions;
   versions!: EdgeVersions;
 
   constructor(options: Partial<EdgeProperties>) {
@@ -632,9 +649,9 @@ class EdgeConfig extends Config<Partial<EdgeProperties>>
       Object.assign(
         {
           arch: global.process.arch,
-          baseUrl: webdrivers.edge.baseUrl,
-          version: webdrivers.edge.latest,
-          versions: webdrivers.edge.versions
+          baseUrl: webDrivers.edge.baseUrl,
+          version: webDrivers.edge.latest,
+          versions: webDrivers.edge.versions
         },
         options
       )
@@ -664,7 +681,7 @@ class EdgeConfig extends Config<Partial<EdgeProperties>>
       );
     }
 
-    const urlOrObj = webdrivers.edge.versions[this.version].url;
+    const urlOrObj = webDrivers.edge.versions[this.version].url;
     if (typeof urlOrObj === 'string') {
       return urlOrObj;
     }
@@ -708,9 +725,9 @@ class EdgeChromiumConfig extends Config<Partial<EdgeProperties>>
       Object.assign(
         {
           arch: global.process.arch,
-          baseUrl: webdrivers.edgeChromium.baseUrl,
+          baseUrl: webDrivers.edgeChromium.baseUrl,
           platform: global.process.platform,
-          version: webdrivers.edgeChromium.latest
+          version: webDrivers.edgeChromium.latest
         },
         options
       )

--- a/src/tunnels/webdrivers.json
+++ b/src/tunnels/webdrivers.json
@@ -1,6 +1,5 @@
 {
   "$schema": "./schemas/webdrivers.json",
-
   "drivers": {
     "selenium": {
       "baseUrl": "https://selenium-release.storage.googleapis.com",
@@ -22,14 +21,14 @@
       "latest": "17134",
       "baseUrl": "https://download.microsoft.com/download",
       "versions": {
-        "17134": {
-          "url": "https://download.microsoft.com/download/F/8/A/F8AF50AB-3C3A-4BC4-8773-DC27B32988DD/MicrosoftWebDriver.exe"
+        "15063": {
+          "url": "https://download.microsoft.com/download/3/4/2/342316D7-EBE0-4F10-ABA2-AE8E0CDF36DD/MicrosoftWebDriver.exe"
         },
         "16299": {
           "url": "https://download.microsoft.com/download/D/4/1/D417998A-58EE-4EFE-A7CC-39EF9E020768/MicrosoftWebDriver.exe"
         },
-        "15063": {
-          "url": "https://download.microsoft.com/download/3/4/2/342316D7-EBE0-4F10-ABA2-AE8E0CDF36DD/MicrosoftWebDriver.exe"
+        "17134": {
+          "url": "https://download.microsoft.com/download/F/8/A/F8AF50AB-3C3A-4BC4-8773-DC27B32988DD/MicrosoftWebDriver.exe"
         }
       }
     },

--- a/tests/integration/tunnels/SeleniumTunnel.ts
+++ b/tests/integration/tunnels/SeleniumTunnel.ts
@@ -6,6 +6,7 @@ import { execSync } from 'child_process';
 import { ObjectSuiteDescriptor } from 'src/core/lib/interfaces/object';
 import { TestFunction } from 'src/core/lib/Test';
 import { mockImport } from 'tests/support/mockUtil';
+import webdrivers from 'src/tunnels/webdrivers.json';
 
 import _SeleniumTunnel from 'src/tunnels/SeleniumTunnel';
 import { BrowserName } from 'src/tunnels/types';
@@ -69,17 +70,19 @@ async function downloadTest(
 
 // artifact is a glob pattern that should match the downloaded file, relative to
 // the base tunnel directory
+// TODO: use the built in current driver versions -- just change the platform
+// and arch
 const testConfigs: DownloadTestOptions[] = [
   {
     driver: { browserName: 'chrome' },
     platform: 'win32',
-    artifact: '*/*/chromedriver.exe'
+    artifact: `${webdrivers.drivers.chrome.latest}/*/chromedriver.exe`
   },
   {
     driver: { browserName: 'chrome' },
     platform: 'linux',
     arch: 'x64',
-    artifact: '*/*/chromedriver'
+    artifact: `${webdrivers.drivers.chrome.latest}/*/chromedriver`
   },
   {
     driver: {
@@ -90,34 +93,26 @@ const testConfigs: DownloadTestOptions[] = [
     artifact: '2.35/*/chromedriver'
   },
   {
-    driver: {
-      browserName: 'chrome',
-      version: '2.36'
-    },
-    platform: 'darwin',
-    artifact: '2.36/*/chromedriver'
-  },
-  {
     driver: { browserName: 'ie' },
     arch: 'x64',
-    artifact: '*/x64/IEDriverServer.exe'
+    artifact: `${webdrivers.drivers.ie.latest}/x64/IEDriverServer.exe`
   },
   {
     driver: { browserName: 'ie' },
     arch: 'x86',
-    artifact: '*/x86/IEDriverServer.exe'
+    artifact: `${webdrivers.drivers.ie.latest}/x86/IEDriverServer.exe`
   },
   {
     driver: { browserName: 'internet explorer' },
-    artifact: '*/*/IEDriverServer.exe'
+    artifact: `${webdrivers.drivers.ie.latest}/*/IEDriverServer.exe`
   },
   {
     driver: { browserName: 'edge' },
-    artifact: '*/MicrosoftWebDriver.exe'
+    artifact: `${webdrivers.drivers.edge.latest}/MicrosoftWebDriver.exe`
   },
   {
     driver: { browserName: 'MicrosoftEdge' },
-    artifact: '*/MicrosoftWebDriver.exe'
+    artifact: `${webdrivers.drivers.edge.latest}/MicrosoftWebDriver.exe`
   },
   {
     driver: {
@@ -125,7 +120,7 @@ const testConfigs: DownloadTestOptions[] = [
     },
     platform: 'win32',
     arch: 'x64',
-    artifact: '*/x64/msedgedriver.exe'
+    artifact: `${webdrivers.drivers.edgeChromium.latest}/x64/msedgedriver.exe`
   },
   {
     driver: {
@@ -133,29 +128,29 @@ const testConfigs: DownloadTestOptions[] = [
     },
     platform: 'win32',
     arch: 'x86',
-    artifact: '*/x86/msedgedriver.exe'
+    artifact: `${webdrivers.drivers.edgeChromium.latest}/x86/msedgedriver.exe`
   },
   {
     driver: {
       browserName: 'MicrosoftEdgeChromium'
     },
     platform: 'darwin',
-    artifact: '*/*/msedgedriver'
+    artifact: `${webdrivers.drivers.edgeChromium.latest}/*/msedgedriver`
   },
   {
     driver: { browserName: 'firefox' },
     platform: 'linux',
-    artifact: '*/*/geckodriver'
+    artifact: `${webdrivers.drivers.firefox.latest}/*/geckodriver`
   },
   {
     driver: { browserName: 'firefox' },
     platform: 'darwin',
-    artifact: '*/*/geckodriver'
+    artifact: `${webdrivers.drivers.firefox.latest}/*/geckodriver`
   },
   {
     driver: { browserName: 'firefox' },
     platform: 'win32',
-    artifact: '*/*/geckodriver.exe'
+    artifact: `${webdrivers.drivers.firefox.latest}/*/geckodriver.exe`
   }
 ];
 
@@ -235,7 +230,7 @@ const suite: ObjectSuiteDescriptor = {
     },
 
     'version check': async function() {
-      const version = '79.0.3945.36';
+      const version = webdrivers.drivers.chrome.latest;
       const { arch } = process;
       tunnel = new SeleniumTunnel({
         directory: mkdtempSync(join(tmpdir(), 'intern-test')),

--- a/tests/integration/tunnels/SeleniumTunnel.ts
+++ b/tests/integration/tunnels/SeleniumTunnel.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from 'fs';
+import { existsSync, mkdtempSync } from 'fs';
 import { sync as glob } from 'glob';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -315,6 +315,12 @@ const suite: ObjectSuiteDescriptor = {
               new RegExp(geckodriverVersion),
               'unexpected driver version'
             );
+
+            const dataFile = join(tunnel.directory, 'webdrivers.json');
+            assert.isFalse(
+              existsSync(dataFile),
+              `did not expect ${dataFile} to exist`
+            );
           },
 
           async 'good url'() {
@@ -358,6 +364,12 @@ const suite: ObjectSuiteDescriptor = {
               result,
               new RegExp(geckodriverVersion),
               'unexpected driver version'
+            );
+
+            const dataFile = join(tunnel.directory, 'webdrivers.json');
+            assert.isTrue(
+              existsSync(dataFile),
+              `expected ${dataFile} to exist`
             );
           }
         }

--- a/tests/unit/tunnels/SeleniumTunnel.ts
+++ b/tests/unit/tunnels/SeleniumTunnel.ts
@@ -1,34 +1,48 @@
+import Tunnel from 'src/tunnels/Tunnel';
 import SeleniumTunnel from 'src/tunnels/SeleniumTunnel';
+import { Response } from 'src/common';
 import { BrowserName, isWebDriver } from 'src/tunnels/types';
+import { mockImport } from 'tests/support/mockUtil';
+import { createSandbox } from 'sinon';
 
-registerSuite('tunnels/SeleniumTunnel', {
-  config: {
-    'name only': function() {
+const { afterEach, suite, test } = intern.getPlugin('interface.tdd');
+
+class MockTunnel extends Tunnel {
+  _downloadFile() {
+    return Promise.resolve();
+  }
+}
+
+const sandbox = createSandbox();
+
+suite('tunnels/SeleniumTunnel', () => {
+  suite('config', () => {
+    test('name only', () => {
       const tunnel = new SeleniumTunnel({
         drivers: [{ browserName: 'chrome' }]
       });
       assert.isFalse(tunnel.isDownloaded);
-    },
+    });
 
-    'config object': function() {
+    test('config object', () => {
       const tunnel = new SeleniumTunnel({
         drivers: [{ executable: 'README.md', url: '', seleniumProperty: '' }]
       });
       Object.defineProperty(tunnel, 'artifact', { value: '.' });
       Object.defineProperty(tunnel, 'directory', { value: '.' });
       assert.isTrue(tunnel.isDownloaded);
-    },
+    });
 
-    'invalid name': function() {
+    test('invalid name', () => {
       assert.throws(function() {
         const tunnel = new SeleniumTunnel({ drivers: <any>['foo'] });
         Object.defineProperty(tunnel, 'artifact', { value: '.' });
         Object.defineProperty(tunnel, 'directory', { value: '.' });
         tunnel.isDownloaded;
       }, /Invalid driver/);
-    },
+    });
 
-    'config object with invalid name': function() {
+    test('config object with invalid name', () => {
       assert.throws(function() {
         const tunnel = new SeleniumTunnel({
           drivers: [{ browserName: 'foo' as BrowserName }]
@@ -37,9 +51,9 @@ registerSuite('tunnels/SeleniumTunnel', {
         Object.defineProperty(tunnel, 'directory', { value: '.' });
         tunnel.isDownloaded;
       }, /Invalid driver/);
-    },
+    });
 
-    'debug args': (function() {
+    suite('debug args', () => {
       function createTest(version: string, hasDebugArg: boolean) {
         return function() {
           const tunnel = new SeleniumTunnel({
@@ -73,25 +87,107 @@ registerSuite('tunnels/SeleniumTunnel', {
 
       const oldLog = console.log;
 
-      return {
-        afterEach() {
-          console.log = oldLog;
-        },
-        tests: {
-          '3.0.0': createTest('3.0.0', false),
-          '3.5.0': createTest('3.5.0', false),
-          '3.14.0': createTest('3.14.0', false),
-          '3.141.59': createTest('3.141.59', false)
-        }
-      };
-    })()
-  },
+      afterEach(() => {
+        console.log = oldLog;
+      });
 
-  isWebDriver() {
+      test('3.0.0', createTest('3.0.0', false));
+      test('3.5.0', createTest('3.5.0', false));
+      test('3.14.0', createTest('3.14.0', false));
+      test('3.141.59', createTest('3.141.59', false));
+    });
+  });
+
+  test('isWebDriver', () => {
     assert.isTrue(isWebDriver({ browserName: 'chrome' }));
     assert.isFalse(isWebDriver({ browser: 'chrome' } as any));
     assert.isFalse(isWebDriver('chrome' as any));
     assert.isFalse(isWebDriver(5 as any));
     assert.isFalse(isWebDriver(undefined as any));
-  }
+  });
+
+  suite('download webdriver data', () => {
+    const mockResponse = {
+      json: () => Promise.resolve({}),
+      status: 200
+    };
+    const mockJson = sandbox.stub(mockResponse, 'json').resolves({});
+    const mockStatus = sandbox.stub(mockResponse, 'status').value(200);
+    const mockRequest = sandbox.spy((_url: string) =>
+      Promise.resolve(mockResponse as Response)
+    );
+
+    afterEach(() => {
+      sandbox.reset();
+    });
+
+    test('successful download', async () => {
+      const MockedSeleniumTunnel = (
+        await mockImport(
+          () => import('src/tunnels/SeleniumTunnel'),
+          replace => {
+            replace(() => import('src/tunnels/Tunnel'))
+              .transparently()
+              .withDefault(MockTunnel);
+            replace(() => import('src/common'))
+              .transparently()
+              .with({ request: mockRequest });
+          }
+        )
+      ).default;
+      const tunnel = new MockedSeleniumTunnel();
+
+      await tunnel.download();
+      assert.equal(
+        mockRequest.callCount,
+        1,
+        'expected download to make a request'
+      );
+      assert.match(
+        mockRequest.getCall(0).args[0],
+        /theintern\.io/,
+        'exected request to theintern.io'
+      );
+      assert.equal(
+        mockJson.callCount,
+        1,
+        'expected response JSON to be requested'
+      );
+    });
+
+    test('failed download', async () => {
+      const MockedSeleniumTunnel = (
+        await mockImport(
+          () => import('src/tunnels/SeleniumTunnel'),
+          replace => {
+            replace(() => import('src/tunnels/Tunnel'))
+              .transparently()
+              .withDefault(MockTunnel);
+            replace(() => import('src/common'))
+              .transparently()
+              .with({ request: mockRequest });
+          }
+        )
+      ).default;
+      const tunnel = new MockedSeleniumTunnel();
+      mockStatus.value(400);
+
+      await tunnel.download();
+      assert.equal(
+        mockRequest.callCount,
+        1,
+        'expected download to make a request'
+      );
+      assert.match(
+        mockRequest.getCall(0).args[0],
+        /theintern\.io/,
+        'exected request to theintern.io'
+      );
+      assert.equal(
+        mockJson.callCount,
+        0,
+        'tunnel should not have requested response JSON'
+      );
+    });
+  });
 });


### PR DESCRIPTION
This PR adds support scripts for updating Intern's webdriver list and publishing the list to Intern's github.io site. It also will update SeleniumTunnel to check for an updated driver list before downloading drivers.

Webdriver versions must still be updated manually (the `webdriver` npm script helps with this)  since none of them but chromedriver have any sort of webservice that indicates the latest stable version.

resolves #1071 