### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -226,7 +226,7 @@ registerSuite('Suite name', {
   },
 
   test2() {
-    // do somthing
+    // do something
   }
 });
 ```
@@ -246,7 +246,7 @@ registerSuite('Suite name', {
     },
 
     test2() {
-      // do somthing
+      // do something
     }
   }
 });
@@ -261,7 +261,7 @@ registerSuite('Suite name', {
     },
 
     test2() {
-        // do somthing
+        // do something
     },
 
     'sub-suite': {
@@ -395,7 +395,7 @@ registerSuite('Suite name', {
     },
 
     test2: async(dfd => {
-      // do somthing
+      // do something
     })
   }
 });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,9 +52,9 @@ environment-specific default method for loading scripts/modules. This means
 
 ## Plugins
 
-Plugins are scripts that provide additional funtionality to Intern. They may
+Plugins are scripts that provide additional functionality to Intern. They may
 register values or functions that can be directly used in tests, register
-callbacks that will fire at certain poitns in the testing process, or modify the
+callbacks that will fire at certain points in the testing process, or modify the
 environment in some way (e.g., `babel-register`).
 
 ```ts

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ query args, or an environment variable. All of these methods use the same basic
 syntax and provide the same capabilities. Assuming Intern is being run with the
 default [Node runner](running.md#node) or [browser runner](running.md#browser)
 and without a `config` argument, Intern will attempt to load configuration
-informatioon from an `intern.json` file in the project root.
+information from an `intern.json` file in the project root.
 
 Wherever config property values come from, the executor will validate and
 normalize them into a canonical format ("resolve" them) when the testing process
@@ -459,7 +459,7 @@ are passed through to the registered loader script.
 }
 ```
 
-It's useful to think of Intern's loader scriptss as glue code that Intern uses
+It's useful to think of Intern's loader scripts as glue code that Intern uses
 to load configured suites within the environment. When Intern needs to load a
 module (i.e. a test suite) it hands off a list of these modules to the loader
 script and waits for the loading process to be handled by the loader. For more

--- a/docs/how_to.md
+++ b/docs/how_to.md
@@ -282,7 +282,7 @@ support. Internally, modules are loaded using script tags, like:
 <script src="myscript.js" type="module"></script>
 ```
 
-> ⚠️ Note that the `esm` loader requires that _all_ modules in a dependecy tree
+> ⚠️ Note that the `esm` loader requires that _all_ modules in a dependency tree
 > be ESMs, so its utility is currently somewhat limited.
 
 ## Use Intern with a remote service like BrowserStack
@@ -352,7 +352,7 @@ order specified.
 When writing unit tests with Intern, occasionally you will need to interact with
 a web service. However, because the Intern serves code at
 `http://localhost:9000` by default, any cross-origin requests will fail. In
-order to test Ajax requests wihtout using CORS of JSONP, setup a reverse proxy
+order to test Ajax requests without using CORS of JSONP, setup a reverse proxy
 to Intern and tell the in-browser test runner to load from that URL by setting
 the `serverUrl` configuration option.
 


### PR DESCRIPTION
There are small typos in:
- docs/api.md
- docs/architecture.md
- docs/configuration.md
- docs/how_to.md

Fixes:
- Should read `without` rather than `wihtout`.
- Should read `something` rather than `somthing`.
- Should read `scripts` rather than `scriptss`.
- Should read `points` rather than `poitns`.
- Should read `information` rather than `informatioon`.
- Should read `functionality` rather than `funtionality`.
- Should read `dependency` rather than `dependecy`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md